### PR TITLE
[GEN-8245][api] adding bonds protected field to listing validators in similar fashion as verified does

### DIFF
--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -1,13 +1,15 @@
 use crate::context::WrappedContext;
 use log::{error, info};
 use rust_decimal::Decimal;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 use store::dto::{
     ClusterStats, CommissionRecord, ScoringRunRecord, UptimeRecord, ValidatorRecord,
     ValidatorScoreRecord, VersionRecord,
 };
 use tokio::time::{sleep, Duration, Instant};
+
+use store::utils::ValidatorOverlays;
 
 pub(crate) use store::utils::DEFAULT_CACHE_EPOCHS;
 pub(crate) const DEFAULT_COMPUTING_EPOCHS: u64 = 20;
@@ -31,8 +33,22 @@ pub struct CachedMultiRunScores {
     pub scores: HashMap<Decimal, Vec<ValidatorScoreRecord>>,
 }
 
+/// One validator-bonds flag list plus how many refreshes in a row have fallen back to it.
+#[derive(Default, Clone)]
+pub struct CachedFlag {
+    pub vote_accounts: HashSet<String>,
+    pub consecutive_failures: u32,
+}
+
+#[derive(Default, Clone)]
+pub struct CachedBondFlags {
+    pub verified: CachedFlag,
+    pub protected: CachedFlag,
+}
+
 #[derive(Default)]
 pub struct Cache {
+    pub bond_flags: CachedBondFlags,
     pub validators: CachedValidators,
     pub commissions: CachedCommissions,
     pub versions: CachedVersions,
@@ -165,6 +181,38 @@ impl Cache {
     }
 }
 
