### PR TITLE
[priorityfee/mev] not needed to sort [GEN-5657]

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -16,3 +16,7 @@ cargo run --bin api -- \
   --scoring-url https://scoring.marinade.finance --admin-auth-token ABCD \
   --blacklist-path ./blacklist.csv --glossary-path ./glossary.md
 ```
+
+```bash
+curl 'http://localhost:8080/validators'
+```

--- a/api/README.md
+++ b/api/README.md
@@ -18,5 +18,5 @@ cargo run --bin api -- \
 ```
 
 ```bash
-curl 'http://localhost:8080/validators'
+curl 'http://localhost:8000/validators'
 ```

--- a/store/src/validators_jito.rs
+++ b/store/src/validators_jito.rs
@@ -466,8 +466,12 @@ pub async fn get_last_jito_info(
     psql_client: &Client,
     epochs: u64,
 ) -> anyhow::Result<Vec<JitoRecord>> {
-    let mev_records = get_last_mev_info(psql_client, epochs).await?;
-    let priority_fee_records = get_last_priority_fee_info(psql_client, epochs).await?;
+    let (mev_records, priority_fee_records) = tokio::join!(
+        get_last_mev_info(psql_client, epochs),
+        get_last_priority_fee_info(psql_client, epochs)
+    );
+    let mev_records = mev_records?;
+    let priority_fee_records = priority_fee_records?;
 
     // Combine the two records into a single JitoRecord (combine by vote_account and epoch)
     let mut mev_map: HashMap<(String, Decimal), JitoMevRecord> = HashMap::new();

--- a/store/src/validators_jito.rs
+++ b/store/src/validators_jito.rs
@@ -466,12 +466,10 @@ pub async fn get_last_jito_info(
     psql_client: &Client,
     epochs: u64,
 ) -> anyhow::Result<Vec<JitoRecord>> {
-    let (mev_records, priority_fee_records) = tokio::join!(
+    let (mev_records, priority_fee_records) = tokio::try_join!(
         get_last_mev_info(psql_client, epochs),
         get_last_priority_fee_info(psql_client, epochs)
-    );
-    let mev_records = mev_records?;
-    let priority_fee_records = priority_fee_records?;
+    )?;
 
     // Combine the two records into a single JitoRecord (combine by vote_account and epoch)
     let mut mev_map: HashMap<(String, Decimal), JitoMevRecord> = HashMap::new();

--- a/store/src/validators_jito.rs
+++ b/store/src/validators_jito.rs
@@ -510,11 +510,5 @@ pub async fn get_last_jito_info(
         });
     }
 
-    result.sort_by(|a, b| {
-        a.epoch
-            .cmp(&b.epoch)
-            .then_with(|| a.vote_account.cmp(&b.vote_account))
-    });
-
     Ok(result)
 }


### PR DESCRIPTION
When I was adding sorting to the `/jito` endpoint, I thought the endpoint returned a list of data for every past epoch. But I’ve recently realised that the epoch only indicates where the data comes from — the actual purpose of the endpoint is to return the MEV rewards for the **latest available** epoch. For example, if mev vote account data is available for epoch 810, it returns that; if not, but mev vote account data is available for 809, then it returns 809 instead. The vote account will be unique in output and epoch as well.

So, sorting the data doesn't make much sense and only slows the endpoint down.
It's a "micro" optimisation, but I believe there should not be this stuff.