### PR TITLE
[perf] lower number of queries [GEN-8006]

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -19,6 +19,20 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:17.4
+        env:
+          POSTGRES_DB: delegation-strategy
+          POSTGRES_USER: delegation-strategy
+          POSTGRES_PASSWORD: delegation-strategy
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: 🚧 Checkout project
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -50,4 +64,6 @@ jobs:
         run: cargo fmt -- --check && cargo clippy
 
       - name: 🧨 Run cargo tests
+        env:
+          DS_TEST_POSTGRES_URL: postgresql://delegation-strategy:delegation-strategy@localhost:5432/delegation-strategy
         run: cargo test --all-features

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,3 +29,19 @@ docker cp postgresql-${DB}:/etc/ssl/certs/ssl-cert-snakeoil.pem /tmp/postgres-ro
 ```
 
 The PostgreSQL URL is then `postgresql://delegation-strategy:delegation-strategy@localhost:5432/delegation-strategy`
+
+# 2. Run the SQL loader tests
+
+`store/tests/cluster_stats_sql.rs` exercises the `/cluster-stats` and
+`/validators/flat` queries against a real PostgreSQL. It creates its own schema,
+applies `migrations/*.sql` into it and drops it again, so it needs an empty
+database only on the first run.
+
+```bash
+export DS_TEST_POSTGRES_URL='postgresql://delegation-strategy:delegation-strategy@localhost:5432/delegation-strategy'
+cargo test --all-features
+```
+
+Without `DS_TEST_POSTGRES_URL` the tests report why they are skipped and pass.
+On Podman, start the container with `podman run` and export
+`DOCKER_HOST=unix:///run/user/1000/podman/podman.sock`.

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1484,27 +1484,38 @@ async fn load_stake_distribution(
     };
     let first_epoch = last_epoch - epochs.min(last_epoch) + 1;
 