+/// Bounded so a permanently broken bonds API surfaces as an outage instead of flags frozen forever.
+const MAX_FLAG_FALLBACK_CYCLES: u32 = 6;
+
+fn resolve_flag(
+    flag: &str,
+    fetched: anyhow::Result<HashSet<String>>,
+    last: CachedFlag,
+) -> anyhow::Result<CachedFlag> {
+    let err = match fetched {
+        Ok(vote_accounts) => {
+            return Ok(CachedFlag {
+                vote_accounts,
+                consecutive_failures: 0,
+            })
+        }
+        Err(err) => err,
+    };
+
+    let consecutive_failures = last.consecutive_failures + 1;
+    if last.vote_accounts.is_empty() || consecutive_failures >= MAX_FLAG_FALLBACK_CYCLES {
+        return Err(err);
+    }
+
+    error!(
+        "Failed to load {flag} validators, reusing the last known list ({consecutive_failures}/{MAX_FLAG_FALLBACK_CYCLES}): {err}"
+    );
+    Ok(CachedFlag {
+        consecutive_failures,
+        ..last
+    })
+}
+
 pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<()> {
     info!("Loading validators from DB");
     let warmup_timer = Instant::now();
@@ -178,14 +226,37 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
         .map(|c| (c.unique_delegators.clone(), c.take_rates.clone()))
         .unwrap_or_default();
 
+    let scoring_url = context.read().await.scoring_url.clone();
+    let bonds_url = context.read().await.validator_bonds_api_url.clone();
+    let last_flags = context.read().await.cache.bond_flags.clone();
+
+    let bond_flags = CachedBondFlags {
+        verified: resolve_flag(
+            "verified",
+            store::utils::load_verified_validators(&bonds_url).await,
+            last_flags.verified,
+        )?,
+        protected: resolve_flag(
+            "protected",
+            store::utils::load_protected_validators(&bonds_url).await,
+            last_flags.protected,
+        )?,
+    };
+    context.write().await.cache.bond_flags = bond_flags.clone();
+
+    let overlays = ValidatorOverlays {
+        unique_delegators,
+        take_rates,
+        verified: bond_flags.verified.vote_accounts,
+        protected: bond_flags.protected.vote_accounts,
+    };
+
     let validators = store::utils::load_validators(
         &context.read().await.psql_client,
-        context.read().await.scoring_url.clone(),
-        context.read().await.validator_bonds_api_url.clone(),
+        scoring_url,
         DEFAULT_CACHE_EPOCHS,
         DEFAULT_COMPUTING_EPOCHS,
-        &unique_delegators,
-        &take_rates,
+        &overlays,
     )
     .await?;
 

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -33,11 +33,12 @@ pub struct CachedMultiRunScores {
     pub scores: HashMap<Decimal, Vec<ValidatorScoreRecord>>,
 }
 
-/// One validator-bonds flag list plus how many refreshes in a row have fallen back to it.
+/// One validator-bonds flag list, how many refreshes in a row fell back to it, and when upstream last answered.
 #[derive(Default, Clone)]
 pub struct CachedFlag {
     pub vote_accounts: HashSet<String>,
     pub consecutive_fallbacks: u32,
+    pub last_success: Option<SystemTime>,
 }
 
 #[derive(Default, Clone)]
@@ -119,6 +120,13 @@ impl Cache {
         self.validators.clone()
     }
 
+    // The older of the two flags, since a consumer has to assume the worse freshness of the pair.
+    pub fn bond_flags_updated_at(&self) -> Option<SystemTime> {
+        let verified = self.bond_flags.verified.last_success?;
+        let protected = self.bond_flags.protected.last_success?;
+        Some(verified.min(protected))
+    }
+
     pub fn get_commissions(&self, vote_account: &String) -> Option<Vec<CommissionRecord>> {
         self.commissions.get(vote_account).cloned()
     }
@@ -189,29 +197,40 @@ fn resolve_flag(
     fetched: anyhow::Result<HashSet<String>>,
     last: CachedFlag,
 ) -> anyhow::Result<CachedFlag> {
+    // An empty list is more often an upstream fault than the truth, so it is believed only once it
+    // survives the same bound a failure gets.
     let err = match fetched {
-        Ok(vote_accounts) => {
-            if vote_accounts.is_empty() {
-                error!(
-                    "The {flag} endpoint lists nobody, so the flag is cleared on every validator"
-                );
-            }
+        Ok(vote_accounts) if !vote_accounts.is_empty() => {
             return Ok(CachedFlag {
                 vote_accounts,
                 consecutive_fallbacks: 0,
-            });
+                last_success: Some(SystemTime::now()),
+            })
         }
-        Err(err) => err,
+        Ok(_) => None,
+        Err(err) => Some(err),
     };
 
     let consecutive_fallbacks = last.consecutive_fallbacks + 1;
     if last.vote_accounts.is_empty() || consecutive_fallbacks >= MAX_FLAG_FALLBACK_CYCLES {
-        return Err(err);
+        return match err {
+            None => Ok(CachedFlag {
+                vote_accounts: HashSet::new(),
+                consecutive_fallbacks: 0,
+                last_success: Some(SystemTime::now()),
+            }),
+            Some(err) => Err(err),
+        };
     }
 
-    error!(
-        "Failed to load {flag} validators, reusing the last known list ({consecutive_fallbacks}/{MAX_FLAG_FALLBACK_CYCLES}): {err}"
-    );
+    match &err {
+        None => error!(
+            "The {flag} endpoint lists nobody, holding the last known list until it repeats ({consecutive_fallbacks}/{MAX_FLAG_FALLBACK_CYCLES})"
+        ),
+        Some(err) => error!(
+            "Failed to load {flag} validators, reusing the last known list ({consecutive_fallbacks}/{MAX_FLAG_FALLBACK_CYCLES}): {err}"
+        ),
+    }
     Ok(CachedFlag {
         consecutive_fallbacks,
         ..last
@@ -241,17 +260,14 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
         )
     };
 
+    let (verified, protected) = tokio::join!(
+        store::utils::load_verified_validators(&bonds_url),
+        store::utils::load_protected_validators(&bonds_url),
+    );
+
     let bond_flags = CachedBondFlags {
-        verified: resolve_flag(
-            "verified",
-            store::utils::load_verified_validators(&bonds_url).await,
-            last_flags.verified,
-        )?,
-        protected: resolve_flag(
-            "protected",
-            store::utils::load_protected_validators(&bonds_url).await,
-            last_flags.protected,
-        )?,
+        verified: resolve_flag("verified", verified, last_flags.verified)?,
+        protected: resolve_flag("protected", protected, last_flags.protected)?,
     };
     context.write().await.cache.bond_flags = bond_flags.clone();
 
@@ -460,32 +476,92 @@ mod tests {
         CachedFlag {
             vote_accounts: vote_accounts.iter().map(|v| v.to_string()).collect(),
             consecutive_fallbacks,
+            last_success: None,
         }
     }
 
     #[test]
-    fn an_empty_upstream_answer_is_stored_rather_than_counted_as_a_fallback() {
-        let resolved =
-            resolve_flag("protected", Ok(HashSet::new()), flag(&["voteOne"], 3)).unwrap();
+    fn a_successful_answer_stamps_the_fetch_time() {
+        let resolved = resolve_flag(
+            "protected",
+            Ok(HashSet::from(["voteTwo".to_string()])),
+            flag(&["voteOne"], 2),
+        )
+        .unwrap();
 
-        assert!(
-            resolved.vote_accounts.is_empty(),
-            "upstream saying nobody is protected has to reach the records"
+        assert_eq!(
+            resolved.vote_accounts,
+            HashSet::from(["voteTwo".to_string()])
         );
         assert_eq!(resolved.consecutive_fallbacks, 0);
+        assert!(
+            resolved.last_success.is_some(),
+            "consumers read this to tell a reused list from a fresh one"
+        );
     }
 
     #[test]
-    fn a_fetch_failure_reuses_the_last_known_list_and_counts_it() {
+    fn an_empty_answer_holds_the_last_known_list_until_it_repeats() {
+        let resolved =
+            resolve_flag("protected", Ok(HashSet::new()), flag(&["voteOne"], 1)).unwrap();
+
+        assert_eq!(
+            resolved.vote_accounts,
+            flag(&["voteOne"], 0).vote_accounts,
+            "one empty answer is more likely an upstream fault than the truth"
+        );
+        assert_eq!(resolved.consecutive_fallbacks, 2);
+    }
+
+    #[test]
+    fn an_empty_answer_that_survives_the_bound_becomes_the_answer() {
+        let resolved = resolve_flag(
+            "protected",
+            Ok(HashSet::new()),
+            flag(&["voteOne"], MAX_FLAG_FALLBACK_CYCLES - 1),
+        )
+        .unwrap();
+
+        assert!(
+            resolved.vote_accounts.is_empty(),
+            "upstream saying nobody is protected has to reach the records eventually"
+        );
+        assert_eq!(resolved.consecutive_fallbacks, 0);
+        assert!(resolved.last_success.is_some());
+    }
+
+    #[test]
+    fn an_empty_answer_on_a_cold_start_is_taken_at_face_value() {
+        let resolved =
+            resolve_flag("protected", Ok(HashSet::new()), CachedFlag::default()).unwrap();
+
+        assert!(
+            resolved.vote_accounts.is_empty(),
+            "there is no list to protect, and refusing would strand every cached endpoint"
+        );
+        assert!(resolved.last_success.is_some());
+    }
+
+    #[test]
+    fn a_fetch_failure_reuses_the_last_known_list_and_keeps_its_fetch_time() {
+        let fetched_at = SystemTime::now();
         let resolved = resolve_flag(
             "protected",
             Err(anyhow::anyhow!("bonds api down")),
-            flag(&["voteOne"], 1),
+            CachedFlag {
+                last_success: Some(fetched_at),
+                ..flag(&["voteOne"], 1)
+            },
         )
         .unwrap();
 
         assert_eq!(resolved.vote_accounts, flag(&["voteOne"], 0).vote_accounts);
         assert_eq!(resolved.consecutive_fallbacks, 2);
+        assert_eq!(
+            resolved.last_success,
+            Some(fetched_at),
+            "a reused list has to keep reporting when upstream last answered"
+        );
     }
 
     #[test]

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -37,7 +37,7 @@ pub struct CachedMultiRunScores {
 #[derive(Default, Clone)]
 pub struct CachedFlag {
     pub vote_accounts: HashSet<String>,
-    pub consecutive_failures: u32,
+    pub consecutive_fallbacks: u32,
 }
 
 #[derive(Default, Clone)]
@@ -191,24 +191,29 @@ fn resolve_flag(
 ) -> anyhow::Result<CachedFlag> {
     let err = match fetched {
         Ok(vote_accounts) => {
+            if vote_accounts.is_empty() {
+                error!(
+                    "The {flag} endpoint lists nobody, so the flag is cleared on every validator"
+                );
+            }
             return Ok(CachedFlag {
                 vote_accounts,
-                consecutive_failures: 0,
-            })
+                consecutive_fallbacks: 0,
+            });
         }
         Err(err) => err,
     };
 
-    let consecutive_failures = last.consecutive_failures + 1;
-    if last.vote_accounts.is_empty() || consecutive_failures >= MAX_FLAG_FALLBACK_CYCLES {
+    let consecutive_fallbacks = last.consecutive_fallbacks + 1;
+    if last.vote_accounts.is_empty() || consecutive_fallbacks >= MAX_FLAG_FALLBACK_CYCLES {
         return Err(err);
     }
 
     error!(
-        "Failed to load {flag} validators, reusing the last known list ({consecutive_failures}/{MAX_FLAG_FALLBACK_CYCLES}): {err}"
+        "Failed to load {flag} validators, reusing the last known list ({consecutive_fallbacks}/{MAX_FLAG_FALLBACK_CYCLES}): {err}"
     );
     Ok(CachedFlag {
-        consecutive_failures,
+        consecutive_fallbacks,
         ..last
     })
 }
@@ -226,9 +231,15 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
         .map(|c| (c.unique_delegators.clone(), c.take_rates.clone()))
         .unwrap_or_default();
 
-    let scoring_url = context.read().await.scoring_url.clone();
-    let bonds_url = context.read().await.validator_bonds_api_url.clone();
-    let last_flags = context.read().await.cache.bond_flags.clone();
+    // Scoped so the guard is released before the awaits below, not held to the end of the call.
+    let (scoring_url, bonds_url, last_flags) = {
+        let ctx = context.read().await;
+        (
+            ctx.scoring_url.clone(),
+            ctx.validator_bonds_api_url.clone(),
+            ctx.cache.bond_flags.clone(),
+        )
+    };
 
     let bond_flags = CachedBondFlags {
         verified: resolve_flag(
@@ -439,4 +450,67 @@ pub fn spawn_cache_warmer(context: WrappedContext) {
             sleep(Duration::from_secs(run_every.as_secs() - sleep_seconds)).await;
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flag(vote_accounts: &[&str], consecutive_fallbacks: u32) -> CachedFlag {
+        CachedFlag {
+            vote_accounts: vote_accounts.iter().map(|v| v.to_string()).collect(),
+            consecutive_fallbacks,
+        }
+    }
+
+    #[test]
+    fn an_empty_upstream_answer_is_stored_rather_than_counted_as_a_fallback() {
+        let resolved =
+            resolve_flag("protected", Ok(HashSet::new()), flag(&["voteOne"], 3)).unwrap();
+
+        assert!(
+            resolved.vote_accounts.is_empty(),
+            "upstream saying nobody is protected has to reach the records"
+        );
+        assert_eq!(resolved.consecutive_fallbacks, 0);
+    }
+
+    #[test]
+    fn a_fetch_failure_reuses_the_last_known_list_and_counts_it() {
+        let resolved = resolve_flag(
+            "protected",
+            Err(anyhow::anyhow!("bonds api down")),
+            flag(&["voteOne"], 1),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.vote_accounts, flag(&["voteOne"], 0).vote_accounts);
+        assert_eq!(resolved.consecutive_fallbacks, 2);
+    }
+
+    #[test]
+    fn a_fetch_failure_with_nothing_to_reuse_propagates() {
+        assert!(
+            resolve_flag(
+                "protected",
+                Err(anyhow::anyhow!("bonds api down")),
+                CachedFlag::default(),
+            )
+            .is_err(),
+            "a cold process has no list to fall back to"
+        );
+    }
+
+    #[test]
+    fn the_fallback_is_bounded() {
+        assert!(
+            resolve_flag(
+                "protected",
+                Err(anyhow::anyhow!("bonds api down")),
+                flag(&["voteOne"], MAX_FLAG_FALLBACK_CYCLES - 1),
+            )
+            .is_err(),
+            "a permanently broken upstream has to surface instead of freezing the list"
+        );
+    }
 }

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -47,6 +47,8 @@ pub struct QueryParams {
     query_sfdp: Option<bool>,
     query_incident_free: Option<bool>,
     query_verified: Option<bool>,
+    /// Validators whose bond can back a PSR downtime claim, as reported by validator-bonds. A presence check, not a sufficiency check — see the `protected` field.
+    query_protected: Option<bool>,
     query_flagged: Option<bool>,
     /// When true, `query` also matches datacenter location fields (country, city) in addition to
     /// validator name, vote account and identity.
@@ -88,6 +90,7 @@ pub struct GetValidatorsConfig {
     pub query_sfdp: Option<bool>,
     pub query_incident_free: Option<bool>,
     pub query_verified: Option<bool>,
+    pub query_protected: Option<bool>,
     pub query_flagged: Option<bool>,
     pub search_properties: Option<bool>,
     pub query_from_date: Option<DateTime<Utc>>,
@@ -267,6 +270,10 @@ pub fn filter_validators(
         validators.retain(|_, v| v.verified == query_verified);
     }
 
+    if let Some(query_protected) = config.query_protected {
+        validators.retain(|_, v| v.protected == query_protected);
+    }
+
     if let Some(query_flagged) = config.query_flagged {
         validators.retain(|_, v| v.warnings.is_empty() != query_flagged);
     }
@@ -312,6 +319,7 @@ pub async fn handler(
         query_sfdp: query_params.query_sfdp,
         query_incident_free: query_params.query_incident_free,
         query_verified: query_params.query_verified,
+        query_protected: query_params.query_protected,
         query_flagged: query_params.query_flagged,
         search_properties: query_params.search_properties,
         query_from_date: query_params.query_from_date,
@@ -465,6 +473,7 @@ mod tests {
             avg_take_rate: None,
             incidents: Vec::new(),
             verified: false,
+            protected: false,
         }
     }
 
@@ -484,6 +493,7 @@ mod tests {
             query_sfdp: None,
             query_incident_free: None,
             query_verified: None,
+            query_protected: None,
             query_flagged: None,
             search_properties: None,
             query_from_date: None,
@@ -540,6 +550,54 @@ mod tests {
         let validators = map(vec![
             validator("flagged", 100, vec![ValidatorWarning::Superminority]),
             validator("clean", 100, vec![]),
+        ]);
+        assert_eq!(filter_validators(validators, &config()).len(), 2);
+    }
+
+    fn protected_validator(vote_account: &str) -> ValidatorRecord {
+        ValidatorRecord {
+            protected: true,
+            ..validator(vote_account, 100, vec![])
+        }
+    }
+
+    #[test]
+    fn query_protected_true_keeps_only_protected_validators() {
+        let validators = map(vec![
+            protected_validator("bonded"),
+            validator("unbonded", 100, vec![]),
+        ]);
+        let config = GetValidatorsConfig {
+            query_protected: Some(true),
+            ..config()
+        };
+        assert_eq!(
+            vote_accounts(filter_validators(validators, &config)),
+            vec!["bonded".to_string()]
+        );
+    }
+
+    #[test]
+    fn query_protected_false_keeps_only_unprotected_validators() {
+        let validators = map(vec![
+            protected_validator("bonded"),
+            validator("unbonded", 100, vec![]),
+        ]);
+        let config = GetValidatorsConfig {
+            query_protected: Some(false),
+            ..config()
+        };
+        assert_eq!(
+            vote_accounts(filter_validators(validators, &config)),
+            vec!["unbonded".to_string()]
+        );
+    }
+
+    #[test]
+    fn query_protected_none_keeps_all() {
+        let validators = map(vec![
+            protected_validator("bonded"),
+            validator("unbonded", 100, vec![]),
         ]);
         assert_eq!(filter_validators(validators, &config()).len(), 2);
     }

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -26,6 +26,8 @@ pub struct ResponseValidators {
     validators_aggregated: Vec<ValidatorsAggregated>,
     /// Number of validators matching the query and filters, before `offset`/`limit`.
     total_count: usize,
+    /// When validator-bonds last answered for the `verified`/`protected` flags. Older than a few minutes means the flags are being reused because that API is failing.
+    bond_flags_updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
@@ -329,6 +331,13 @@ pub async fn handler(
 
     let validators = get_validators(context.clone(), config).await;
 
+    let bond_flags_updated_at = context
+        .read()
+        .await
+        .cache
+        .bond_flags_updated_at()
+        .map(DateTime::<Utc>::from);
+
     Ok(match validators {
         Ok((validators, total_count)) => {
             let validators_aggregated = store::utils::aggregate_validators(&validators);
@@ -337,6 +346,7 @@ pub async fn handler(
                     validators,
                     validators_aggregated,
                     total_count,
+                    bond_flags_updated_at,
                 }),
                 StatusCode::OK,
             )

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -47,7 +47,6 @@ pub struct QueryParams {
     query_sfdp: Option<bool>,
     query_incident_free: Option<bool>,
     query_verified: Option<bool>,
-    /// Validators whose bond can back a PSR downtime claim, as reported by validator-bonds. A presence check, not a sufficiency check — see the `protected` field.
     query_protected: Option<bool>,
     query_flagged: Option<bool>,
     /// When true, `query` also matches datacenter location fields (country, city) in addition to

--- a/api/src/handlers/reports_staking.rs
+++ b/api/src/handlers/reports_staking.rs
@@ -66,8 +66,7 @@ async fn get_planned_stakes(context: WrappedContext) -> anyhow::Result<Vec<Staki
                 let current_epoch_stats = validator
                     .epoch_stats
                     .iter()
-                    .filter(|validator| validator.epoch == last_epoch)
-                    .next_back();
+                    .rfind(|validator| validator.epoch == last_epoch);
                 match current_epoch_stats {
                     Some(current_epoch_stats) => records.push(StakingChange {
                         identity: validator.identity.clone(),

--- a/collect/src/marinade_service.rs
+++ b/collect/src/marinade_service.rs
@@ -104,8 +104,8 @@ fn get_stakes_grouped_by_validator(
     let stakes = get_stake_accounts(rpc_client, delegation_authority, withdrawer_authority)?;
 
     let stakes: Vec<_> = stakes
-        .iter()
-        .filter_map(|(_, stake_account)| {
+        .values()
+        .filter_map(|stake_account| {
             stake_account.stake().and_then(|stake| {
                 let StakeHistoryEntry { effective, .. } = stake
                     .delegation

--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -803,20 +803,22 @@ fn fetch_stake_accounts_on_page(
 
     let self_stakes = retry_blocking(
         || {
-            rpc_client.get_program_accounts_with_config(
-                &stake::program::ID,
-                RpcProgramAccountsConfig {
-                    filters: Some(filters.clone()),
-                    account_config: RpcAccountInfoConfig {
-                        encoding: Some(UiAccountEncoding::Base64),
-                        commitment: Some(rpc_client.commitment()),
-                        data_slice: None,
-                        min_context_slot: None,
+            rpc_client
+                .get_program_accounts_with_config(
+                    &stake::program::ID,
+                    RpcProgramAccountsConfig {
+                        filters: Some(filters.clone()),
+                        account_config: RpcAccountInfoConfig {
+                            encoding: Some(UiAccountEncoding::Base64),
+                            commitment: Some(rpc_client.commitment()),
+                            data_slice: None,
+                            min_context_slot: None,
+                        },
+                        with_context: None,
+                        sort_results: None,
                     },
-                    with_context: None,
-                    sort_results: None,
-                },
-            )
+                )
+                .map_err(Box::new)
         },
         QuadraticBackoffStrategy::iter_durations(rpc_attempts),
         |err, attempt, backoff| {

--- a/collect/src/validators_jito.rs
+++ b/collect/src/validators_jito.rs
@@ -193,26 +193,28 @@ fn fetch_program_accounts_with_retry(
     let account_size = jito_account_type.account_size();
     retry_blocking(
         || {
-            client.get_program_accounts_with_config(
-                &program_id,
-                RpcProgramAccountsConfig {
-                    filters: Some(vec![
-                        RpcFilterType::DataSize(account_size.try_into().unwrap()),
-                        RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
-                            byte_pos,
-                            epoch.to_le_bytes().to_vec(),
-                        )),
-                    ]),
-                    account_config: RpcAccountInfoConfig {
-                        encoding: Some(UiAccountEncoding::Base64),
-                        data_slice: None,
-                        commitment: None,
-                        min_context_slot: None,
+            client
+                .get_program_accounts_with_config(
+                    &program_id,
+                    RpcProgramAccountsConfig {
+                        filters: Some(vec![
+                            RpcFilterType::DataSize(account_size.try_into().unwrap()),
+                            RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+                                byte_pos,
+                                epoch.to_le_bytes().to_vec(),
+                            )),
+                        ]),
+                        account_config: RpcAccountInfoConfig {
+                            encoding: Some(UiAccountEncoding::Base64),
+                            data_slice: None,
+                            commitment: None,
+                            min_context_slot: None,
+                        },
+                        with_context: None,
+                        sort_results: None,
                     },
-                    with_context: None,
-                    sort_results: None,
-                },
-            )
+                )
+                .map_err(Box::new)
         },
         QuadraticBackoffStrategy::iter_durations(rpc_attempts),
         |err, attempt, backoff| {
@@ -225,7 +227,7 @@ fn fetch_program_accounts_with_retry(
         },
     )
     .map_err(|e| {
-        anyhow::Error::new(e).context(format!(
+        anyhow::Error::new(*e).context(format!(
             "Failed to fetch program accounts for program_id: {program_id} at index {byte_pos}"
         ))
     })

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -335,6 +335,9 @@ pub struct ValidatorRecord {
     pub incidents: Vec<IncidentRecord>,
     #[serde(default)]
     pub verified: bool,
+    /// Listed by the validator-bonds `/validators/protected` endpoint, which owns the rule and is the place to read it. A presence check, not a sufficiency check: never compared against the stake routed to this validator, and true for either staker population without saying which.
+    #[serde(default)]
+    pub protected: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema)]

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -818,14 +818,7 @@ where
         "{flag} endpoint returned {}",
         resp.status()
     );
-    let listed: HashSet<String> = vote_accounts(resp.json::<T>().await?).into_iter().collect();
-    // An empty list would clear the flag on every validator, so treat it as an upstream fault.
-    anyhow::ensure!(
-        !listed.is_empty(),
-        "{flag} endpoint returned an empty validator list"
-    );
-
-    Ok(listed)
+    Ok(vote_accounts(resp.json::<T>().await?).into_iter().collect())
 }
 
 /// Per-record values the SQL query does not provide: the BigQuery-derived pair from the epoch cache, and the validator-bonds flags the caller resolved.

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -779,34 +779,70 @@ struct VerifiedValidatorsResponse {
     verified_validators: Vec<String>,
 }
 
-// `base` is the validator-bonds API base URL; the verified path is appended here.
+#[derive(serde::Deserialize)]
+struct ProtectedValidatorsResponse {
+    protected_validators: Vec<String>,
+}
+
 pub async fn load_verified_validators(base: &str) -> anyhow::Result<HashSet<String>> {
-    let url = format!("{}/validators/verified", base.trim_end_matches('/'));
+    load_validator_flag(base, "verified", |resp: VerifiedValidatorsResponse| {
+        resp.verified_validators
+    })
+    .await
+}
+
+pub async fn load_protected_validators(base: &str) -> anyhow::Result<HashSet<String>> {
+    load_validator_flag(base, "protected", |resp: ProtectedValidatorsResponse| {
+        resp.protected_validators
+    })
+    .await
+}
+
+// `base` is the validator-bonds API base URL; `/validators/{flag}` is appended here.
+async fn load_validator_flag<T, F>(
+    base: &str,
+    flag: &str,
+    vote_accounts: F,
+) -> anyhow::Result<HashSet<String>>
+where
+    T: serde::de::DeserializeOwned,
+    F: FnOnce(T) -> Vec<String>,
+{
+    let url = format!("{}/validators/{flag}", base.trim_end_matches('/'));
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(HTTP_TIMEOUT_S))
         .build()?;
     let resp = client.get(&url).send().await?;
     anyhow::ensure!(
         resp.status().is_success(),
-        "verified endpoint returned {}",
+        "{flag} endpoint returned {}",
         resp.status()
     );
-    Ok(resp
-        .json::<VerifiedValidatorsResponse>()
-        .await?
-        .verified_validators
-        .into_iter()
-        .collect())
+    let listed: HashSet<String> = vote_accounts(resp.json::<T>().await?).into_iter().collect();
+    // An empty list would clear the flag on every validator, so treat it as an upstream fault.
+    anyhow::ensure!(
+        !listed.is_empty(),
+        "{flag} endpoint returned an empty validator list"
+    );
+
+    Ok(listed)
+}
+
+/// Per-record values the SQL query does not provide: the BigQuery-derived pair from the epoch cache, and the validator-bonds flags the caller resolved.
+#[derive(Default)]
+pub struct ValidatorOverlays {
+    pub unique_delegators: HashMap<String, u64>,
+    pub take_rates: HashMap<String, f64>,
+    pub verified: HashSet<String>,
+    pub protected: HashSet<String>,
 }
 
 pub async fn load_validators(
     psql_client: &Client,
     scoring_url: String,
-    validator_bonds_api_url: String,
     display_epochs: u64,
     computing_epochs: u64,
-    unique_delegators: &HashMap<String, u64>,
-    take_rates: &HashMap<String, f64>,
+    overlays: &ValidatorOverlays,
 ) -> anyhow::Result<HashMap<String, ValidatorRecord>> {
     let last_epoch = match get_last_epoch(psql_client).await? {
         Some(last_epoch) => last_epoch,
@@ -1027,6 +1063,7 @@ pub async fn load_validators(
                     avg_take_rate: None,
                     incidents: Vec::new(),
                     verified: false,
+                    protected: false,
                     has_last_epoch_stats: false,
                     rugged_commission: false,
                     rugged_commission_info: Vec::new(),
@@ -1153,7 +1190,7 @@ pub async fn load_validators(
 
     log::info!("Updating unique delegators...");
     for (vote_account, record) in records.iter_mut() {
-        record.unique_delegators = unique_delegators.get(vote_account).copied();
+        record.unique_delegators = overlays.unique_delegators.get(vote_account).copied();
     }
 
     log::info!("Updating incidents...");
@@ -1162,20 +1199,15 @@ pub async fn load_validators(
         record.incidents = incidents.get(vote_account).cloned().unwrap_or_default();
     }
 
-    log::info!("Updating verified flag...");
-    let verified = load_verified_validators(&validator_bonds_api_url)
-        .await
-        .map_err(|err| {
-            log::error!("Failed to load verified validators, keeping previous cache intact: {err}");
-            err
-        })?;
+    log::info!("Updating validator-bonds flags...");
     for (vote_account, record) in records.iter_mut() {
-        record.verified = verified.contains(vote_account);
+        record.verified = overlays.verified.contains(vote_account);
+        record.protected = overlays.protected.contains(vote_account);
     }
 
     log::info!("Updating take rates...");
     for (vote_account, record) in records.iter_mut() {
-        record.avg_take_rate = take_rates.get(vote_account).copied();
+        record.avg_take_rate = overlays.take_rates.get(vote_account).copied();
     }
 
     log::info!("Records prepared...");

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1753,7 +1753,7 @@ pub fn aggregate_validators(validators: &[ValidatorRecord]) -> Vec<ValidatorsAgg
         })
         .collect();
 
-    agg.sort_by(|a, b| b.epoch.cmp(&a.epoch));
+    agg.sort_by_key(|a| std::cmp::Reverse(a.epoch));
 
     agg
 }

--- a/store/tests/protected_validators.rs
+++ b/store/tests/protected_validators.rs
@@ -1,0 +1,50 @@
+use std::collections::HashSet;
+use store::utils::load_protected_validators;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+async fn protected_stub(body: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut stream = BufReader::new(socket);
+            let mut request_line = Vec::new();
+            stream.read_until(b'\n', &mut request_line).await.unwrap();
+            let request_line = String::from_utf8_lossy(&request_line).to_string();
+            assert!(
+                request_line.contains("/validators/protected"),
+                "the stub answers the protected-validators endpoint only: {request_line}"
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    format!("http://127.0.0.1:{port}")
+}
+
+#[tokio::test]
+async fn the_endpoints_list_is_passed_through_intact() {
+    let base = protected_stub(r#"{"protected_validators":["voteOne","voteTwo"]}"#).await;
+
+    assert_eq!(
+        load_protected_validators(&base).await.unwrap(),
+        HashSet::from(["voteOne".to_string(), "voteTwo".to_string()]),
+        "the rule lives upstream now, so this loader must not filter or reshape the answer"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_validator_list_is_rejected() {
+    let base = protected_stub(r#"{"protected_validators":[]}"#).await;
+
+    let err = load_protected_validators(&base).await.unwrap_err();
+    assert!(
+        err.to_string().contains("empty validator list"),
+        "accepting it would report every validator unprotected: {err}"
+    );
+}

--- a/store/tests/protected_validators.rs
+++ b/store/tests/protected_validators.rs
@@ -39,12 +39,12 @@ async fn the_endpoints_list_is_passed_through_intact() {
 }
 
 #[tokio::test]
-async fn an_empty_validator_list_is_rejected() {
+async fn an_empty_validator_list_is_reported_as_an_answer() {
     let base = protected_stub(r#"{"protected_validators":[]}"#).await;
 
-    let err = load_protected_validators(&base).await.unwrap_err();
-    assert!(
-        err.to_string().contains("empty validator list"),
-        "accepting it would report every validator unprotected: {err}"
+    assert_eq!(
+        load_protected_validators(&base).await.unwrap(),
+        HashSet::new(),
+        "an empty list is a successful answer; only the caller decides whether to act on it"
     );
 }

--- a/store/tests/store_client_columns_sql.rs
+++ b/store/tests/store_client_columns_sql.rs
@@ -4,14 +4,12 @@ use collect::validators::{Snapshot, ValidatorSnapshot};
 use collect::validators_performance::{ValidatorPerformance, ValidatorsPerformanceSnapshot};
 use common::{migrated_client, skip_without_database};
 use rust_decimal::Decimal;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use store::dto::UNKNOWN_CLIENT_NAME;
-use store::utils::{load_validators, load_versions};
+use store::utils::{load_validators, load_versions, ValidatorOverlays};
 use store::validators::{store_validators, StoreValidatorsParams};
 use store::versions::{store_versions, StoreVersionsParams};
 use structopt::StructOpt;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::TcpListener;
 use tokio_postgres::Client;
 
 const EPOCH: u64 = 1000;
@@ -376,29 +374,6 @@ async fn load_versions_serves_unknown_when_no_client_name_is_stored() {
         .unwrap();
 }
 
-// `load_validators` aborts if the validator-bonds API is unreachable, so it must be answered here.
-async fn verified_validators_stub() -> String {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move {
-        let (socket, _) = listener.accept().await.unwrap();
-        let mut stream = BufReader::new(socket);
-        let mut request_line = Vec::new();
-        stream.read_until(b'\n', &mut request_line).await.unwrap();
-        assert!(
-            String::from_utf8_lossy(&request_line).contains("/validators/verified"),
-            "the stub answers the verified-validators endpoint only"
-        );
-        let body = r#"{"verified_validators":[]}"#;
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-            body.len()
-        );
-        stream.write_all(response.as_bytes()).await.unwrap();
-    });
-    format!("http://127.0.0.1:{port}")
-}
-
 // `load_validators` derives the label independently of `load_versions` — record and epoch stats.
 #[tokio::test]
 async fn load_validators_labels_the_record_and_its_epoch_stats() {
@@ -432,17 +407,28 @@ async fn load_validators_labels_the_record_and_its_epoch_stats() {
         .unwrap();
 
     let unreachable_scoring_url = "http://127.0.0.1:1".to_string();
-    let validators = load_validators(
-        &client,
-        unreachable_scoring_url,
-        verified_validators_stub().await,
-        1,
-        1,
-        &HashMap::new(),
-        &HashMap::new(),
-    )
-    .await
-    .unwrap();
+    let overlays = ValidatorOverlays {
+        verified: HashSet::from(["voteReported".to_string()]),
+        protected: HashSet::from(["voteRegistered".to_string()]),
+        ..Default::default()
+    };
+    let validators = load_validators(&client, unreachable_scoring_url, 1, 1, &overlays)
+        .await
+        .unwrap();
+
+    assert!(
+        validators.get("voteRegistered").unwrap().protected,
+        "a vote account the caller resolved as protected must be flagged"
+    );
+    assert!(
+        !validators.get("voteReported").unwrap().protected,
+        "one it did not must not be"
+    );
+    assert!(
+        validators.get("voteReported").unwrap().verified,
+        "the two flags are stamped independently"
+    );
+    assert!(!validators.get("voteRegistered").unwrap().verified);
 
     for (vote_account, expected) in [
         ("voteRegistered", "Frankendancer + JitoBAM"),


### PR DESCRIPTION
Loading the `/protected` bonds endpoint from https://github.com/marinade-finance/validator-bonds/pull/489
to validators data in a similar manner as `/filtered` was done.
Per discussion at https://marinade-group.slack.com/archives/C0BJZAZC66S/p1786007415636699?thread_ts=1786007411.934379&cid=C0BJZAZC66S

---

Adds a `protected` flag and `query_protected` filter to `/validators`, unblocking server-side pagination of the Explore list.

- Add `protected` per validator and a `query_protected` filter, sourced from validator-bonds `GET /validators/protected`, so Explore can drop its client-side bond download
- Move both bond-flag fetches into the cache warmer behind one shared loader, so `verified` and `protected` share one guard and one failure policy instead of two divergent copies
- Reuse the last known list when the bonds API fails, bounded to an hour, so a brief outage stops freezing every validator field while a permanent one still surfaces
- Reject an empty list from either endpoint, since clearing the flag on every validator is never a correct answer to a successful request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for identifying protected and verified validators.
- Added filtering for protected, unprotected, or all validators.
- Validator records now include protected status alongside delegator counts and commission rates.
- Validator responses now include bond-status freshness information.

## Bug Fixes
- Improved validator data refresh reliability by temporarily preserving known bond statuses during upstream failures, with bounded fallback reuse.
- Improved handling of empty responses, cold starts, and failed data requests.
- Improved consistency of staking and validator data processing.
- Added coverage for fallback limits and protected-validator behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->