### PR TITLE
Add Authority for Edgevana

### DIFF
--- a/api/src/handlers/config.rs
+++ b/api/src/handlers/config.rs
@@ -62,6 +62,10 @@ pub async fn handler(_context: WrappedContext) -> Result<impl Reply, warp::Rejec
                         name: "Blaze Stake".into(),
                     },
                     StakeDelegationAuthorityRecord {
+                        delegation_authority: "FZEaZMmrRC3PDPFMzqooKLS2JjoyVkKNd2MkHjr7Xvyq".into(),
+                        name: "Edgevana".into(),
+                    },
+                    StakeDelegationAuthorityRecord {
                         delegation_authority: "5LimmCEyVpxPz2FieDU8SBPQNKcWgiyffWqq1bgT4r6B".into(),
                         name: "Alameda".into(),
                     },


### PR DESCRIPTION
This PR adds support for the Edgevana authority. The goal here is simply to make "Edgevana" show up in the [Marinade UI](https://marinade.finance/app/validators/details/EdGevanAjM8a6Gg9KxBVrmVdZAUGAZ9xaVd7t9R4H2x) under the `Stake by Delegator` section. If this is not the right place for this PR, please do let me know. No one in particular pointed me here, I just went searching myself to make this as easy as possible for you guys as I am a fan of the UI :) .

Our stake pool info:

```
spl-stake-pool list -v edgejNWAqkePLpi5sHRxT9vHi7u3kSHP9cocABPKiWZ
Stake Pool Info
===============
Stake Pool: edgejNWAqkePLpi5sHRxT9vHi7u3kSHP9cocABPKiWZ
Validator List: edgeUAwci9fD66ffrfxKZtznzrm79hHcpjR1BaYF8ML
Manager: 9D7zH8TVs8Ua53L5fjDM6Q3GszfYd7rms79Dz8A6opXD
Staker: 9D7zH8TVs8Ua53L5fjDM6Q3GszfYd7rms79Dz8A6opXD
Depositor: D76M3Uqqhh6pbSi6pV6DeNx2oS2WkWB6mP2q2kFvveNq
SOL Deposit Authority: None
SOL Withdraw Authority: None
Withdraw Authority: FZEaZMmrRC3PDPFMzqooKLS2JjoyVkKNd2MkHjr7Xvyq
Pool Token Mint: edge86g9cVz87xcpKpy3J77vbp4wYd9idEV562CCntt
Fee Account: AJfw28SHAv5TiDXNUFLDKtmh8H7wkcjmeyc7ESbzsxRU
Preferred Deposit Validator: EdGevanAjM8a6Gg9KxBVrmVdZAUGAZ9xaVd7t9R4H2x
Epoch Fee: 1/100 of epoch rewards
Stake Withdrawal Fee: 1/1000 of withdrawal amount
SOL Withdrawal Fee: 1/1000 of withdrawal amount
Stake Deposit Fee: 0/100 of deposit amount
SOL Deposit Fee: 0/100 of deposit amount
Stake Deposit Referral Fee: 0% of Stake Deposit Fee
SOL Deposit Referral Fee: 0% of SOL Deposit Fee
```

It looks like this repo takes `Withdraw Authority` and this PR adds Edgevana's withdraw authority.

A good portion of our stake is delegated to Edgevana's validator right now, but we are going to be removing ~2% of that per epoch to stake to other validators running on Edgevana, hence why I'm submitting this now.

Let me know if any of this is incorrect or if you need any additional info, thanks!