### PR TITLE
Performance enhancements [GEN-8006]

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,9 +33,9 @@ The PostgreSQL URL is then `postgresql://delegation-strategy:delegation-strategy
 # 2. Run the SQL loader tests
 
 `store/tests/cluster_stats_sql.rs` exercises the `/cluster-stats` and
-`/validators/flat` queries against a real PostgreSQL. It creates its own schema,
-applies `migrations/*.sql` into it and drops it again, so it needs an empty
-database only on the first run.
+`/validators/flat` queries against a real PostgreSQL. It drops and recreates its
+own schema on every run, so the database does not have to be empty — permission
+to create a schema is enough, and repeat runs are safe.
 
 ```bash
 export DS_TEST_POSTGRES_URL='postgresql://delegation-strategy:delegation-strategy@localhost:5432/delegation-strategy'

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -105,6 +105,16 @@ impl Cache {
         self.validators.clone()
     }
 
+    pub fn find_validator_key(&self, vote_account_or_identity: &str) -> Option<String> {
+        self.validators
+            .iter()
+            .find(|(_, record)| {
+                record.identity == vote_account_or_identity
+                    || record.vote_account == vote_account_or_identity
+            })
+            .map(|(vote_key, _)| vote_key.clone())
+    }
+
     pub fn get_commissions(&self, vote_account: &String) -> Option<Vec<CommissionRecord>> {
         self.commissions.get(vote_account).cloned()
     }
@@ -374,4 +384,41 @@ pub fn spawn_cache_warmer(context: WrappedContext) {
             sleep(Duration::from_secs(run_every.as_secs() - sleep_seconds)).await;
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cache_with(records: &[(&str, &str)]) -> Cache {
+        let mut cache = Cache::new();
+        for (vote_account, identity) in records {
+            cache.validators.insert(
+                vote_account.to_string(),
+                ValidatorRecord {
+                    vote_account: vote_account.to_string(),
+                    identity: identity.to_string(),
+                    ..Default::default()
+                },
+            );
+        }
+        cache
+    }
+
+    #[test]
+    fn find_validator_key_resolves_vote_account_and_identity() {
+        let cache = cache_with(&[("vote-a", "id-a"), ("vote-b", "id-b")]);
+
+        assert_eq!(
+            cache.find_validator_key("vote-a"),
+            Some("vote-a".to_string())
+        );
+        assert_eq!(cache.find_validator_key("id-b"), Some("vote-b".to_string()));
+        assert_eq!(cache.find_validator_key("nope"), None);
+    }
+
+    #[test]
+    fn find_validator_key_on_an_empty_cache_is_none() {
+        assert_eq!(Cache::new().find_validator_key("vote-a"), None);
+    }
 }

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -204,18 +204,21 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
     )
     .await?;
 
+    let validators_aggregated = store::utils::aggregate_validators(&validators);
+    let validators_len = validators.len();
+
     {
         let mut ctx = context.write().await;
         if let Some(refreshed) = refreshed {
             ctx.cache.per_epoch = Some(refreshed);
         }
-        ctx.cache.validators.clone_from(&validators);
-        ctx.cache.validators_aggregated = store::utils::aggregate_validators(&validators);
+        ctx.cache.validators = validators;
+        ctx.cache.validators_aggregated = validators_aggregated;
     }
 
     info!(
         "Loaded {} validators to cache in {} ms",
-        validators.len(),
+        validators_len,
         warmup_timer.elapsed().as_millis()
     );
 
@@ -228,15 +231,11 @@ pub async fn warm_commissions_cache(context: &WrappedContext) -> anyhow::Result<
         store::utils::load_commissions(&context.read().await.psql_client, DEFAULT_CACHE_EPOCHS)
             .await?;
 
-    context
-        .write()
-        .await
-        .cache
-        .commissions
-        .clone_from(&commissions);
+    let commissions_len = commissions.len();
+    context.write().await.cache.commissions = commissions;
     info!(
         "Loaded {} commissions to cache in {} ms",
-        commissions.len(),
+        commissions_len,
         warmup_timer.elapsed().as_millis()
     );
 
@@ -249,10 +248,11 @@ pub async fn warm_versions_cache(context: &WrappedContext) -> anyhow::Result<()>
         store::utils::load_versions(&context.read().await.psql_client, DEFAULT_CACHE_EPOCHS)
             .await?;
 
-    context.write().await.cache.versions.clone_from(&versions);
+    let versions_len = versions.len();
+    context.write().await.cache.versions = versions;
     info!(
         "Loaded {} versions to cache in {} ms",
-        versions.len(),
+        versions_len,
         warmup_timer.elapsed().as_millis()
     );
 
@@ -264,10 +264,11 @@ pub async fn warm_uptimes_cache(context: &WrappedContext) -> anyhow::Result<()> 
     let uptimes =
         store::utils::load_uptimes(&context.read().await.psql_client, DEFAULT_CACHE_EPOCHS).await?;
 
-    context.write().await.cache.uptimes.clone_from(&uptimes);
+    let uptimes_len = uptimes.len();
+    context.write().await.cache.uptimes = uptimes;
     info!(
         "Loaded {} uptimes to cache in {} ms",
-        uptimes.len(),
+        uptimes_len,
         warmup_timer.elapsed().as_millis()
     );
 
@@ -307,39 +308,26 @@ pub async fn warm_scores_cache(context: &WrappedContext) -> anyhow::Result<()> {
     let multi_run_scores =
         store::scoring::load_all_scores(&context.read().await.psql_client).await?;
 
-    let last_scoring_run =
-        store::utils::load_last_scoring_run(&context.read().await.psql_client).await?;
-
     let multi_run_scoring_runs =
         store::scoring::load_scoring_runs(&context.read().await.psql_client).await?;
 
     let scores_len = scores.len();
     let multi_run_scores_len: usize = multi_run_scores.values().map(|v| v.len()).sum();
 
-    context
-        .write()
-        .await
-        .cache
-        .validators_single_run_scores
-        .clone_from(&CachedSingleRunScores {
-            scoring_run: last_scoring_run,
-            scores,
-        });
+    context.write().await.cache.validators_single_run_scores = CachedSingleRunScores {
+        scoring_run: last_scoring_run,
+        scores,
+    };
     info!(
         "Loaded {} single run scores to cache in {} ms",
         scores_len,
         warmup_timer.elapsed().as_millis()
     );
 
-    context
-        .write()
-        .await
-        .cache
-        .validators_multi_run_scores
-        .clone_from(&CachedMultiRunScores {
-            scoring_runs: Some(multi_run_scoring_runs),
-            scores: multi_run_scores,
-        });
+    context.write().await.cache.validators_multi_run_scores = CachedMultiRunScores {
+        scoring_runs: Some(multi_run_scoring_runs),
+        scores: multi_run_scores,
+    };
     info!(
         "Loaded {} multiple run scores to cache in {} ms",
         multi_run_scores_len,

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -1,7 +1,9 @@
 use crate::context::WrappedContext;
 use log::{error, info};
 use rust_decimal::Decimal;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::time::{SystemTime, UNIX_EPOCH};
 use store::dto::{
     ClusterStats, CommissionRecord, ScoringRunRecord, UptimeRecord, ValidatorRecord,
@@ -367,11 +369,30 @@ pub fn spawn_cache_warmer(context: WrappedContext) {
             }
 
             let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-            let run_every = Duration::from_secs(CACHE_WARMUP_TIME_S);
-            let sleep_seconds = now.as_secs() % run_every.as_secs();
-            sleep(Duration::from_secs(run_every.as_secs() - sleep_seconds)).await;
+            let sleep_seconds = warmup_sleep_seconds(
+                now.as_secs(),
+                warmup_phase_seconds(CACHE_WARMUP_TIME_S),
+                CACHE_WARMUP_TIME_S,
+            );
+            sleep(Duration::from_secs(sleep_seconds)).await;
         }
     });
+}
+
+// replicas warming on the same wall-clock boundary hit the shared connection as a 2x spike
+fn warmup_phase_seconds(period_seconds: u64) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    std::env::var("HOSTNAME")
+        .unwrap_or_default()
+        .hash(&mut hasher);
+    hasher.finish() % period_seconds
+}
+
+fn warmup_sleep_seconds(now_seconds: u64, phase_seconds: u64, period_seconds: u64) -> u64 {
+    match (period_seconds + phase_seconds - now_seconds % period_seconds) % period_seconds {
+        0 => period_seconds,
+        wait => wait,
+    }
 }
 
 #[cfg(test)]
@@ -408,5 +429,30 @@ mod tests {
     #[test]
     fn find_validator_key_on_an_empty_cache_is_none() {
         assert_eq!(Cache::new().find_validator_key("vote-a"), None);
+    }
+
+    #[test]
+    fn warmup_without_a_phase_keeps_the_previous_boundary_alignment() {
+        assert_eq!(warmup_sleep_seconds(0, 0, 600), 600);
+        assert_eq!(warmup_sleep_seconds(1, 0, 600), 599);
+        assert_eq!(warmup_sleep_seconds(599, 0, 600), 1);
+        assert_eq!(warmup_sleep_seconds(600, 0, 600), 600);
+    }
+
+    #[test]
+    fn warmup_wakes_on_its_own_phase_within_one_period() {
+        for phase in [0, 1, 137, 599] {
+            for now in [0, 1, 137, 599, 600, 12_345] {
+                let sleep = warmup_sleep_seconds(now, phase, 600);
+                assert!((1..=600).contains(&sleep), "phase {phase} now {now}");
+                assert_eq!((now + sleep) % 600, phase, "phase {phase} now {now}");
+            }
+        }
+    }
+
+    #[test]
+    fn warmup_phase_is_stable_and_within_the_period() {
+        assert_eq!(warmup_phase_seconds(600), warmup_phase_seconds(600));
+        assert!(warmup_phase_seconds(600) < 600);
     }
 }

--- a/api/src/handlers/commissions.rs
+++ b/api/src/handlers/commissions.rs
@@ -41,14 +41,11 @@ pub async fn handler(
     info!("Fetching commissions {:?}", &vote_account);
     metrics::REQUEST_COUNT_COMMISSIONS.inc();
 
-    let validators = context.read().await.cache.get_validators();
-    let validator = validators.iter().find(|(_vote_key, record)| {
-        record.identity == vote_account || record.vote_account == vote_account
-    });
+    let vote_key = context.read().await.cache.find_validator_key(&vote_account);
 
-    match validator {
-        Some((vote_key, _validator)) => {
-            let commissions = context.read().await.cache.get_commissions(vote_key);
+    match vote_key {
+        Some(vote_key) => {
+            let commissions = context.read().await.cache.get_commissions(&vote_key);
 
             Ok(match commissions {
                 Some(mut commissions) => {

--- a/api/src/handlers/events.rs
+++ b/api/src/handlers/events.rs
@@ -75,13 +75,8 @@ pub async fn handler(
 ) -> Result<impl Reply, warp::Rejection> {
     info!("Fetching events {:?}", &vote_account);
 
-    let validators = context.read().await.cache.get_validators();
-    let validator = validators.iter().find(|(_vote_key, record)| {
-        record.identity == vote_account || record.vote_account == vote_account
-    });
-
-    let vote_key = match validator {
-        Some((vote_key, _validator)) => vote_key.clone(),
+    let vote_key = match context.read().await.cache.find_validator_key(&vote_account) {
+        Some(vote_key) => vote_key,
         None => {
             error!("No validator found for {}", &vote_account);
             return Ok(response_error(

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -394,6 +394,134 @@ mod tests {
         );
     }
 
+    // Context owns a live Client, so get_validators cannot be exercised without a database
+    // even though it never queries one
+    async fn context_with(records: Vec<ValidatorRecord>) -> Option<WrappedContext> {
+        let url = std::env::var("DS_TEST_POSTGRES_URL").ok()?;
+        let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+            .await
+            .unwrap();
+        tokio::spawn(async move {
+            let _ = connection.await;
+        });
+
+        let mut context = crate::context::Context::new(
+            client,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        )
+        .unwrap();
+        context.cache.validators = cache_of(records);
+        Some(std::sync::Arc::new(tokio::sync::RwLock::new(context)))
+    }
+
+    fn stake_record(vote_account: &str, epochs: &[u64], stake: u64) -> ValidatorRecord {
+        let mut record = record(vote_account, &format!("id-{vote_account}"), epochs);
+        record.activated_stake = Decimal::from(stake);
+        record
+    }
+
+    #[tokio::test]
+    async fn get_validators_orders_by_stake_and_pages_without_touching_the_rest() {
+        let records = vec![
+            stake_record("small", &[LAST_EPOCH - 1, LAST_EPOCH], 10),
+            stake_record("large", &[LAST_EPOCH - 1, LAST_EPOCH], 30),
+            stake_record("medium", &[LAST_EPOCH - 1, LAST_EPOCH], 20),
+        ];
+        let Some(context) = context_with(records).await else {
+            eprintln!("skipping: DS_TEST_POSTGRES_URL is not set");
+            return;
+        };
+
+        let all = get_validators(context.clone(), config()).await.unwrap();
+        assert_eq!(
+            all.iter()
+                .map(|v| v.vote_account.as_str())
+                .collect::<Vec<_>>(),
+            vec!["large", "medium", "small"],
+            "default order is stake descending"
+        );
+
+        let page = get_validators(
+            context.clone(),
+            GetValidatorsConfig {
+                offset: 1,
+                limit: 1,
+                ..config()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            page.iter()
+                .map(|v| v.vote_account.as_str())
+                .collect::<Vec<_>>(),
+            vec!["medium"],
+            "offset and limit apply to the sorted order"
+        );
+
+        let ascending = get_validators(
+            context,
+            GetValidatorsConfig {
+                order_direction: OrderDirection::ASC,
+                ..config()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            ascending
+                .iter()
+                .map(|v| v.vote_account.as_str())
+                .collect::<Vec<_>>(),
+            vec!["small", "medium", "large"]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_validators_trims_epoch_stats_to_the_requested_window() {
+        let epochs: Vec<u64> = (LAST_EPOCH - 4..=LAST_EPOCH).collect();
+        let Some(context) = context_with(vec![stake_record("only", &epochs, 10)]).await else {
+            eprintln!("skipping: DS_TEST_POSTGRES_URL is not set");
+            return;
+        };
+
+        let two = get_validators(
+            context.clone(),
+            GetValidatorsConfig {
+                epochs: 2,
+                ..config()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            two[0]
+                .epoch_stats
+                .iter()
+                .map(|es| es.epoch)
+                .collect::<Vec<_>>(),
+            vec![LAST_EPOCH - 1, LAST_EPOCH],
+            "epochs=2 keeps only the newest two, in their stored order"
+        );
+
+        let none = get_validators(
+            context,
+            GetValidatorsConfig {
+                epochs: 0,
+                ..config()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(none.len(), 1, "the validator is still returned");
+        assert!(
+            none[0].epoch_stats.is_empty(),
+            "epochs=0 is what marinade-web sends: the record stays, every epoch stat goes"
+        );
+    }
+
     #[test]
     fn filters_by_presence_of_a_name() {
         let mut named = record("named", "id-named", &[LAST_EPOCH - 1, LAST_EPOCH]);

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -91,18 +91,16 @@ pub async fn get_validators(
     context: WrappedContext,
     config: GetValidatorsConfig,
 ) -> anyhow::Result<Vec<ValidatorRecord>> {
-    let validators = context.read().await.cache.get_validators();
+    let ctx = context.read().await;
 
-    let mut validators = filter_validators(validators, &config);
+    let mut validators = filter_validators(&ctx.cache.validators, &config);
 
     let field_extractor = get_field_extractor(config.order_field);
 
-    validators.sort_by(
-        |a: &ValidatorRecord, b: &ValidatorRecord| match config.order_direction {
-            OrderDirection::ASC => field_extractor(a).cmp(&field_extractor(b)),
-            OrderDirection::DESC => field_extractor(b).cmp(&field_extractor(a)),
-        },
-    );
+    validators.sort_by(|a, b| match config.order_direction {
+        OrderDirection::ASC => field_extractor(a).cmp(&field_extractor(b)),
+        OrderDirection::DESC => field_extractor(b).cmp(&field_extractor(a)),
+    });
     let max_epoch = validators
         .iter()
         .flat_map(|validator| &validator.epoch_stats)
@@ -115,19 +113,13 @@ pub async fn get_validators(
         .into_iter()
         .skip(config.offset)
         .take(config.limit)
-        .map(|mut v| {
-            v.epoch_stats = match config.query_from_date {
+        .map(|v| {
+            let mut v = v.clone();
+            match config.query_from_date {
                 Some(from_date) => v
                     .epoch_stats
-                    .into_iter()
-                    .filter(|es| es.epoch_start_at.is_some())
-                    .filter(|es| es.epoch_start_at.unwrap() > from_date)
-                    .collect(),
-                None => v
-                    .epoch_stats
-                    .into_iter()
-                    .filter(|es| es.epoch >= min_epoch)
-                    .collect(),
+                    .retain(|es| es.epoch_start_at.is_some_and(|start| start > from_date)),
+                None => v.epoch_stats.retain(|es| es.epoch >= min_epoch),
             };
 
             v
@@ -154,10 +146,10 @@ fn get_field_extractor(order_field: OrderField) -> Box<dyn Fn(&ValidatorRecord) 
     }
 }
 
-pub fn filter_validators(
-    mut validators: HashMap<String, ValidatorRecord>,
+pub fn filter_validators<'a>(
+    validators: &'a HashMap<String, ValidatorRecord>,
     config: &GetValidatorsConfig,
-) -> Vec<ValidatorRecord> {
+) -> Vec<&'a ValidatorRecord> {
     let last_epoch = validators
         .values()
         .flat_map(|validator| &validator.epoch_stats)
@@ -169,7 +161,9 @@ pub fn filter_validators(
     let last_epochs_with_credits_or_stake_start =
         last_epoch.saturating_sub(MIN_REQUIRED_EPOCHS_WITH_CREDITS_OR_STAKE);
 
-    validators.retain(|_, validator| {
+    let mut validators: Vec<&ValidatorRecord> = validators.values().collect();
+
+    validators.retain(|validator| {
         // Check that validator has stats for the last 2 epochs including last
         if !(min_required_epoch..=last_epoch).all(|epoch| {
             validator
@@ -192,21 +186,21 @@ pub fn filter_validators(
     });
 
     if config.query_sfdp.is_some() {
-        validators.retain(|_, validator| validator.foundation_stake.gt(&Decimal::ZERO))
+        validators.retain(|validator| validator.foundation_stake.gt(&Decimal::ZERO))
     }
 
     if let Some(vote_accounts) = &config.query_vote_accounts {
-        validators.retain(|key, _| vote_accounts.contains(key));
+        validators.retain(|v| vote_accounts.contains(&v.vote_account));
     }
 
     if let Some(identities) = &config.query_identities {
-        validators.retain(|_, v| identities.contains(&v.identity));
+        validators.retain(|v| identities.contains(&v.identity));
     }
 
     if let Some(query) = &config.query {
         let query = query.to_lowercase();
         let search_properties = config.search_properties.unwrap_or(false);
-        validators.retain(|_, v| {
+        validators.retain(|v| {
             let matches = |field: &Option<String>| {
                 field
                     .as_ref()
@@ -221,26 +215,206 @@ pub fn filter_validators(
     }
 
     if let Some(query_superminority) = config.query_superminority {
-        validators.retain(|_, v| v.superminority == query_superminority);
+        validators.retain(|v| v.superminority == query_superminority);
     }
 
     if let Some(query_marinade_stake) = config.query_marinade_stake {
-        validators.retain(|_, v| (v.marinade_stake > Decimal::from(0)) == query_marinade_stake);
+        validators.retain(|v| (v.marinade_stake > Decimal::from(0)) == query_marinade_stake);
     }
 
     if let Some(query_with_names) = config.query_with_names {
-        validators.retain(|_, v| query_with_names == v.info_name.is_some());
+        validators.retain(|v| query_with_names == v.info_name.is_some());
     }
 
     if let Some(query_score) = config.query_score {
-        validators.retain(|_, v| (v.score.unwrap_or(0.0) > 0.0) == query_score);
+        validators.retain(|v| (v.score.unwrap_or(0.0) > 0.0) == query_score);
     }
 
     if let Some(query_incident_free) = config.query_incident_free {
-        validators.retain(|_, v| v.incidents.is_empty() == query_incident_free);
+        validators.retain(|v| v.incidents.is_empty() == query_incident_free);
     }
 
-    validators.into_values().collect()
+    validators
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use store::dto::ValidatorEpochStats;
+
+    const LAST_EPOCH: u64 = 100;
+
+    fn config() -> GetValidatorsConfig {
+        GetValidatorsConfig {
+            order_direction: DEFAULT_ORDER_DIRECTION,
+            order_field: DEFAULT_ORDER_FIELD,
+            offset: 0,
+            limit: DEFAULT_LIMIT,
+            query: None,
+            query_identities: None,
+            query_vote_accounts: None,
+            query_superminority: None,
+            query_score: None,
+            query_marinade_stake: None,
+            query_with_names: None,
+            query_sfdp: None,
+            query_incident_free: None,
+            search_properties: None,
+            query_from_date: None,
+            epochs: DEFAULT_EPOCHS,
+        }
+    }
+
+    fn record(vote_account: &str, identity: &str, epochs: &[u64]) -> ValidatorRecord {
+        ValidatorRecord {
+            vote_account: vote_account.into(),
+            identity: identity.into(),
+            epoch_stats: epochs
+                .iter()
+                .map(|&epoch| ValidatorEpochStats {
+                    epoch,
+                    credits: 1,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    // production keys this map by vote_account (store::utils::load_validators), and the
+    // query_vote_accounts filter relies on that equivalence
+    fn cache_of(records: Vec<ValidatorRecord>) -> HashMap<String, ValidatorRecord> {
+        records
+            .into_iter()
+            .map(|record| (record.vote_account.clone(), record))
+            .collect()
+    }
+
+    fn kept(
+        validators: &HashMap<String, ValidatorRecord>,
+        config: &GetValidatorsConfig,
+    ) -> Vec<String> {
+        let mut kept: Vec<String> = filter_validators(validators, config)
+            .into_iter()
+            .map(|v| v.vote_account.clone())
+            .collect();
+        kept.sort();
+        kept
+    }
+
+    #[test]
+    fn drops_validators_missing_either_of_the_last_two_epochs() {
+        let validators = cache_of(vec![
+            record("full", "id-full", &[LAST_EPOCH - 1, LAST_EPOCH]),
+            record("gap", "id-gap", &[LAST_EPOCH]),
+            record("stale", "id-stale", &[LAST_EPOCH - 2, LAST_EPOCH - 1]),
+        ]);
+
+        assert_eq!(kept(&validators, &config()), vec!["full"]);
+    }
+
+    #[test]
+    fn drops_validators_without_credits_or_stake_in_the_last_two_epochs() {
+        let mut idle = record("idle", "id-idle", &[LAST_EPOCH - 1, LAST_EPOCH]);
+        for stats in idle.epoch_stats.iter_mut() {
+            stats.credits = 0;
+        }
+        let mut staked = record("staked", "id-staked", &[LAST_EPOCH - 1, LAST_EPOCH]);
+        for stats in staked.epoch_stats.iter_mut() {
+            stats.credits = 0;
+            stats.activated_stake = Decimal::from(1);
+        }
+
+        let validators = cache_of(vec![
+            idle,
+            staked,
+            record("active", "id-active", &[LAST_EPOCH - 1, LAST_EPOCH]),
+        ]);
+
+        assert_eq!(kept(&validators, &config()), vec!["active", "staked"]);
+    }
+
+    #[test]
+    fn filters_by_vote_account() {
+        let validators = cache_of(vec![
+            record("wanted", "id-wanted", &[LAST_EPOCH - 1, LAST_EPOCH]),
+            record("other", "id-other", &[LAST_EPOCH - 1, LAST_EPOCH]),
+        ]);
+
+        let config = GetValidatorsConfig {
+            query_vote_accounts: Some(vec!["wanted".to_string()]),
+            ..config()
+        };
+
+        assert_eq!(kept(&validators, &config), vec!["wanted"]);
+    }
+
+    #[test]
+    fn filters_by_identity() {
+        let validators = cache_of(vec![
+            record("wanted", "id-wanted", &[LAST_EPOCH - 1, LAST_EPOCH]),
+            record("other", "id-other", &[LAST_EPOCH - 1, LAST_EPOCH]),
+        ]);
+
+        let config = GetValidatorsConfig {
+            query_identities: Some(vec!["id-wanted".to_string()]),
+            ..config()
+        };
+
+        assert_eq!(kept(&validators, &config), vec!["wanted"]);
+    }
+
+    #[test]
+    fn text_query_matches_name_vote_account_and_identity_but_not_location_by_default() {
+        let mut named = record("aaa", "id-aaa", &[LAST_EPOCH - 1, LAST_EPOCH]);
+        named.info_name = Some("Alice Node".to_string());
+        let mut located = record("bbb", "id-bbb", &[LAST_EPOCH - 1, LAST_EPOCH]);
+        located.dc_city = Some("Alice Springs".to_string());
+
+        let validators = cache_of(vec![
+            named,
+            located,
+            record("alice-vote", "id-ccc", &[LAST_EPOCH - 1, LAST_EPOCH]),
+            record("ddd", "identity-alice", &[LAST_EPOCH - 1, LAST_EPOCH]),
+        ]);
+
+        let config = GetValidatorsConfig {
+            query: Some("ALICE".to_string()),
+            ..config()
+        };
+        assert_eq!(kept(&validators, &config), vec!["aaa", "alice-vote", "ddd"]);
+
+        let config = GetValidatorsConfig {
+            search_properties: Some(true),
+            ..config
+        };
+        assert_eq!(
+            kept(&validators, &config),
+            vec!["aaa", "alice-vote", "bbb", "ddd"]
+        );
+    }
+
+    #[test]
+    fn filters_by_presence_of_a_name() {
+        let mut named = record("named", "id-named", &[LAST_EPOCH - 1, LAST_EPOCH]);
+        named.info_name = Some("Alice".to_string());
+        let validators = cache_of(vec![
+            named,
+            record("nameless", "id-nameless", &[LAST_EPOCH - 1, LAST_EPOCH]),
+        ]);
+
+        let config = GetValidatorsConfig {
+            query_with_names: Some(true),
+            ..config()
+        };
+        assert_eq!(kept(&validators, &config), vec!["named"]);
+
+        let config = GetValidatorsConfig {
+            query_with_names: Some(false),
+            ..config
+        };
+        assert_eq!(kept(&validators, &config), vec!["nameless"]);
+    }
 }
 
 #[utoipa::path(

--- a/api/src/handlers/uptimes.rs
+++ b/api/src/handlers/uptimes.rs
@@ -41,14 +41,11 @@ pub async fn handler(
     info!("Fetching uptimes {:?}", &vote_account);
     metrics::REQUEST_COUNT_UPTIMES.inc();
 
-    let validators = context.read().await.cache.get_validators();
-    let validator = validators.iter().find(|(_vote_key, record)| {
-        record.identity == vote_account || record.vote_account == vote_account
-    });
+    let vote_key = context.read().await.cache.find_validator_key(&vote_account);
 
-    match validator {
-        Some((vote_key, _validator)) => {
-            let uptimes = context.read().await.cache.get_uptimes(vote_key);
+    match vote_key {
+        Some(vote_key) => {
+            let uptimes = context.read().await.cache.get_uptimes(&vote_key);
 
             Ok(match uptimes {
                 Some(mut uptimes) => {

--- a/api/src/handlers/versions.rs
+++ b/api/src/handlers/versions.rs
@@ -34,14 +34,11 @@ pub async fn handler(
     info!("Fetching versions {:?}", &vote_account);
     metrics::REQUEST_COUNT_VERSIONS.inc();
 
-    let validators = context.read().await.cache.get_validators();
-    let validator = validators.iter().find(|(_vote_key, record)| {
-        record.identity == vote_account || record.vote_account == vote_account
-    });
+    let vote_key = context.read().await.cache.find_validator_key(&vote_account);
 
-    match validator {
-        Some((vote_key, _validator)) => {
-            let versions = context.read().await.cache.get_versions(vote_key);
+    match vote_key {
+        Some(vote_key) => {
+            let versions = context.read().await.cache.get_versions(&vote_key);
 
             Ok(match versions {
                 Some(versions) => {

--- a/migrations/0019-vote-account-indexes.sql
+++ b/migrations/0019-vote-account-indexes.sql
@@ -1,0 +1,10 @@
+CREATE INDEX IF NOT EXISTS idx_versions_vote_account_created_at ON versions (vote_account, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_commissions_vote_account_created_at ON commissions (vote_account, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_uptimes_vote_account_end_at ON uptimes (vote_account, end_at DESC);
+CREATE INDEX IF NOT EXISTS idx_versions_epoch ON versions (epoch);
+CREATE INDEX IF NOT EXISTS idx_commissions_epoch ON commissions (epoch);
+CREATE INDEX IF NOT EXISTS idx_uptimes_epoch ON uptimes (epoch);
+CREATE INDEX IF NOT EXISTS idx_mev_vote_account_epoch_created_at ON mev (vote_account, epoch, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_jito_priority_fee_vote_account_epoch_created_at ON jito_priority_fee (vote_account, epoch, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cluster_info_epoch ON cluster_info (epoch);
+CREATE INDEX IF NOT EXISTS idx_scores_scoring_run_id ON scores (scoring_run_id);

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -192,7 +192,7 @@ impl Validator {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema)]
+#[derive(Deserialize, Serialize, Debug, Clone, Default, utoipa::ToSchema)]
 pub struct ValidatorEpochStats {
     pub epoch: u64,
     pub epoch_start_at: Option<DateTime<Utc>>,
@@ -239,7 +239,7 @@ pub struct ValidatorEpochStats {
     pub rank_apy: Option<usize>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema)]
+#[derive(Deserialize, Serialize, Debug, Clone, Default, utoipa::ToSchema)]
 pub struct ValidatorRecord {
     pub identity: String,
     pub vote_account: String,

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1509,8 +1509,7 @@ async fn load_stake_distribution(
 
     let mut distributions: Vec<StakeDistribution> = Default::default();
 
-    // Callers pair these per-epoch series with load_dc_concentration_stats, so an epoch with no
-    // validator rows must still yield an entry instead of being dropped by the SQL grouping.
+    // Callers pair this with load_dc_concentration_stats, so a row-less epoch still needs an entry
     for epoch in (first_epoch..=last_epoch).rev() {
         let mut stake_by: HashMap<String, u64> = Default::default();
         let mut count_by: HashMap<String, u64> = Default::default();
@@ -1668,8 +1667,7 @@ pub async fn load_validators_aggregated_flat(
     epochs: u64,
 ) -> anyhow::Result<Vec<ValidatorAggregatedFlat>> {
     let epochs = epochs.max(1);
-    // last_version is deliberately left unbounded while the client columns are bounded to $2:
-    // adding the bound changes what historical scoring runs see, so it needs a ds-sam side check.
+    // last_version stays unbounded: bounding it to $2 moves the scripts/scoring.R min-version gate
     let rows = psql_client
             .query(
                 "with

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -548,21 +548,25 @@ pub fn update_validators_ranks<T>(
 ) where
     T: Ord,
 {
-    let mut stats_by_epoch: HashMap<u64, Vec<(String, T)>> = Default::default();
+    let mut stats_by_epoch: HashMap<u64, Vec<(String, usize, T)>> = Default::default();
     for (vote_account, record) in validators.iter() {
-        for validator_epoch_stats in record.epoch_stats.iter() {
+        for (stats_index, validator_epoch_stats) in record.epoch_stats.iter().enumerate() {
             stats_by_epoch
                 .entry(validator_epoch_stats.epoch)
                 .or_default()
-                .push((vote_account.clone(), field_extractor(validator_epoch_stats)));
+                .push((
+                    vote_account.clone(),
+                    stats_index,
+                    field_extractor(validator_epoch_stats),
+                ));
         }
     }
 
-    for (epoch, stats) in stats_by_epoch.iter_mut() {
-        stats.sort_by(|(_, stat_a), (_, stat_b)| stat_a.cmp(stat_b));
+    for stats in stats_by_epoch.values_mut() {
+        stats.sort_by(|(_, _, stat_a), (_, _, stat_b)| stat_a.cmp(stat_b));
         let mut previous_value: Option<&T> = None;
         let mut same_ranks: usize = 0;
-        for (index, (vote_account, stat)) in stats.iter().enumerate() {
+        for (index, (vote_account, stats_index, stat)) in stats.iter().enumerate() {
             if let Some(some_previous_value) = previous_value {
                 if some_previous_value == stat {
                     same_ranks += 1;
@@ -572,13 +576,8 @@ pub fn update_validators_ranks<T>(
             }
             previous_value = Some(stat);
 
-            let validator_epoch_stats = validators
-                .get_mut(vote_account)
-                .unwrap()
-                .epoch_stats
-                .iter_mut()
-                .find(|a| a.epoch == *epoch)
-                .unwrap();
+            let validator_epoch_stats =
+                &mut validators.get_mut(vote_account).unwrap().epoch_stats[*stats_index];
             rank_updater(validator_epoch_stats, stats.len() - index + same_ranks);
         }
     }
@@ -1070,7 +1069,6 @@ pub async fn load_validators(
     })
     .await?;
 
-    let last_epoch = get_last_epoch(psql_client).await?.unwrap_or(0);
     let mut first_epoch = last_epoch - display_epochs.min(last_epoch) + 1;
     let mut epochs_range = first_epoch..=last_epoch;
 

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1871,3 +1871,83 @@ pub async fn store_scoring(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(vote_account: &str, stake_by_epoch: &[(u64, u64)]) -> ValidatorRecord {
+        ValidatorRecord {
+            vote_account: vote_account.into(),
+            epoch_stats: stake_by_epoch
+                .iter()
+                .map(|&(epoch, stake)| ValidatorEpochStats {
+                    epoch,
+                    activated_stake: Decimal::from(stake),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn rank_by_stake(records: Vec<ValidatorRecord>) -> HashMap<String, ValidatorRecord> {
+        let mut validators: HashMap<String, ValidatorRecord> = records
+            .into_iter()
+            .map(|record| (record.vote_account.clone(), record))
+            .collect();
+        update_validators_ranks(
+            &mut validators,
+            |a: &ValidatorEpochStats| a.activated_stake,
+            |a: &mut ValidatorEpochStats, rank: usize| a.rank_activated_stake = Some(rank),
+        );
+        validators
+    }
+
+    fn rank_at(validators: &HashMap<String, ValidatorRecord>, vote: &str, epoch: u64) -> usize {
+        validators[vote]
+            .epoch_stats
+            .iter()
+            .find(|stats| stats.epoch == epoch)
+            .unwrap()
+            .rank_activated_stake
+            .unwrap()
+    }
+
+    #[test]
+    fn ranks_highest_stake_first_and_shares_a_rank_on_ties() {
+        let validators = rank_by_stake(vec![
+            record("low", &[(100, 10)]),
+            record("tied-a", &[(100, 20)]),
+            record("tied-b", &[(100, 20)]),
+        ]);
+
+        assert_eq!(rank_at(&validators, "tied-a", 100), 2);
+        assert_eq!(rank_at(&validators, "tied-b", 100), 2);
+        assert_eq!(rank_at(&validators, "low", 100), 3);
+    }
+
+    // epoch_stats are stored in a different order per validator, and each validator's stake
+    // rank differs per epoch, so a rank written by sorted position instead of by epoch lands
+    // on the wrong entry
+    #[test]
+    fn ranks_land_on_the_epoch_they_were_computed_for() {
+        let validators = rank_by_stake(vec![
+            record("a", &[(98, 10), (99, 30), (100, 20)]),
+            record("b", &[(100, 30), (99, 10), (98, 20)]),
+            record("c", &[(99, 20), (98, 30), (100, 10)]),
+        ]);
+
+        assert_eq!(rank_at(&validators, "a", 98), 3);
+        assert_eq!(rank_at(&validators, "b", 98), 2);
+        assert_eq!(rank_at(&validators, "c", 98), 1);
+
+        assert_eq!(rank_at(&validators, "b", 99), 3);
+        assert_eq!(rank_at(&validators, "c", 99), 2);
+        assert_eq!(rank_at(&validators, "a", 99), 1);
+
+        assert_eq!(rank_at(&validators, "c", 100), 3);
+        assert_eq!(rank_at(&validators, "a", 100), 2);
+        assert_eq!(rank_at(&validators, "b", 100), 1);
+    }
+}

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1692,9 +1692,9 @@ pub async fn load_validators_aggregated_flat(
     let rows = psql_client
             .query(
                 "with
-                cluster_stake AS (select epoch, sum(activated_stake) as stake from validators group by epoch),
-                cluster_skip_rate AS (select epoch, sum(skip_rate * activated_stake) / sum(activated_stake) stake_weighted_skip_rate from validators group by epoch),
-                dc AS (select validators.epoch, sum(activated_stake) / cluster_stake.stake as dc_concentration, dc_aso from validators LEFT JOIN cluster_stake ON validators.epoch = cluster_stake.epoch group by validators.epoch, dc_aso, cluster_stake.stake),
+                cluster_stake AS (select epoch, sum(activated_stake) as stake from validators where epoch between $1 and $2 group by epoch),
+                cluster_skip_rate AS (select epoch, sum(skip_rate * activated_stake) / sum(activated_stake) stake_weighted_skip_rate from validators where epoch between $1 and $2 group by epoch),
+                dc AS (select validators.epoch, sum(activated_stake) / cluster_stake.stake as dc_concentration, dc_aso from validators LEFT JOIN cluster_stake ON validators.epoch = cluster_stake.epoch where validators.epoch between $1 and $2 group by validators.epoch, dc_aso, cluster_stake.stake),
                 agg_versions AS (select vote_account, (array_agg(version order by created_at desc) filter (where version is not null))[1] as last_version, (array_agg(client_vendor order by created_at desc) filter (where client_vendor is not null and epoch <= $2))[1] as last_client_vendor, (array_agg(client_lineage order by created_at desc) filter (where client_lineage is not null and epoch <= $2))[1] as last_client_lineage from versions group by vote_account)
                 select
                     validators.vote_account,

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1446,22 +1446,51 @@ pub async fn load_block_production_stats(
                     COALESCE(SUM(leader_slots), 0) leader_slots,
                     COALESCE(1 - COALESCE(SUM(blocks_produced), 0) / NULLIF(SUM(leader_slots), 0), 1)::DOUBLE PRECISION avg_skip_rate
                 FROM validators
-                WHERE epoch > $1
-                GROUP BY epoch ORDER BY epoch DESC",
-                &[&Decimal::from(first_epoch)],
+                WHERE epoch BETWEEN $1 AND $2
+                GROUP BY epoch",
+                &[&Decimal::from(first_epoch), &Decimal::from(last_epoch)],
             )
             .await?;
 
-    for row in rows {
-        stats.push(BlockProductionStats {
-            epoch: row.get::<_, Decimal>("epoch").try_into()?,
-            blocks_produced: row.get::<_, Decimal>("blocks_produced").try_into()?,
-            leader_slots: row.get::<_, Decimal>("leader_slots").try_into()?,
-            avg_skip_rate: row.get("avg_skip_rate"),
-        })
+    let mut rows_by_epoch = group_rows_by_epoch(rows)?;
+
+    // paired positionally with the other cluster-stats series, so a row-less epoch still needs an entry
+    for epoch in (first_epoch..=last_epoch).rev() {
+        stats.push(
+            match rows_by_epoch
+                .remove(&epoch)
+                .and_then(|rows| rows.into_iter().next())
+            {
+                Some(row) => BlockProductionStats {
+                    epoch,
+                    blocks_produced: row.get::<_, Decimal>("blocks_produced").try_into()?,
+                    leader_slots: row.get::<_, Decimal>("leader_slots").try_into()?,
+                    avg_skip_rate: row.get("avg_skip_rate"),
+                },
+                None => BlockProductionStats {
+                    epoch,
+                    blocks_produced: 0,
+                    leader_slots: 0,
+                    avg_skip_rate: 1.0,
+                },
+            },
+        )
     }
 
     Ok(stats)
+}
+
+fn group_rows_by_epoch(
+    rows: Vec<tokio_postgres::Row>,
+) -> anyhow::Result<HashMap<u64, Vec<tokio_postgres::Row>>> {
+    let mut rows_by_epoch: HashMap<u64, Vec<tokio_postgres::Row>> = Default::default();
+    for row in rows {
+        rows_by_epoch
+            .entry(row.get::<_, Decimal>("epoch").try_into()?)
+            .or_default()
+            .push(row);
+    }
+    Ok(rows_by_epoch)
 }
 
 struct StakeDistribution {
@@ -1499,13 +1528,7 @@ async fn load_stake_distribution(
         )
         .await?;
 
-    let mut rows_by_epoch: HashMap<u64, Vec<tokio_postgres::Row>> = Default::default();
-    for row in rows {
-        rows_by_epoch
-            .entry(row.get::<_, Decimal>("epoch").try_into()?)
-            .or_default()
-            .push(row);
-    }
+    let mut rows_by_epoch = group_rows_by_epoch(rows)?;
 
     let mut distributions: Vec<StakeDistribution> = Default::default();
 

--- a/store/tests/cluster_stats_sql.rs
+++ b/store/tests/cluster_stats_sql.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use store::utils::{
-    load_client_diversity_stats, load_dc_concentration_stats, load_validators_aggregated_flat,
+    load_block_production_stats, load_client_diversity_stats, load_dc_concentration_stats,
+    load_validators_aggregated_flat,
 };
 use tokio_postgres::{Client, NoTls};
 
@@ -187,6 +188,35 @@ async fn stake_distribution_emits_every_requested_epoch_including_gaps() {
         epochs,
         "cluster-stats series must cover the same epoch window"
     );
+
+    let block_production = load_block_production_stats(&client, EPOCHS).await.unwrap();
+    assert_eq!(
+        block_production
+            .iter()
+            .map(|stats| stats.epoch)
+            .collect::<Vec<u64>>(),
+        epochs,
+        "cluster-stats series must cover the same epoch window"
+    );
+
+    let gap_production = block_production
+        .iter()
+        .find(|stats| stats.epoch == GAP_EPOCH)
+        .unwrap();
+    assert_eq!(gap_production.blocks_produced, 0);
+    assert_eq!(gap_production.leader_slots, 0);
+    assert_eq!(gap_production.avg_skip_rate, 1.0);
+
+    let oldest_production = block_production
+        .iter()
+        .find(|stats| stats.epoch == first_epoch)
+        .unwrap();
+    assert_eq!(
+        oldest_production.leader_slots, 300,
+        "the oldest requested epoch must be inside the window, not excluded by an exclusive bound"
+    );
+    assert_eq!(oldest_production.blocks_produced, 300);
+    assert_eq!(oldest_production.avg_skip_rate, 0.0);
 
     client
         .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))

--- a/store/tests/cluster_stats_sql.rs
+++ b/store/tests/cluster_stats_sql.rs
@@ -57,13 +57,40 @@ async fn insert_validator(
     client_vendor: Option<&str>,
     client_lineage: Option<&str>,
 ) {
+    insert_validator_in_dc(
+        client,
+        vote_account,
+        epoch,
+        activated_stake,
+        credits,
+        client_vendor,
+        client_lineage,
+        None,
+        0.0,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn insert_validator_in_dc(
+    client: &Client,
+    vote_account: &str,
+    epoch: u64,
+    activated_stake: u64,
+    credits: u64,
+    client_vendor: Option<&str>,
+    client_lineage: Option<&str>,
+    dc_aso: Option<&str>,
+    skip_rate: f64,
+) {
     client
         .execute(
             "INSERT INTO validators (
                 identity, vote_account, epoch, activated_stake, marinade_stake,
                 marinade_native_stake, superminority, stake_to_become_superminority, credits,
-                leader_slots, blocks_produced, skip_rate, client_vendor, client_lineage, updated_at
-            ) VALUES ($1, $2, $3, $4, 0, 0, false, 0, $5, 100, 100, 0, $6, $7, NOW())",
+                leader_slots, blocks_produced, skip_rate, client_vendor, client_lineage,
+                dc_aso, updated_at
+            ) VALUES ($1, $2, $3, $4, 0, 0, false, 0, $5, 100, 100, $8, $6, $7, $9, NOW())",
             &[
                 &format!("identity-{vote_account}"),
                 &vote_account,
@@ -72,6 +99,8 @@ async fn insert_validator(
                 &Decimal::from(credits),
                 &client_vendor,
                 &client_lineage,
+                &skip_rate,
+                &dc_aso,
             ],
         )
         .await
@@ -290,6 +319,105 @@ async fn validators_flat_client_columns_keep_open_lower_bound_and_bounded_upper_
     assert_eq!(
         validator.version, "2.2.0",
         "last_version is deliberately unbounded and still reports data from above last_epoch"
+    );
+
+    client
+        .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .unwrap();
+}
+
+// the cluster_stake / cluster_skip_rate / dc CTEs are bounded to the epoch window; an epoch
+// outside it must not reach any of the three aggregates
+#[tokio::test]
+async fn validators_flat_ignores_rows_outside_the_epoch_window() {
+    let schema = "ds_test_validators_flat_window";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    let first_epoch = LAST_EPOCH - EPOCHS + 1;
+    for epoch in first_epoch..=LAST_EPOCH {
+        insert_validator_in_dc(
+            &client,
+            "voteA",
+            epoch,
+            100,
+            10,
+            None,
+            None,
+            Some("aso1"),
+            0.5,
+        )
+        .await;
+        insert_validator_in_dc(
+            &client,
+            "voteB",
+            epoch,
+            300,
+            10,
+            None,
+            None,
+            Some("aso2"),
+            0.1,
+        )
+        .await;
+    }
+
+    let outside = first_epoch - 1;
+    insert_validator_in_dc(
+        &client,
+        "voteA",
+        outside,
+        10_000,
+        10,
+        None,
+        None,
+        Some("aso1"),
+        0.9,
+    )
+    .await;
+    insert_validator_in_dc(
+        &client,
+        "voteB",
+        outside,
+        10_000,
+        10,
+        None,
+        None,
+        Some("aso2"),
+        0.9,
+    )
+    .await;
+
+    let validators = load_validators_aggregated_flat(&client, LAST_EPOCH, EPOCHS)
+        .await
+        .unwrap();
+    assert_eq!(
+        validators.len(),
+        2,
+        "the out-of-window epoch must not add to the HAVING COUNT(*)"
+    );
+
+    let a = validators
+        .iter()
+        .find(|v| v.vote_account == "voteA")
+        .unwrap();
+
+    // 100 of 400 in-window stake per epoch; the epoch-990 row would move this to 10100/20400
+    assert!(
+        (a.avg_dc_concentration - 0.25).abs() < 1e-9,
+        "avg_dc_concentration was {}",
+        a.avg_dc_concentration
+    );
+
+    // leader_slots is 100 (< 200), so grace uses least(own skip rate, cluster weighted) =
+    // least(0.5, (0.5*100 + 0.1*300) / 400) = 0.2
+    assert!(
+        (a.avg_grace_skip_rate - 0.2).abs() < 1e-9,
+        "avg_grace_skip_rate was {}",
+        a.avg_grace_skip_rate
     );
 
     client

--- a/store/tests/cluster_stats_sql.rs
+++ b/store/tests/cluster_stats_sql.rs
@@ -283,7 +283,7 @@ async fn validators_flat_survives_zero_epochs() {
         .unwrap();
     assert!(
         validators.is_empty(),
-        "epochs=0 can never satisfy the HAVING clause"
+        "epochs=0 collapses to a 1-epoch window, short of the 7 positive-credit epochs HAVING requires"
     );
 
     client


### PR DESCRIPTION
While working on adding delegation client IDs and related enhancements, several more pain points were observed. This PR tries to improve the behaviour further.

Related:

* https://github.com/marinade-finance/delegation-strategy-2/pull/217
* https://github.com/marinade-finance/delegation-strategy-2/pull/232


- `/validators` and the four per-validator endpoints no longer deep-clone the entire validator cache on every request.
- Each API replica gets its own cache warm-up phase instead of all replicas warming on the same wall-clock boundary.
- Adds `migrations/0019-vote-account-indexes.sql` so the per-minute collector queries stop doing a full scan plus full sort of the whole table.
- Removes two duplicate queries per warm cycle.
- Stops the cache warmers deep-copying freshly loaded data when they could move it, including one copy made while holding the context write lock.
- Rank assignment no longer re-scans each validator's epoch list to find the entry it just ranked.
- Bounds the `cluster_stake` / `cluster_skip_rate` / `dc` CTEs to the requested epoch window so `/validators/flat` stops aggregating all of history to serve ten epochs (raised in review on #232).
- `/cluster-stats` block production now covers the same epoch window as the other four series — **this changes the response shape**, adding the oldest requested epoch and zero-filling epochs with no validator rows.
- Adds test coverage for the paths this branch touches that had none: validator filtering and paging, cache key lookup, warm-up scheduling, rank assignment, and the epoch-window bounds.
- Corrects the `DEVELOPMENT.md` claim that the SQL tests need an empty database, since they drop and recreate their own schema every run (raised in review on #232).

## Deploying

`0019` should be pre-built with `CREATE INDEX CONCURRENTLY` before the migration is applied, because `versions` (4M rows) and `uptimes` (3.2M rows) have writers every minute; the migration uses `IF NOT EXISTS` so it becomes a no-op afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved validator lookup speed across commissions, events, uptimes, and versions.
  * Added database indexes to accelerate validator and time-based queries.
  * Improved cache warming reliability and scheduling across hosts.

* **Bug Fixes**
  * Corrected validator ranking across epochs and tied rankings.
  * Ensured missing epochs display zeroed block-production metrics.
  * Restricted aggregated statistics to the requested epoch range.

* **Documentation**
  * Clarified that SQL loader tests safely recreate their schemas and can run repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->