### PR TITLE
[collector] fixing when not available epoch to be clear [EVNT-37]

### DIFF
--- a/scripts/check-collect-store-validators-block-rewards.bash
+++ b/scripts/check-collect-store-validators-block-rewards.bash
@@ -13,8 +13,12 @@ collect_store_validators_block_rewards() {
       set -e
       echo "Collecting validators block rewards"
       ${SCRIPT_DIR}/collect-validators-block-rewards.bash > "$output_file"
-      echo "Storing validators block rewards from $output_file"
-      ${SCRIPT_DIR}/store-validators-block-rewards.bash "$output_file"
+      if [[ -s "$output_file" ]]; then
+        echo "Storing validators block rewards from $output_file"
+        ${SCRIPT_DIR}/store-validators-block-rewards.bash "$output_file"
+      else
+        echo "No block rewards data collected yet (BigQuery has no data for the epoch); skipping store, will retry next run"
+      fi
       set +e
       ;;
     1)


### PR DESCRIPTION
An additional fix on top of https://github.com/marinade-finance/delegation-strategy-2/pull/220

When BigQuery has ≤ loading_limit rows for an epoch, collect intentionally writes an empty snapshot (to avoid persisting a partial epoch), but the orchestration script piped that empty file into store, which failed with EOF while parsing a value. 

This fixes `check-collect-store-validators-block-rewards.bash` to only run store when the snapshot file is non-empty and otherwise log and skip — the "retried next run" behavior the collect WARN already promises.

Omit failure

```
Checking validators block rewards...
[2026-06-08T11:11:28Z INFO  check] Running check command BlockRewards(BlockRewardsCheckParams { slot_offset_wait: 10000 }) with commitment finalized
[2026-06-08T11:11:29Z INFO  check::validators_block_rewards] Checking epoch data about epoch in DB table validators_block_rewards
[2026-06-08T11:11:29Z INFO  check::validators_block_rewards] DB validators_block_rewards stores last epoch: 973. On-chain epoch 984 slot index: 11137
[2026-06-08T11:11:29Z INFO  check::validators_block_rewards] The previous epoch (983) has surpassed the last recorded table validators_block_rewards epoch (973). Initiating data collection for validators_block_rewards analysis.
Collecting validators block rewards
[2026-06-08T11:11:29Z INFO  collect::validators_block_rewards] Collecting validator block rewards snapshot
[2026-06-08T11:11:29Z INFO  collect::validators_block_rewards] Current epoch: EpochInfo { epoch: 984, slot_index: 11137, slots_in_epoch: 432000, absolute_slot: 425099137, block_height: 403180907, transaction_count: Some(518985057186) }
[2026-06-08T11:11:29Z INFO  collect::validators_block_rewards] Looking at epoch: 983
[2026-06-08T11:11:29Z INFO  collect::validators_block_rewards] Querying BigQuery for epoch 983 from project table data-store-406413.mainnet_beta_stakes.rewards_validators_blocks
[2026-06-08T11:11:29Z INFO  collect::validators_block_rewards] Executing query: SELECT epoch, identity_account, vote_account, amount, node_pubkey, authorized_voter FROM `data-store-406413.mainnet_beta_stakes.rewards_validators_blocks` WHERE epoch = 983
[2026-06-08T11:11:30Z INFO  collect::validators_block_rewards] Retrieved 0 rows from BigQuery for epoch 983
[2026-06-08T11:11:30Z WARN  collect::validators_block_rewards] No data found for epoch 983. This epoch may not have data available yet. The collection will be retried next time.
[2026-06-08T11:11:30Z INFO  collect] Collect validators-block-rewards finished successfully.
Storing validators block rewards from validators-block-rewards.yaml
[2026-06-08T11:11:30Z INFO  store::validators_block_rewards] Storing block rewards snapshot...
Error: Failed to parse snapshot block rewards file 'validators-block-rewards.yaml': EOF while parsing a value
```