### PR TITLE
[fix] dev has got no funded bonds [GEN-7996]

### DIFF
--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -418,10 +418,9 @@ pub fn get_self_stake(
 
     let bonds = fetch_bonds(bonds_url)?;
     assert!(!bonds.is_empty(), "Failed to fetch bonds data");
-    assert!(
-        !bonds.iter().all(|b| b.funded_amount == Decimal::ZERO),
-        "All bonds have zero funded amounts, expected at least one non-zero amount"
-    );
+    if bonds.iter().all(|b| b.funded_amount == Decimal::ZERO) {
+        log::warn!("All bonds have zero funded amounts");
+    }
 
     for bond in bonds {
         let funded_amount_u64 = bond

--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -426,15 +426,17 @@ pub fn get_self_stake(
     if bonds.iter().all(|b| b.funded_amount == Decimal::ZERO) {
         if allow_zero_funded_bonds {
             warn!(
-                "All {} bonds from {} have zero funded amounts",
+                "All {} bonds from {} for epoch {} have zero funded amounts",
                 bonds.len(),
-                bonds_url
+                bonds_url,
+                epoch
             );
         } else {
             anyhow::bail!(
-                "All {} bonds from {} have zero funded amounts, expected at least one non-zero amount",
+                "All {} bonds from {} for epoch {} have zero funded amounts, expected at least one non-zero amount",
                 bonds.len(),
-                bonds_url
+                bonds_url,
+                epoch
             );
         }
     }

--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -403,6 +403,7 @@ pub fn get_self_stake(
     epoch: Epoch,
     stake_history: &StakeHistory,
     bonds_url: &str,
+    allow_zero_funded_bonds: bool,
     rpc_attempts: usize,
 ) -> anyhow::Result<HashMap<String, u64>> {
     let withdraw_authorities = get_withdraw_authorities(rpc_client)?;
@@ -417,13 +418,25 @@ pub fn get_self_stake(
     assert!(!self_stake.is_empty(), "Failed to fetch self stake data");
 
     let bonds = fetch_bonds(bonds_url)?;
-    assert!(!bonds.is_empty(), "Failed to fetch bonds data");
-    if bonds.iter().all(|b| b.funded_amount == Decimal::ZERO) {
-        log::warn!(
-            "All {} bonds from {} have zero funded amounts",
-            bonds.len(),
-            bonds_url
+    if bonds.is_empty() {
+        anyhow::bail!(
+            "Fetched empty bonds list from {bonds_url} for epoch {epoch}, expected at least one bond"
         );
+    }
+    if bonds.iter().all(|b| b.funded_amount == Decimal::ZERO) {
+        if allow_zero_funded_bonds {
+            warn!(
+                "All {} bonds from {} have zero funded amounts",
+                bonds.len(),
+                bonds_url
+            );
+        } else {
+            anyhow::bail!(
+                "All {} bonds from {} have zero funded amounts, expected at least one non-zero amount",
+                bonds.len(),
+                bonds_url
+            );
+        }
     }
 
     for bond in bonds {

--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -419,7 +419,11 @@ pub fn get_self_stake(
     let bonds = fetch_bonds(bonds_url)?;
     assert!(!bonds.is_empty(), "Failed to fetch bonds data");
     if bonds.iter().all(|b| b.funded_amount == Decimal::ZERO) {
-        log::warn!("All bonds have zero funded amounts");
+        log::warn!(
+            "All {} bonds from {} have zero funded amounts",
+            bonds.len(),
+            bonds_url
+        );
     }
 
     for bond in bonds {

--- a/collect/src/validators.rs
+++ b/collect/src/validators.rs
@@ -30,6 +30,12 @@ pub struct ValidatorsParams {
     pub bonds_url: String,
 
     #[structopt(
+        long = "allow-zero-funded-bonds",
+        help = "When set (or ALLOW_ZERO_FUNDED_BONDS=true), if all bonds have funded_amount == 0, log a warning instead of failing."
+    )]
+    pub allow_zero_funded_bonds: bool,
+
+    #[structopt(
         long = "rpc-attempts",
         help = "How many times to retry the operation.",
         default_value = "10"
@@ -162,11 +168,17 @@ pub fn collect_validators_info(
     let foundation_stake = get_foundation_stakes(&client, epoch, &stake_history)?;
     let institutional_stake = get_institutional_stakes(&client, epoch, &stake_history)?;
     let marinade_native_stake = get_marinade_native_stakes(&client, epoch, &stake_history)?;
+    let allow_zero_funded_bonds = validator_params.allow_zero_funded_bonds
+        || std::env::var("ALLOW_ZERO_FUNDED_BONDS")
+            .ok()
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(false);
     let self_stake = get_self_stake(
         &client,
         epoch,
         &stake_history,
         &validator_params.bonds_url,
+        allow_zero_funded_bonds,
         validator_params.rpc_attempts,
     )?;
     let validators_info = get_validators_info(&client)?;


### PR DESCRIPTION
Let's not make the dev cron fail.

```
[2026-05-20T11:03:43Z INFO  collect::solana_service] Processed 0 self stakes on page 249
[2026-05-20T11:03:43Z INFO  collect::solana_service] Processed 14 self stakes on page 250
[2026-05-20T11:03:44Z INFO  collect::solana_service] Processed 2 self stakes on page 251
[2026-05-20T11:03:44Z INFO  collect::solana_service] Processed 1 self stakes on page 252
[2026-05-20T11:03:45Z INFO  collect::solana_service] Processed 8 self stakes on page 253
[2026-05-20T11:03:45Z INFO  collect::solana_service] Processed 0 self stakes on page 254
[2026-05-20T11:03:45Z INFO  collect::solana_service] Processed 0 self stakes on page 255
thread 'main' panicked at collect/src/solana_service.rs:421:5:
All bonds have zero funded amounts, expected at least one non-zero amount
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

ops configuration https://github.com/marinade-finance/ops-infra/pull/2171