-    let mut distributions: Vec<StakeDistribution> = Default::default();
-
-    for epoch in (first_epoch..=last_epoch).rev() {
-        let rows = psql_client
-            .query(
-                &format!(
-                    "SELECT
+    let rows = psql_client
+        .query(
+            &format!(
+                "SELECT
+                    epoch,
                     {column_expr} AS grouping_key,
                     SUM(activated_stake) AS stake,
                     COUNT(*) AS validator_count
-                FROM validators WHERE epoch = $1
-                GROUP BY 1"
-                ),
-                &[&Decimal::from(epoch)],
-            )
-            .await?;
+                FROM validators WHERE epoch BETWEEN $1 AND $2
+                GROUP BY epoch, grouping_key"
+            ),
+            &[&Decimal::from(first_epoch), &Decimal::from(last_epoch)],
+        )
+        .await?;
 
+    let mut rows_by_epoch: HashMap<u64, Vec<tokio_postgres::Row>> = Default::default();
+    for row in rows {
+        rows_by_epoch
+            .entry(row.get::<_, Decimal>("epoch").try_into()?)
+            .or_default()
+            .push(row);
+    }
+
+    let mut distributions: Vec<StakeDistribution> = Default::default();
+
+    // Callers pair these per-epoch series with load_dc_concentration_stats, so an epoch with no
+    // validator rows must still yield an entry instead of being dropped by the SQL grouping.
+    for epoch in (first_epoch..=last_epoch).rev() {
         let mut stake_by: HashMap<String, u64> = Default::default();
         let mut count_by: HashMap<String, u64> = Default::default();
         let mut total_stake: u64 = 0;
-        for row in rows.iter() {
+        for row in rows_by_epoch.remove(&epoch).unwrap_or_default().iter() {
             let grouping_key: String = row.get("grouping_key");
             let stake: u64 = row.get::<_, Decimal>("stake").try_into()?;
             total_stake += stake;
@@ -1656,14 +1667,16 @@ pub async fn load_validators_aggregated_flat(
     last_epoch: u64,
     epochs: u64,
 ) -> anyhow::Result<Vec<ValidatorAggregatedFlat>> {
+    let epochs = epochs.max(1);
+    // last_version is deliberately left unbounded while the client columns are bounded to $2:
+    // adding the bound changes what historical scoring runs see, so it needs a ds-sam side check.
     let rows = psql_client
             .query(
                 "with
                 cluster_stake AS (select epoch, sum(activated_stake) as stake from validators group by epoch),
                 cluster_skip_rate AS (select epoch, sum(skip_rate * activated_stake) / sum(activated_stake) stake_weighted_skip_rate from validators group by epoch),
                 dc AS (select validators.epoch, sum(activated_stake) / cluster_stake.stake as dc_concentration, dc_aso from validators LEFT JOIN cluster_stake ON validators.epoch = cluster_stake.epoch group by validators.epoch, dc_aso, cluster_stake.stake),
-                agg_versions AS (select vote_account, (array_agg(version order by created_at desc))[1] as last_version from versions where version is not null group by vote_account),
-                agg_clients AS (select vote_account, (array_agg(client_vendor order by created_at desc) filter (where client_vendor is not null))[1] as last_client_vendor, (array_agg(client_lineage order by created_at desc) filter (where client_lineage is not null))[1] as last_client_lineage from versions where epoch <= $2 group by vote_account)
+                agg_versions AS (select vote_account, (array_agg(version order by created_at desc) filter (where version is not null))[1] as last_version, (array_agg(client_vendor order by created_at desc) filter (where client_vendor is not null and epoch <= $2))[1] as last_client_vendor, (array_agg(client_lineage order by created_at desc) filter (where client_lineage is not null and epoch <= $2))[1] as last_client_lineage from versions group by vote_account)
                 select
                     validators.vote_account,
                     min(activated_stake / 1e9)::double precision AS minimum_stake,
@@ -1676,14 +1689,13 @@ pub async fn load_validators_aggregated_flat(
                     coalesce((array_agg(validators.dc_aso ORDER BY validators.epoch DESC))[1], 'Unknown') dc_aso,
                     coalesce((array_agg((marinade_stake / 1e9)::double precision ORDER BY validators.epoch DESC))[1], 0) AS marinade_stake,
                     coalesce((array_agg(agg_versions.last_version))[1], '0.0.0') AS last_version,
-                    coalesce((array_agg(agg_clients.last_client_vendor))[1], 'unknown') AS last_client_vendor,
-                    coalesce((array_agg(agg_clients.last_client_lineage))[1], 'unknown') AS last_client_lineage
+                    coalesce((array_agg(agg_versions.last_client_vendor))[1], 'unknown') AS last_client_vendor,
+                    coalesce((array_agg(agg_versions.last_client_lineage))[1], 'unknown') AS last_client_lineage
                 FROM
                     validators
                     LEFT JOIN dc ON dc.dc_aso = validators.dc_aso AND dc.epoch = validators.epoch
                     LEFT JOIN cluster_skip_rate ON cluster_skip_rate.epoch = validators.epoch
                     LEFT JOIN agg_versions ON validators.vote_account = agg_versions.vote_account
-                    LEFT JOIN agg_clients ON validators.vote_account = agg_clients.vote_account
                 WHERE
                 validators.epoch BETWEEN $1 AND $2
                 GROUP BY validators.vote_account

--- a/store/tests/cluster_stats_sql.rs
+++ b/store/tests/cluster_stats_sql.rs
@@ -1,0 +1,293 @@
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use store::utils::{
+    load_client_diversity_stats, load_dc_concentration_stats, load_validators_aggregated_flat,
+};
+use tokio_postgres::{Client, NoTls};
+
+const POSTGRES_URL_ENV: &str = "DS_TEST_POSTGRES_URL";
+const LAST_EPOCH: u64 = 1000;
+const EPOCHS: u64 = 7;
+const GAP_EPOCH: u64 = 997;
+
+async fn migrated_client(schema: &str) -> Option<Client> {
+    let url = std::env::var(POSTGRES_URL_ENV).ok()?;
+
+    let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+    tokio::spawn(async move {
+        if let Err(err) = connection.await {
+            panic!("postgres connection error: {err}");
+        }
+    });
+
+    client
+        .batch_execute(&format!(
+            "DROP SCHEMA IF EXISTS {schema} CASCADE;
+             CREATE SCHEMA {schema};
+             SET search_path TO {schema}"
+        ))
+        .await
+        .unwrap();
+
+    let migrations_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../migrations");
+    let mut migrations: Vec<_> = std::fs::read_dir(migrations_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "sql"))
+        .collect();
+    migrations.sort();
+    for migration in migrations {
+        let sql = std::fs::read_to_string(&migration).unwrap();
+        client
+            .batch_execute(&sql)
+            .await
+            .unwrap_or_else(|err| panic!("migration {} failed: {err}", migration.display()));
+    }
+
+    Some(client)
+}
+
+async fn insert_validator(
+    client: &Client,
+    vote_account: &str,
+    epoch: u64,
+    activated_stake: u64,
+    credits: u64,
+    client_vendor: Option<&str>,
+    client_lineage: Option<&str>,
+) {
+    client
+        .execute(
+            "INSERT INTO validators (
+                identity, vote_account, epoch, activated_stake, marinade_stake,
+                marinade_native_stake, superminority, stake_to_become_superminority, credits,
+                leader_slots, blocks_produced, skip_rate, client_vendor, client_lineage, updated_at
+            ) VALUES ($1, $2, $3, $4, 0, 0, false, 0, $5, 100, 100, 0, $6, $7, NOW())",
+            &[
+                &format!("identity-{vote_account}"),
+                &vote_account,
+                &Decimal::from(epoch),
+                &Decimal::from(activated_stake),
+                &Decimal::from(credits),
+                &client_vendor,
+                &client_lineage,
+            ],
+        )
+        .await
+        .unwrap();
+}
+
+async fn insert_version(
+    client: &Client,
+    vote_account: &str,
+    epoch: u64,
+    created_at: &str,
+    version: Option<&str>,
+    client_vendor: Option<&str>,
+    client_lineage: Option<&str>,
+) {
+    client
+        .execute(
+            "INSERT INTO versions (
+                vote_account, epoch, epoch_slot, version, client_vendor, client_lineage, created_at
+            ) VALUES ($1, $2, 0, $3, $4, $5, $6)",
+            &[
+                &vote_account,
+                &Decimal::from(epoch),
+                &version,
+                &client_vendor,
+                &client_lineage,
+                &created_at.parse::<DateTime<Utc>>().unwrap(),
+            ],
+        )
+        .await
+        .unwrap();
+}
+
+fn skip_without_database(schema: &str) -> bool {
+    if std::env::var(POSTGRES_URL_ENV).is_ok() {
+        return false;
+    }
+    eprintln!("skipping {schema}: {POSTGRES_URL_ENV} is not set");
+    true
+}
+
+#[tokio::test]
+async fn stake_distribution_emits_every_requested_epoch_including_gaps() {
+    let schema = "ds_test_stake_distribution";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    let first_epoch = LAST_EPOCH - EPOCHS + 1;
+    for epoch in first_epoch..=LAST_EPOCH {
+        if epoch == GAP_EPOCH {
+            continue;
+        }
+        insert_validator(
+            &client,
+            "voteA",
+            epoch,
+            100,
+            10,
+            Some("jito"),
+            Some("agave"),
+        )
+        .await;
+        insert_validator(
+            &client,
+            "voteB",
+            epoch,
+            200,
+            10,
+            Some("jito"),
+            Some("agave"),
+        )
+        .await;
+        insert_validator(&client, "voteC", epoch, 700, 10, None, None).await;
+    }
+
+    let diversity = load_client_diversity_stats(&client, EPOCHS).await.unwrap();
+
+    let epochs: Vec<u64> = diversity.iter().map(|stats| stats.epoch).collect();
+    assert_eq!(
+        epochs,
+        (first_epoch..=LAST_EPOCH).rev().collect::<Vec<u64>>(),
+        "every requested epoch must be emitted exactly once, newest first"
+    );
+
+    let gap = diversity
+        .iter()
+        .find(|stats| stats.epoch == GAP_EPOCH)
+        .unwrap();
+    assert_eq!(gap.total_activated_stake, 0);
+    assert!(gap.client_stake.is_empty());
+    assert!(gap.client_share.is_empty());
+    assert!(gap.client_validator_count.is_empty());
+
+    let populated = diversity
+        .iter()
+        .find(|stats| stats.epoch == LAST_EPOCH)
+        .unwrap();
+    assert_eq!(populated.total_activated_stake, 1000);
+    assert_eq!(populated.client_stake.get("jito"), Some(&300));
+    assert_eq!(populated.client_stake.get("unknown"), Some(&700));
+    assert_eq!(populated.client_validator_count.get("jito"), Some(&2));
+    assert_eq!(populated.client_validator_count.get("unknown"), Some(&1));
+    assert!((populated.client_share.get("jito").unwrap() - 0.3).abs() < 1e-9);
+    assert!((populated.client_share.get("unknown").unwrap() - 0.7).abs() < 1e-9);
+
+    let concentration = load_dc_concentration_stats(&client, EPOCHS).await.unwrap();
+    assert_eq!(
+        concentration
+            .iter()
+            .map(|stats| stats.epoch)
+            .collect::<Vec<u64>>(),
+        epochs,
+        "cluster-stats series must cover the same epoch window"
+    );
+
+    client
+        .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn validators_flat_client_columns_keep_open_lower_bound_and_bounded_upper_bound() {
+    let schema = "ds_test_validators_flat";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    for epoch in (LAST_EPOCH - EPOCHS + 1)..=LAST_EPOCH {
+        insert_validator(
+            &client,
+            "voteA",
+            epoch,
+            100,
+            10,
+            Some("jito"),
+            Some("agave"),
+        )
+        .await;
+    }
+
+    insert_version(
+        &client,
+        "voteA",
+        900,
+        "2026-01-01T00:00:00Z",
+        Some("2.0.0"),
+        Some("bam"),
+        Some("agave"),
+    )
+    .await;
+    insert_version(
+        &client,
+        "voteA",
+        999,
+        "2026-02-01T00:00:00Z",
+        Some("2.1.0"),
+        None,
+        None,
+    )
+    .await;
+    insert_version(
+        &client,
+        "voteA",
+        1001,
+        "2026-03-01T00:00:00Z",
+        Some("2.2.0"),
+        Some("firedancer-vendor"),
+        Some("firedancer"),
+    )
+    .await;
+
+    let validators = load_validators_aggregated_flat(&client, LAST_EPOCH, EPOCHS)
+        .await
+        .unwrap();
+    assert_eq!(validators.len(), 1);
+    let validator = &validators[0];
+
+    assert_eq!(
+        validator.client_vendor, "bam",
+        "the only client row sits below the epoch window, so the lower bound must stay open"
+    );
+    assert_eq!(validator.client_lineage, "agave");
+    assert_eq!(
+        validator.version, "2.2.0",
+        "last_version is deliberately unbounded and still reports data from above last_epoch"
+    );
+
+    client
+        .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn validators_flat_survives_zero_epochs() {
+    let schema = "ds_test_validators_flat_zero";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    insert_validator(&client, "voteA", LAST_EPOCH, 100, 10, Some("jito"), None).await;
+
+    let validators = load_validators_aggregated_flat(&client, LAST_EPOCH, 0)
+        .await
+        .unwrap();
+    assert!(
+        validators.is_empty(),
+        "epochs=0 can never satisfy the HAVING clause"
+    );
+
+    client
+        .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
A follow-up to https://github.com/marinade-finance/delegation-strategy-2/pull/217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced database round-trips for stake distribution loading across epoch ranges.
  * Streamlined validator aggregation and client/version metadata calculations.

* **Bug Fixes**
  * Improved correctness of client metadata and version selection at epoch boundaries.
  * Ensured zero-epoch requests return no results and gaps are handled with zero/empty outputs.

* **Tests**
  * Added PostgreSQL-backed integration tests that validate stake distribution, diversity, and concentration stats.
  * Updated CI to provision PostgreSQL for the test suite and support local connections.

* **Documentation**
  * Updated development guidance with steps and `DS_TEST_POSTGRES_URL` for running SQL loader tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->