### PR TITLE
Additional fix on non existing epoch n.2 [EVNT-37]

### DIFF
--- a/check/src/validators_jito.rs
+++ b/check/src/validators_jito.rs
@@ -4,7 +4,7 @@ use solana_client::rpc_client::RpcClient;
 use structopt::StructOpt;
 use tokio_postgres::Client;
 
-pub const MILLISECONDS_PER_SLOT: u64 = 400; // 0.4 seconds per slot
+pub use collect::common::MILLISECONDS_PER_SLOT;
 
 #[derive(Debug, StructOpt)]
 pub struct ValidatorsJitoCheckParams {

--- a/collect/src/common.rs
+++ b/collect/src/common.rs
@@ -1,6 +1,8 @@
 use std::{thread, time::Duration};
 use structopt::StructOpt;
 
+pub const MILLISECONDS_PER_SLOT: u64 = 400; // 0.4 seconds per slot
+
 #[derive(Debug, StructOpt)]
 pub struct CommonParams {
     #[structopt(short = "u", long = "url", env = "RPC_URL")]

--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -262,7 +262,7 @@ pub fn get_validators_info(
 
     let mut validator_info_map = HashMap::new();
     if validator_info.is_empty() {
-        println!("No validator info accounts found");
+        warn!("No validator info accounts found");
     }
     for (validator_info_pubkey, validator_info_account) in validator_info.iter() {
         match parse_validator_info(validator_info_pubkey, validator_info_account) {

--- a/collect/src/validators_block_rewards.rs
+++ b/collect/src/validators_block_rewards.rs
@@ -39,13 +39,23 @@ pub struct BlockRewardsParams {
 
     #[structopt(
         long = "loading-limit",
+        env = "LOADING_LIMIT",
         help = "When loading validators' block rewards data, we expect a higher number from the ETL to consider the data valid.",
         default_value = "10"
     )]
     loading_limit: u32,
+
+    #[structopt(
+        long = "max-data-delay-hours",
+        env = "MAX_DATA_DELAY_HOURS",
+        help = "Fail instead of skipping when block rewards data is still missing this many hours after the target epoch ended (approximate; assumes ~400ms slots). 0 disables the check. Ignored when --epoch is set (backfill).",
+        default_value = "12"
+    )]
+    max_data_delay_hours: u64,
 }
 
 const DATA_VERSION: u16 = 1;
+const MILLISECONDS_PER_HOUR: u64 = 3_600_000;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ValidatorsBlockRewardsSnapshot {
@@ -158,7 +168,32 @@ pub fn collect_validator_block_rewards_info(
     })?;
 
     if block_rewards.len() <= rewards_params.loading_limit as usize {
-        warn!("No data found for epoch {looking_at_epoch}. This epoch may not have data available yet. The collection will be retried next time.");
+        if rewards_params.epoch.is_some() {
+            warn!(
+                "No data found for backfill epoch {looking_at_epoch}. May not be available yet. BigQuery returned {} rows (loading limit {}).",
+                block_rewards.len(),
+                rewards_params.loading_limit,
+            );
+        } else {
+            let hours_since_epoch_end = current_epoch_info
+                .slot_index
+                .saturating_mul(MILLISECONDS_PER_SLOT)
+                / MILLISECONDS_PER_HOUR;
+            if rewards_params.max_data_delay_hours > 0
+                && hours_since_epoch_end >= rewards_params.max_data_delay_hours
+            {
+                anyhow::bail!(
+                    "No block rewards data for epoch {looking_at_epoch}: BigQuery returned {} rows (loading limit {}) ~{hours_since_epoch_end}h after the epoch ended (threshold {}h). Upstream stakes-etl load is overdue.",
+                    block_rewards.len(),
+                    rewards_params.loading_limit,
+                    rewards_params.max_data_delay_hours,
+                );
+            }
+            warn!(
+                "No data found for epoch {looking_at_epoch} (~{hours_since_epoch_end}h after epoch end). May not be available yet; will retry next run. BigQuery returned {} rows.",
+                block_rewards.len(),
+            );
+        }
     } else {
         info!(
             "Successfully retrieved {} validator block rewards",

--- a/collect/src/validators_block_rewards.rs
+++ b/collect/src/validators_block_rewards.rs
@@ -170,7 +170,7 @@ pub fn collect_validator_block_rewards_info(
     if block_rewards.len() <= rewards_params.loading_limit as usize {
         if rewards_params.epoch.is_some() {
             warn!(
-                "No data found for backfill epoch {looking_at_epoch}. May not be available yet. BigQuery returned {} rows (loading limit {}).",
+                "Insufficient block rewards data for backfill epoch {looking_at_epoch} (rows <= loading limit). May not be available yet. BigQuery returned {} rows (loading limit {}).",
                 block_rewards.len(),
                 rewards_params.loading_limit,
             );
@@ -183,15 +183,16 @@ pub fn collect_validator_block_rewards_info(
                 && hours_since_epoch_end >= rewards_params.max_data_delay_hours
             {
                 anyhow::bail!(
-                    "No block rewards data for epoch {looking_at_epoch}: BigQuery returned {} rows (loading limit {}) ~{hours_since_epoch_end}h after the epoch ended (threshold {}h). Upstream stakes-etl load is overdue.",
+                    "Insufficient block rewards data for epoch {looking_at_epoch} (rows <= loading limit): BigQuery returned {} rows (loading limit {}) ~{hours_since_epoch_end}h after the epoch ended (threshold {}h). Upstream stakes-etl load is overdue.",
                     block_rewards.len(),
                     rewards_params.loading_limit,
                     rewards_params.max_data_delay_hours,
                 );
             }
             warn!(
-                "No data found for epoch {looking_at_epoch} (~{hours_since_epoch_end}h after epoch end). May not be available yet; will retry next run. BigQuery returned {} rows.",
+                "Insufficient block rewards data for epoch {looking_at_epoch} (rows <= loading limit, ~{hours_since_epoch_end}h after epoch end). May not be available yet; will retry next run. BigQuery returned {} rows (loading limit {}).",
                 block_rewards.len(),
+                rewards_params.loading_limit,
             );
         }
     } else {


### PR DESCRIPTION
I was reviewing the change from https://github.com/marinade-finance/delegation-strategy-2/pull/221, and I realized that I don't like the fact that if data is not available for a long time, we just skip/warn. It is ok for the data to be unavailable when stakes-etl is not done with BQ loading yet. But when it is not available for a long time, I think we should reflect that in the CLI result outcome.

With that, I'm proposing an additional change here that starts failing when we are more than 12 hours after the start of the epoch and still do not have any validator data available in BQ.

I'm not sure if it is not a little bit workaround. WDYT @martinkrecek 
