### PR TITLE
[store] mev store to work with sql transactions

### DIFF
--- a/collect/src/validators_mev.rs
+++ b/collect/src/validators_mev.rs
@@ -74,7 +74,7 @@ pub fn validators_mev(
                         RpcFilterType::DataSize(TipDistributionAccount::SIZE.try_into().unwrap()),
                         RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
                             0x89,
-                            (epoch - 1).to_le_bytes().to_vec(),
+                            epoch.to_le_bytes().to_vec(),
                         )),
                     ]),
                     account_config: RpcAccountInfoConfig {
@@ -102,7 +102,7 @@ pub fn validators_mev(
             AccountDeserialize::try_deserialize(
                 &mut validator_tip_distribution_account.1.data.as_slice(),
             )?;
-        if fetched_tip_distribution_account.epoch_created_at != epoch - 1 {
+        if fetched_tip_distribution_account.epoch_created_at != epoch {
             continue;
         }
         if let Some(merkle_root) = fetched_tip_distribution_account.merkle_root {
@@ -115,7 +115,7 @@ pub fn validators_mev(
                         .validator_vote_account
                         .to_string(),
                     mev_commission: fetched_tip_distribution_account.validator_commission_bps,
-                    epoch: epoch - 1,
+                    epoch,
                     total_epoch_rewards: merkle_root.max_total_claim,
                     claimed_epoch_rewards: merkle_root.total_funds_claimed,
                     total_epoch_claimants: merkle_root.max_num_nodes,
@@ -145,7 +145,7 @@ pub fn collect_validators_mev_info(
     info!("Current epoch: {:?}", current_epoch_info);
     info!("Looking at epoch: {}", epoch - 1);
 
-    let validators = validators_mev(&client, epoch, options.rpc_attempts)?;
+    let validators = validators_mev(&client, epoch - 1, options.rpc_attempts)?;
 
     serde_yaml::to_writer(
         std::io::stdout(),

--- a/collect/src/validators_mev.rs
+++ b/collect/src/validators_mev.rs
@@ -115,7 +115,7 @@ pub fn validators_mev(
                         .validator_vote_account
                         .to_string(),
                     mev_commission: fetched_tip_distribution_account.validator_commission_bps,
-                    epoch,
+                    epoch: epoch - 1,
                     total_epoch_rewards: merkle_root.max_total_claim,
                     claimed_epoch_rewards: merkle_root.total_funds_claimed,
                     total_epoch_claimants: merkle_root.max_num_nodes,
@@ -150,7 +150,7 @@ pub fn collect_validators_mev_info(
     serde_yaml::to_writer(
         std::io::stdout(),
         &Snapshot {
-            epoch,
+            epoch: epoch - 1,
             epoch_slot: current_epoch_info.slot_index,
             created_at: created_at.to_string(),
             validators,

--- a/store/src/validators_mev.rs
+++ b/store/src/validators_mev.rs
@@ -33,7 +33,7 @@ pub async fn store_mev(
         .iter()
         .map(|v| (v.0.clone(), ValidatorMEVInfo::new_from_snapshot(v.1)))
         .collect();
-    let snapshot_epoch: i32 = (snapshot.epoch - 1) as i32;
+    let snapshot_epoch: i32 = snapshot.epoch as i32;
     let snapshot_epoch_slot: Decimal = snapshot.epoch_slot.into();
     let mut updated_identities: HashSet<_> = Default::default();
 

--- a/store/src/validators_mev.rs
+++ b/store/src/validators_mev.rs
@@ -33,7 +33,6 @@ pub async fn store_mev(
         .iter()
         .map(|v| (v.0.clone(), ValidatorMEVInfo::new_from_snapshot(v.1)))
         .collect();
-    let snapshot_epoch: i32 = snapshot.epoch as i32;
     let snapshot_epoch_slot: Decimal = snapshot.epoch_slot.into();
     let mut updated_identities: HashSet<_> = Default::default();
 
@@ -46,7 +45,7 @@ pub async fn store_mev(
         FROM mev
         WHERE epoch = $1
     ",
-            &[&snapshot_epoch],
+            &[&(snapshot.epoch as i32)],
         )
         .await?
         .chunks(DEFAULT_CHUNK_SIZE)
@@ -138,6 +137,7 @@ pub async fn store_mev(
             .to_string(),
         );
 
+        let epoch = snapshot.epoch as i32;
         for (vote_account, v) in chunk {
             if updated_identities.contains(vote_account) {
                 continue;
@@ -150,7 +150,7 @@ pub async fn store_mev(
                 &v.total_epoch_claimants,
                 &v.epoch_active_claimants,
                 &snapshot_epoch_slot,
-                &snapshot_epoch,
+                &epoch,
                 &snapshot_created_at,
             ];
             query.add(&mut params);


### PR DESCRIPTION
I would like to propose working with a transaction commit for storing data - either all is stored all nothing is stored.
This is a proposal for the MEV part but the same can be done for the other `store` CLI functionality.

https://github.com/marinade-finance/delegation-strategy-2/compare/with-transaction?expand=1#diff-4bed465c32fbb15b963ac515a4c3a26f2017a105d777e49c6de3954ab4167293R41

The motivation is that for the MEV cron job only part of the data was stored as the cron job was "killed" before finished.

A) WDYT?
B) Maybe there is a better way how to work with `Transaction`, `Client` and `lifetime`. I would be happy to learn.