### PR TITLE
[fix rewards] considering null in /rewards

### DIFF
--- a/store/src/rewards.rs
+++ b/store/src/rewards.rs
@@ -8,7 +8,7 @@ async fn get_jito_rewards_by_table(
 ) -> anyhow::Result<Vec<(u64, f64)>> {
     let query = format!(
         r#"
-        SELECT SUM(total_epoch_rewards) / 1e9 AS amount, epoch
+        SELECT SUM(COALESCE(total_epoch_rewards, 0)) / 1e9 AS amount, epoch
         FROM {}
         GROUP BY epoch
         HAVING COUNT(CASE WHEN total_epoch_rewards IS NULL THEN 1 END) < 10


### PR DESCRIPTION
This is a fix for `/rewards` endpoint falling when not ready loaded data about amounts from priority fee accounts (done by collect)

```
thread 'tokio-runtime-worker' panicked at /home/chalda/marinade/delegation-strategy-2/store/src/rewards.rs:32:21:
error retrieving column amount: error deserializing column 0: a Postgres value was `NULL`
```