### PR TITLE
[store] do not overwrite known validator version with null [GEN-8400]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -45,7 +45,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api"
@@ -1016,6 +1016,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borsh"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1243,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "check"
 version = "0.1.0"
 dependencies = [
@@ -1273,7 +1293,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -1291,6 +1311,12 @@ dependencies = [
  "unicode-width 0.1.14",
  "vec_map",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "collect"
@@ -1316,6 +1342,7 @@ dependencies = [
  "solana-config-program",
  "solana-program",
  "solana-sdk",
+ "solana-stake-interface",
  "solana-vote-program",
  "structopt",
  "tokio",
@@ -1393,6 +1420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1511,6 +1553,15 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1554,6 +1605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,7 +1633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1741,8 +1801,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2206,9 +2278,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2498,6 +2582,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,6 +2685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,7 +2710,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3089,7 +3191,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3166,6 +3268,15 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libsecp256k1"
@@ -3257,12 +3368,12 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3759,18 +3870,19 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.1",
 ]
@@ -3820,7 +3932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3854,27 +3966,27 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.8"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "md-5",
  "memchr",
- "rand 0.9.1",
- "sha2 0.10.9",
+ "rand 0.10.2",
+ "sha2 0.11.0",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.9"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
@@ -3990,7 +4102,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "protobuf",
  "thiserror 1.0.69",
 ]
 
@@ -4025,12 +4136,6 @@ checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"
@@ -4098,9 +4203,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -4149,6 +4254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,6 +4297,17 @@ checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4244,6 +4366,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -4692,7 +4820,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4935,7 +5063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4953,7 +5081,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -4965,8 +5093,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5070,6 +5209,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7260,9 +7409,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"
@@ -7938,9 +8087,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.13"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7955,8 +8104,8 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.1",
- "socket2 0.5.10",
+ "rand 0.10.2",
+ "socket2 0.6.5",
  "tokio",
  "tokio-util",
  "whoami",
@@ -8244,9 +8393,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -8311,7 +8460,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -8533,9 +8682,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "0.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.2+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -8685,11 +8837,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
+checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
 dependencies = [
- "redox_syscall",
+ "libredox",
  "wasite",
  "web-sys",
 ]
@@ -8716,7 +8868,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ validator = { version = "0.20.0", features = ["derive"] }
 bytes = "1.11"
 futures = { version = "0.3", default-features = false }
 warp = "0.3"
-prometheus = "0.13.3"
+prometheus = { version = "0.13.3", default-features = false }
 lazy_static = "1.4.0"
 regex = "1.7.2"
 
@@ -46,6 +46,7 @@ redis = { version = "0.23.0", features = ["json"] }
 # Collect-specific dependencies
 solana-vote-program = "2.2.20"
 solana-sdk = "2.2.2"
+solana-stake-interface = { version = "1.2.1", features = ["serde"] }
 solana-account-decoder = "2.2.20"
 solana-config-program = "2.2.20"
 solana-commitment-config = "2.2.1"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "api"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 rust_decimal = { workspace = true }

--- a/api/src/handlers/validator_score_breakdown.rs
+++ b/api/src/handlers/validator_score_breakdown.rs
@@ -127,35 +127,35 @@ pub async fn handler(
         .map(|(_, ValidatorScoreRecord { score, .. })| *score)
         .min_by(|a, b| to_fixed_for_sort(*a).cmp(&to_fixed_for_sort(*b)));
 
+    #[allow(deprecated)]
+    let score_breakdown = ScoreBreakdown {
+        vote_account,
+        score,
+        min_score_eligible_algo,
+        rank,
+        ui_hints,
+        vemnde_votes,
+        msol_votes,
+        component_scores,
+        component_ranks,
+        component_values,
+        component_weights,
+        components,
+        eligible_stake_algo,
+        eligible_stake_vemnde,
+        eligible_stake_mnde: eligible_stake_vemnde,
+        eligible_stake_msol,
+        target_stake_algo,
+        target_stake_vemnde,
+        target_stake_mnde: target_stake_vemnde,
+        target_stake_msol,
+        scoring_run_id,
+        created_at,
+        epoch,
+        ui_id,
+    };
     Ok(warp::reply::with_status(
-        json(&ResponseScoreBreakdown {
-            score_breakdown: ScoreBreakdown {
-                vote_account,
-                score,
-                min_score_eligible_algo,
-                rank,
-                ui_hints,
-                vemnde_votes,
-                msol_votes,
-                component_scores,
-                component_ranks,
-                component_values,
-                component_weights,
-                components,
-                eligible_stake_algo,
-                eligible_stake_vemnde,
-                eligible_stake_mnde: eligible_stake_vemnde,
-                eligible_stake_msol,
-                target_stake_algo,
-                target_stake_vemnde,
-                target_stake_mnde: target_stake_vemnde,
-                target_stake_msol,
-                scoring_run_id,
-                created_at,
-                epoch,
-                ui_id,
-            },
-        }),
+        json(&ResponseScoreBreakdown { score_breakdown }),
         StatusCode::OK,
     ))
 }

--- a/api/src/handlers/validator_score_breakdowns.rs
+++ b/api/src/handlers/validator_score_breakdowns.rs
@@ -179,6 +179,7 @@ fn compute_score_breakdowns(
             .iter()
             .find(|s| s.scoring_run_id == score.scoring_run_id.into())
         {
+            #[allow(deprecated)]
             score_breakdowns.push(ScoreBreakdown {
                 vote_account: score.vote_account.clone(),
                 score: score.score,

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -2,6 +2,7 @@
 name = "check"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/collect/Cargo.toml
+++ b/collect/Cargo.toml
@@ -2,6 +2,7 @@
 name = "collect"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -12,6 +13,7 @@ env_logger = { workspace = true }
 structopt = { workspace = true }
 solana-client = { workspace = true }
 solana-vote-program = { workspace = true }
+solana-stake-interface = { workspace = true }
 rust_decimal = { workspace = true }
 solana-sdk = { workspace = true }
 solana-program = { workspace = true }

--- a/collect/src/marinade_service.rs
+++ b/collect/src/marinade_service.rs
@@ -11,7 +11,8 @@ use solana_program::{
     pubkey::Pubkey,
     stake_history::{StakeHistory, StakeHistoryEntry},
 };
-use solana_sdk::{pubkey, stake};
+use solana_sdk::pubkey;
+use solana_stake_interface as stake;
 use std::collections::*;
 
 pub fn get_marinade_stakes(

--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -90,7 +90,7 @@ pub fn get_cluster_nodes_versions(
     Ok(cluster_nodes
         .iter()
         .filter_map(|node| {
-            node.version.clone().map(|version| {
+            node.version.clone().and_then(|version| {
                 let version = version
                     .split_once(char::is_whitespace)
                     .map(|(version, extra)| {
@@ -101,10 +101,30 @@ pub fn get_cluster_nodes_versions(
                         version.to_string()
                     })
                     .unwrap_or(version);
-                (node.pubkey.clone(), version)
+                if !is_plausible_node_version(&version) {
+                    warn!(
+                        "Node {} reports malformed version: '{version}', ignoring",
+                        node.pubkey
+                    );
+                    return None;
+                }
+                Some((node.pubkey.clone(), version))
             })
         })
         .collect())
+}
+
+// A malformed gossip version is dropped so store never replaces the last known good version with it.
+fn is_plausible_node_version(version: &str) -> bool {
+    let mut parts = version.splitn(3, '.');
+    let numeric = |part: Option<&str>| {
+        part.is_some_and(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+    };
+    numeric(parts.next())
+        && numeric(parts.next())
+        && parts
+            .next()
+            .is_some_and(|p| p.starts_with(|c: char| c.is_ascii_digit()))
 }
 
 pub fn get_cluster_nodes_ips(rpc_client: &RpcClient) -> anyhow::Result<HashMap<String, String>> {
@@ -570,4 +590,23 @@ pub fn fetch_self_stake(
     }
 
     Ok(self_stake)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_plausible_node_version;
+
+    #[test]
+    fn plausible_node_versions() {
+        assert!(is_plausible_node_version("4.1.0"));
+        assert!(is_plausible_node_version("4.1.0-rc.1"));
+        assert!(is_plausible_node_version("4.2.0-beta.0"));
+        assert!(is_plausible_node_version("0.505.20216"));
+        assert!(!is_plausible_node_version(""));
+        assert!(!is_plausible_node_version("unknown"));
+        assert!(!is_plausible_node_version("4.1"));
+        assert!(!is_plausible_node_version("v4.1.0"));
+        assert!(!is_plausible_node_version("4.x.0"));
+        assert!(!is_plausible_node_version(".."));
+    }
 }

--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -18,7 +18,6 @@ use solana_client::{
 use solana_commitment_config::CommitmentConfig;
 use solana_config_program::{get_config_data, ConfigKeys};
 use solana_program::{
-    stake::{self, state::StakeStateV2},
     stake_history::{StakeHistory, StakeHistoryEntry},
     sysvar::stake_history,
 };
@@ -29,6 +28,7 @@ use solana_sdk::{
     sysvar,
 };
 use solana_sdk::{account::Account, pubkey::Pubkey};
+use solana_stake_interface::{self as stake, state::StakeStateV2};
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -116,15 +116,20 @@ pub fn get_cluster_nodes_versions(
 
 // A malformed gossip version is dropped so store never replaces the last known good version with it.
 fn is_plausible_node_version(version: &str) -> bool {
+    let numeric = |p: &str| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit());
     let mut parts = version.splitn(3, '.');
-    let numeric = |part: Option<&str>| {
-        part.is_some_and(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
-    };
-    numeric(parts.next())
-        && numeric(parts.next())
-        && parts
-            .next()
-            .is_some_and(|p| p.starts_with(|c: char| c.is_ascii_digit()))
+    parts.next().is_some_and(numeric)
+        && parts.next().is_some_and(numeric)
+        && parts.next().is_some_and(|p| match p.split_once('-') {
+            None => numeric(p),
+            Some((patch, prerelease)) => {
+                numeric(patch)
+                    && !prerelease.is_empty()
+                    && prerelease
+                        .bytes()
+                        .all(|b| b.is_ascii_alphanumeric() || b == b'.')
+            }
+        })
 }
 
 pub fn get_cluster_nodes_ips(rpc_client: &RpcClient) -> anyhow::Result<HashMap<String, String>> {
@@ -608,5 +613,10 @@ mod tests {
         assert!(!is_plausible_node_version("v4.1.0"));
         assert!(!is_plausible_node_version("4.x.0"));
         assert!(!is_plausible_node_version(".."));
+        assert!(!is_plausible_node_version("4.1.0garbage"));
+        assert!(!is_plausible_node_version("4.1.0/extra"));
+        assert!(!is_plausible_node_version("4.1.0-"));
+        assert!(!is_plausible_node_version("4.1.0-rc/1"));
+        assert!(!is_plausible_node_version("4.1.0.1"));
     }
 }

--- a/collect/src/validators.rs
+++ b/collect/src/validators.rs
@@ -1,6 +1,6 @@
 use crate::common::*;
 use crate::marinade_service::*;
-use crate::solana_service::solana_client;
+use crate::solana_service::solana_client_with_timeout;
 use crate::solana_service::*;
 use crate::validators_performance::{validators_performance, ValidatorPerformance};
 use crate::whois_service::*;
@@ -10,6 +10,7 @@ use log::info;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use solana_sdk::clock::Epoch;
+use std::time::Duration;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -41,6 +42,13 @@ pub struct ValidatorsParams {
         default_value = "10"
     )]
     rpc_attempts: usize,
+
+    #[structopt(
+        long = "rpc-timeout",
+        help = "How long to wait for RPC response (seconds).",
+        default_value = "300"
+    )]
+    rpc_timeout: u64,
 
     #[structopt(long = "epoch", help = "Which epoch to use for epoch-based metrics.")]
     epoch: Option<Epoch>,
@@ -134,7 +142,11 @@ pub fn collect_validators_info(
     validator_params: ValidatorsParams,
 ) -> anyhow::Result<()> {
     info!("Collecting snaphost of validators: {:?}", &validator_params);
-    let client = solana_client(common_params.rpc_url, common_params.commitment);
+    let client = solana_client_with_timeout(
+        common_params.rpc_url,
+        Duration::from_secs(validator_params.rpc_timeout),
+        common_params.commitment,
+    );
 
     let created_at = chrono::Utc::now();
     let current_epoch_info = client.get_epoch_info()?;

--- a/collect/src/validators_performance.rs
+++ b/collect/src/validators_performance.rs
@@ -1,5 +1,5 @@
 use crate::common::*;
-use crate::solana_service::solana_client;
+use crate::solana_service::solana_client_with_timeout;
 use crate::solana_service::*;
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -7,6 +7,7 @@ use serde_yaml;
 use solana_client::{rpc_client::RpcClient, rpc_response::RpcVoteAccountStatus};
 use solana_sdk::clock::Epoch;
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -16,6 +17,13 @@ pub struct ValidatorsPerformanceParams {
 
     #[structopt(long = "epoch", help = "Which epoch to use for epoch-based metrics.")]
     epoch: Option<Epoch>,
+
+    #[structopt(
+        long = "rpc-timeout",
+        help = "How long to wait for RPC response (seconds).",
+        default_value = "300"
+    )]
+    rpc_timeout: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -131,7 +139,11 @@ pub fn collect_validators_performance_info(
     performance_params: ValidatorsPerformanceParams,
 ) -> anyhow::Result<()> {
     info!("Collecting snaphost of validators' performance");
-    let client = solana_client(common_params.rpc_url, common_params.commitment);
+    let client = solana_client_with_timeout(
+        common_params.rpc_url,
+        Duration::from_secs(performance_params.rpc_timeout),
+        common_params.commitment,
+    );
 
     let created_at = chrono::Utc::now();
     let current_epoch_info = client.get_epoch_info()?;

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,184 @@
+# Repo-local cargo-deny policy. The org-wide static-analysis workflow
+# (marinade-finance/.github) uses this file when present and otherwise fetches
+# the org config. It mirrors that org policy and adds the exceptions this
+# repo's dependency tree needs: the Jito git source and the structopt/yaml-rust
+# maintenance advisories, neither of which has a safe upgrade.
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+# All ignored advisories are unfixable transitive dependencies pulled in
+# through the Solana / Anchor / SPL ecosystem (solana-sdk, solana-zk-sdk,
+# spl-token-2022, anchor-lang, …). Revisit when the upstream Solana crates
+# upgrade past these.
+ignore = [
+  # ed25519-dalek <2.0 — public-key oracle attack. solana-sdk pins 1.x.
+  "RUSTSEC-2022-0093",
+  # curve25519-dalek timing variability in Scalar*::sub. Solana-internal.
+  "RUSTSEC-2024-0344",
+  # atty unmaintained. Pulled by solana-logger via env_logger 0.9.
+  "RUSTSEC-2024-0375",
+  # derivative unmaintained. Pulled via ark-ff / ark-ec.
+  "RUSTSEC-2024-0388",
+  # paste unmaintained. Pulled via solana-program / anchor-lang.
+  "RUSTSEC-2024-0436",
+  # number_prefix unmaintained. Pulled via indicatif.
+  "RUSTSEC-2025-0119",
+  # bincode 1.x unmaintained. Pulled via solana-sdk.
+  "RUSTSEC-2025-0141",
+  # libsecp256k1 unmaintained. Pulled via solana-sdk.
+  "RUSTSEC-2025-0161",
+  # rand unsoundness with custom logger. Pulled via solana-sdk / spl-pod.
+  "RUSTSEC-2026-0097",
+  # rustls-webpki 0.101.x (EOL) cert-validation bugs: URI/wildcard name
+  # constraints and a reachable CRL-parsing panic. Fixed in the 0.102/0.103
+  # lines but the 0.101 line is end-of-life. Pulled via the old rustls 0.21
+  # / tokio-tungstenite 0.20 stack that solana-pubsub-client still pins.
+  # Drop these once the Solana websocket client upgrades tungstenite/rustls.
+  "RUSTSEC-2026-0098",
+  "RUSTSEC-2026-0099",
+  "RUSTSEC-2026-0104",
+  # rustls-webpki <0.103.10 CRL distribution-point matching bug. The 0.103
+  # line is patched (repos pick up 0.103.13 via `cargo update`); the stuck
+  # 0.102.x is pulled via gcp-bigquery-client -> yup-oauth2 -> rustls 0.22.
+  # Revisit when gcp-bigquery-client moves to a rustls 0.23 release.
+  "RUSTSEC-2026-0049",
+  # Unmaintained crates pinned deep in the Solana validator stack
+  # (solana-runtime / solana-ledger / solana-storage-bigtable), reached via
+  # the snapshot-parser git dep, plus the reqwest 0.11 / gcp-bigquery-client
+  # TLS stack. No maintained drop-in at the versions those crates pin; revisit
+  # when the upstream Solana / reqwest crates move forward.
+  # instant — unmaintained. Pulled via backoff -> solana-storage-bigtable.
+  "RUSTSEC-2024-0384",
+  # backoff — unmaintained. Pulled via solana-storage-bigtable.
+  "RUSTSEC-2025-0012",
+  # proc-macro-error2 — unmaintained. Pulled via aquamarine -> solana-runtime.
+  "RUSTSEC-2026-0173",
+  # rustls-pemfile — unmaintained. Pulled via reqwest 0.11 (gcp-bigquery-client).
+  "RUSTSEC-2025-0134",
+  # ansi_term — unmaintained. Pulled via clap 2.x, which the Solana CLI
+  # helper crates (solana-clap-utils -> solana-cli-config / solana-cli-output)
+  # still depend on. Goes away when Solana's CLI crates move off clap 2.
+  "RUSTSEC-2021-0139",
+  # proc-macro-error — unmaintained, build-time only (proc-macro dep of
+  # utoipa-gen < 4). Repos on utoipa >= 4 don't pull it; bumping utoipa past
+  # 3.x is the real fix where the OpenAPI migration is worth it.
+  "RUSTSEC-2024-0370",
+  # structopt — in permanent maintenance mode, no safe upgrade available.
+  # Used directly for CLI parsing across collect/check/api/store; the real fix
+  # is migrating to clap, tracked separately.
+  "RUSTSEC-2022-0104",
+  # yaml-rust — unmaintained, no safe upgrade available. Pulled via serde_yaml
+  # 0.8; dropping it means moving off serde_yaml 0.8 (itself archived).
+  "RUSTSEC-2024-0320",
+]
+
+# Permissive-only allow list. Anything copyleft (GPL/LGPL/AGPL/EUPL/EPL),
+# source-disclosure-required, or commercial-restricting must NOT be added
+# without an explicit security review — the goal is that downstream consumers
+# can ship binaries built from this tree without source-disclosure obligations.
+[licenses]
+allow = [
+  # Classic permissive
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  # Boost — permissive, no patent grant. Used as alternative by `ryu`.
+  "BSL-1.0",
+  # Public-domain-equivalents. Used as alternatives by csv, aho-corasick,
+  # memchr, termcolor, walkdir, adler2, constant_time_eq, …
+  "0BSD",
+  "Unlicense",
+  "MIT-0",
+  "CC0-1.0",
+  # Weak copyleft, file-level — file-level disclosure only.
+  "MPL-2.0",
+  # zlib (libz-rs-sys / zlib-rs and tinyvec/bytemuck/cfg_eval as alternative).
+  "Zlib",
+  # ICU / idna stack pulled in via reqwest -> url -> idna.
+  "Unicode-3.0",
+  # webpki-roots ships the Mozilla CA bundle.
+  "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.93
+exceptions = []
+# First-party workspace crates are routinely unpublished (`publish = false`)
+# and carry no `license` field — they're internal binaries, integration-test
+# crates, and not-yet-released SDKs. Skip the license check for those rather
+# than forcing every repo to stamp a license on internal crates just to make
+# the supply-chain license gate (which is about third-party deps) pass.
+private = { ignore = true }
+
+# Clarify the license for crates that don't declare one in the relevant
+# release's manifest but are licensed upstream. Each expression below is a
+# verified, permissive license:
+#  - mpl-token-metadata 5.x ships without a license field despite Metaplex
+#    publishing it under Apache-2.0. This is third-party, so clarifying here
+#    is the right long-term home.
+#  - TEMPORARY: the marinade-finance first-party crates below
+#    (solana-transaction-*, solana-snapshot-parser) have no `license` field in
+#    their own Cargo.toml. The real fix is to add `license = "Apache-2.0"` in
+#    those repos directly; remove these entries once that lands and the
+#    consuming repos re-pin. Tracked as a follow-up — see the open PRs.
+[[licenses.clarify]]
+crate = "mpl-token-metadata"
+expression = "Apache-2.0"
+license-files = []
+
+# TEMP (fix upstream, then delete): marinade-finance crates missing a license field.
+[[licenses.clarify]]
+crate = "snapshot-parser"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+crate = "snapshot-parser-validator-cli"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+crate = "solana-transaction-builder"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+crate = "solana-transaction-builder-executor"
+expression = "Apache-2.0"
+license-files = []
+
+[[licenses.clarify]]
+crate = "solana-transaction-executor"
+expression = "Apache-2.0"
+license-files = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+# Path dependencies between workspace members are conventionally declared
+# without a version (`foo = { path = "../foo" }`), which cargo-deny would
+# otherwise flag as a wildcard. Allow wildcards *only* for path deps; a
+# wildcard on a crates.io dependency is still denied.
+allow-wildcard-paths = true
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+# First-party crates are routinely consumed as git dependencies pinned to a
+# tag/branch (e.g. solana-transaction-builder, solana-snapshot-parser) before
+# they're ever published to crates.io. Trust the whole marinade-finance org as
+# a git source rather than maintaining a per-repo allow-git URL list. Any other
+# git source remains denied.
+# jito-foundation hosts jito-programs (jito-tip-distribution / jito-priority-fee-
+# distribution / jito-programs-vote-state), consumed by `collect` as a git dep
+# pinned to a rev with no crates.io release; trust the org as a git source.
+[sources.allow-org]
+github = ["marinade-finance", "jito-foundation"]

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -2,6 +2,7 @@
 name = "store"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 rust_decimal = { workspace = true }

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1124,7 +1124,7 @@ pub async fn load_block_production_stats(
 	                epoch,
                     COALESCE(SUM(blocks_produced), 0) blocks_produced,
                     COALESCE(SUM(leader_slots), 0) leader_slots,
-                    (1 - COALESCE(SUM(blocks_produced), 0)  / coalesce(SUM(leader_slots), 1))::DOUBLE PRECISION avg_skip_rate
+                    COALESCE(1 - COALESCE(SUM(blocks_produced), 0) / NULLIF(SUM(leader_slots), 0), 1)::DOUBLE PRECISION avg_skip_rate
                 FROM validators
                 WHERE epoch > $1
                 GROUP BY epoch ORDER BY epoch DESC",

--- a/store/src/validators.rs
+++ b/store/src/validators.rs
@@ -74,7 +74,7 @@ pub async fn store_validators(
             dc_asn = u.dc_asn,
             dc_aso = u.dc_aso,
             commission_advertised = u.commission_advertised,
-            version = u.version,
+            version = COALESCE(u.version, validators.version),
             activated_stake = u.activated_stake,
             marinade_stake = u.marinade_stake,
             foundation_stake = u.foundation_stake,


### PR DESCRIPTION
* make the client wait longer for RPC responses instead of abruptly closing the connection after 30 seconds
* fix a coalesce issue when the version is not available in the DB
* do not override a version with null when the version is parsed incorrectly


> The per-epoch version reflected only the last collector run: a single getClusterNodes gossip miss froze the epoch's version to null once the epoch closed. COALESCE keeps the last known version within the epoch, and malformed gossip version strings are dropped at collect time so they never replace a valid one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster node listings now ignore malformed node version strings for more accurate results.
  * Snapshot-based version updates no longer overwrite stored values when the incoming version is missing.
  * Block production stats now avoid divide-by-zero when leader slots are zero.
* **New Features**
  * Added configurable Solana RPC request timeouts for validator data collection (`--rpc-timeout`, default 300s).
* **Tests**
  * Added unit tests covering valid and invalid node version formats.
* **Chores**
  * Updated crate publishing/package settings and added repo-wide dependency security/license policy checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->