### PR TITLE
[mev/priority fee] fixing /rewards endpoint [GEN-5657] 

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -9,9 +9,10 @@ See how it is configured to be run from code in [ops-infra repository](https://g
 ```bash
 export RPC_URL=...
 export POSTGRES_URL='postgresql://delegation-strategy:delegation-strategy@localhost:5432/delegation-strategy'
+export PG_SSLROOTCERT='/tmp/postgres-root-cert.pem'
 
 cargo run --bin api -- \
-  --postgres-ssl-root-cert /tmp/postgres-root-cert.pem --postgres-url $POSTGRES_URL \
+  --postgres-ssl-root-cert $PG_SSLROOTCERT --postgres-url $POSTGRES_URL \
   --scoring-url https://scoring.marinade.finance --admin-auth-token ABCD \
   --blacklist-path ./blacklist.csv --glossary-path ./glossary.md
 ```

--- a/store/src/rewards.rs
+++ b/store/src/rewards.rs
@@ -1,32 +1,49 @@
 use rust_decimal::Decimal;
 use tokio_postgres::Client;
 
-pub async fn get_mev_rewards(psql_client: &Client, epochs: u64) -> anyhow::Result<Vec<(u64, f64)>> {
+async fn get_jito_rewards_by_table(
+    psql_client: &Client,
+    table_name: &str,
+    epochs: u64,
+) -> anyhow::Result<Vec<(u64, f64)>> {
+    let query = format!(
+        r#"
+        SELECT SUM(total_epoch_rewards) / 1e9 AS amount, epoch
+        FROM {}
+        GROUP BY epoch
+        HAVING COUNT(CASE WHEN total_epoch_rewards IS NULL THEN 1 END) < 10
+        ORDER BY epoch DESC LIMIT $1
+        "#,
+        table_name
+    );
+
     // total_epoch_rewards may be NULL as data on commission is loaded at start of epoch
     // when JITO has not run own snapshot processing that updates data about rewards
     // query ignores whole epoch if there is at least one NULL value
     let rows = psql_client
-        .query(
-            r#"
-             SELECT SUM(total_epoch_rewards) / 1e9 AS amount, epoch
-             FROM mev
-             GROUP BY epoch
-             HAVING COUNT(CASE WHEN total_epoch_rewards IS NULL THEN 1 END) < 10
-             ORDER BY epoch
-             DESC LIMIT $1"#,
-            &[&i64::try_from(epochs)?],
-        )
+        .query(&query, &[&i64::try_from(epochs)?])
         .await?;
 
     Ok(rows
         .into_iter()
         .map(|row| {
             (
-                row.get::<_, i32>("epoch").try_into().unwrap(),
+                row.get::<_, Decimal>("epoch").try_into().unwrap(),
                 row.get::<_, Decimal>("amount").try_into().unwrap(),
             )
         })
         .collect())
+}
+
+pub async fn get_mev_rewards(psql_client: &Client, epochs: u64) -> anyhow::Result<Vec<(u64, f64)>> {
+    get_jito_rewards_by_table(psql_client, "mev", epochs).await
+}
+
+pub async fn get_jito_priority_rewards(
+    psql_client: &Client,
+    epochs: u64,
+) -> anyhow::Result<Vec<(u64, f64)>> {
+    get_jito_rewards_by_table(psql_client, "jito_priority_fee", epochs).await
 }
 
 pub async fn get_estimated_inflation_rewards(


### PR DESCRIPTION
* fix of wrong type of epoch (after changed in PR#178)
* enhancing /rewards endpoint with priority fee data