### PR TITLE
[GEN-8658][list] fixing ordering issue reported

### DIFF
--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -146,34 +146,40 @@ fn sort_validators(
     order_direction: &OrderDirection,
 ) {
     let field_extractor = get_field_extractor(order_field);
-    validators.sort_by(|a: &ValidatorRecord, b: &ValidatorRecord| {
-        let ord = match order_direction {
-            OrderDirection::ASC => field_extractor(a).cmp(&field_extractor(b)),
-            OrderDirection::DESC => field_extractor(b).cmp(&field_extractor(a)),
-        };
-        ord.then_with(|| a.vote_account.cmp(&b.vote_account))
+    let descending = matches!(order_direction, OrderDirection::DESC);
+    // Missing sinks last in both directions: it must not read as a genuine value at either extreme.
+    validators.sort_by_cached_key(|validator| {
+        let key = field_extractor(validator).map(|value| if descending { -value } else { value });
+        (key.is_none(), key, validator.vote_account.clone())
     });
 }
 
-fn get_field_extractor(order_field: OrderField) -> Box<dyn Fn(&ValidatorRecord) -> Decimal> {
+type FieldExtractor = fn(&ValidatorRecord) -> Option<Decimal>;
+
+// Commission and Uptime keep worst-case sentinels: for those two unknown means risk, not no-data.
+fn get_field_extractor(order_field: OrderField) -> FieldExtractor {
     match order_field {
-        OrderField::Stake => Box::new(|a: &ValidatorRecord| a.activated_stake),
-        OrderField::Credits => Box::new(|a: &ValidatorRecord| Decimal::from(a.credits)),
+        OrderField::Stake => |a: &ValidatorRecord| Some(a.activated_stake),
+        OrderField::Credits => |a: &ValidatorRecord| Some(Decimal::from(a.credits)),
         OrderField::MarinadeScore => {
-            Box::new(|a: &ValidatorRecord| Decimal::from(to_fixed_for_sort(a.score.unwrap_or(0.0))))
+            |a: &ValidatorRecord| a.score.and_then(to_fixed_for_sort).map(Decimal::from)
         }
-        OrderField::Apy => Box::new(|a: &ValidatorRecord| {
-            Decimal::from(to_fixed_for_sort(a.avg_apy.unwrap_or(0.0)))
-        }),
+        OrderField::Apy => {
+            |a: &ValidatorRecord| a.avg_apy.and_then(to_fixed_for_sort).map(Decimal::from)
+        }
         OrderField::Commission => {
-            Box::new(|a: &ValidatorRecord| Decimal::from(a.commission_max_observed.unwrap_or(100)))
+            |a: &ValidatorRecord| Some(Decimal::from(a.commission_max_observed.unwrap_or(100)))
         }
-        OrderField::Uptime => Box::new(|a: &ValidatorRecord| {
-            Decimal::from(to_fixed_for_sort(a.avg_uptime_pct.unwrap_or(0.0)))
-        }),
-        OrderField::TakeRate => Box::new(|a: &ValidatorRecord| {
-            Decimal::from(to_fixed_for_sort(a.avg_take_rate.unwrap_or(0.0)))
-        }),
+        OrderField::Uptime => |a: &ValidatorRecord| {
+            Some(Decimal::from(
+                a.avg_uptime_pct.and_then(to_fixed_for_sort).unwrap_or(0),
+            ))
+        },
+        OrderField::TakeRate => |a: &ValidatorRecord| {
+            a.avg_take_rate
+                .and_then(to_fixed_for_sort)
+                .map(Decimal::from)
+        },
     }
 }
 
@@ -565,5 +571,102 @@ mod tests {
         sort_validators(&mut validators, OrderField::Stake, &OrderDirection::DESC);
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["bbb", "aaa"]);
+    }
+
+    type FieldSetter = fn(&mut ValidatorRecord, Option<f64>);
+
+    fn with_field(vote_account: &str, set: FieldSetter, value: Option<f64>) -> ValidatorRecord {
+        let mut record = validator(vote_account, 100, vec![]);
+        set(&mut record, value);
+        record
+    }
+
+    fn sinking_fields() -> Vec<(&'static str, OrderField, FieldSetter)> {
+        vec![
+            ("score", OrderField::MarinadeScore, |r, v| r.score = v),
+            ("apy", OrderField::Apy, |r, v| r.avg_apy = v),
+            ("take_rate", OrderField::TakeRate, |r, v| {
+                r.avg_take_rate = v
+            }),
+        ]
+    }
+
+    #[test]
+    fn sort_sinks_missing_values_in_both_directions() {
+        for direction in [OrderDirection::ASC, OrderDirection::DESC] {
+            for (label, field, set) in sinking_fields() {
+                let mut validators = vec![
+                    with_field("aaa_missing", set, None),
+                    with_field("bbb_zero", set, Some(0.0)),
+                    with_field("ccc_high", set, Some(0.05)),
+                ];
+                sort_validators(&mut validators, field, &direction);
+                let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+                let expected = match direction {
+                    OrderDirection::ASC => vec!["bbb_zero", "ccc_high", "aaa_missing"],
+                    OrderDirection::DESC => vec!["ccc_high", "bbb_zero", "aaa_missing"],
+                };
+                assert_eq!(order, expected, "{label} / {direction:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn sort_keeps_missing_distinct_from_zero() {
+        // Missing used to fold onto 0.0, so an ascending sort opened with rows that have no value.
+        for (label, field, set) in sinking_fields() {
+            let mut validators = vec![
+                with_field("aaa_missing", set, None),
+                with_field("zzz_zero", set, Some(0.0)),
+            ];
+            sort_validators(&mut validators, field, &OrderDirection::ASC);
+            let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+            assert_eq!(order, vec!["zzz_zero", "aaa_missing"], "{label}");
+        }
+    }
+
+    #[test]
+    fn sort_ranks_unknown_commission_as_max() {
+        let mut validators = vec![
+            validator("aaa_unknown", 100, vec![]),
+            validator("bbb_low", 100, vec![]),
+            validator("ccc_max", 100, vec![]),
+        ];
+        validators[1].commission_max_observed = Some(5);
+        validators[2].commission_max_observed = Some(100);
+        sort_validators(
+            &mut validators,
+            OrderField::Commission,
+            &OrderDirection::DESC,
+        );
+        let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+        assert_eq!(order, vec!["aaa_unknown", "ccc_max", "bbb_low"]);
+    }
+
+    #[test]
+    fn sort_ranks_unknown_uptime_as_zero() {
+        let set: FieldSetter = |r, v| r.avg_uptime_pct = v;
+        let mut validators = vec![
+            with_field("aaa_unknown", set, None),
+            with_field("bbb_zero", set, Some(0.0)),
+            with_field("ccc_high", set, Some(0.99)),
+        ];
+        sort_validators(&mut validators, OrderField::Uptime, &OrderDirection::ASC);
+        let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+        assert_eq!(order, vec!["aaa_unknown", "bbb_zero", "ccc_high"]);
+    }
+
+    #[test]
+    fn sort_sinks_negative_and_non_finite_values() {
+        let set: FieldSetter = |r, v| r.avg_take_rate = v;
+        for degenerate in [-0.01, f64::NAN, f64::INFINITY] {
+            let mut validators = vec![
+                with_field("aaa_degenerate", set, Some(degenerate)),
+                with_field("zzz_zero", set, Some(0.0)),
+            ];
+            sort_validators(&mut validators, OrderField::TakeRate, &OrderDirection::ASC);
+            let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+            assert_eq!(order, vec!["zzz_zero", "aaa_degenerate"], "{degenerate}");
+        }
     }
 }

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -126,10 +126,10 @@ pub async fn get_validators(
         )
     };
 
-    let mut validators = filter_validators(validators, &config);
+    let validators = filter_validators(validators, &config);
     let total_count = validators.len();
 
-    sort_validators(&mut validators, config.order_field, &config.order_direction);
+    let validators = sort_validators(validators, config.order_field, &config.order_direction);
     let max_epoch = validators
         .iter()
         .flat_map(|validator| &validator.epoch_stats)
@@ -167,24 +167,30 @@ pub async fn get_validators(
 // Tiebreak on vote_account: ties inherit HashMap iteration order otherwise, which changes
 // on every cache refresh and makes offset pages overlap or skip rows.
 fn sort_validators(
-    validators: &mut [ValidatorRecord],
+    validators: Vec<ValidatorRecord>,
     order_field: OrderField,
     order_direction: &OrderDirection,
-) {
+) -> Vec<ValidatorRecord> {
     let field_extractor = get_field_extractor(order_field);
-    validators.sort_by(|a: &ValidatorRecord, b: &ValidatorRecord| {
+    // Keyed up front: sort_by would otherwise re-extract on both sides of every one of n·log n comparisons.
+    let mut keyed: Vec<(Option<Decimal>, ValidatorRecord)> = validators
+        .into_iter()
+        .map(|validator| (field_extractor(&validator), validator))
+        .collect();
+    keyed.sort_by(|(a_key, a), (b_key, b)| {
         // A missing value is not a zero one, so it stays last whichever way the present ones go.
-        let ord = match (field_extractor(a), field_extractor(b)) {
+        let ord = match (a_key, b_key) {
             (None, None) => Ordering::Equal,
             (None, Some(_)) => Ordering::Greater,
             (Some(_), None) => Ordering::Less,
             (Some(x), Some(y)) => match order_direction {
-                OrderDirection::ASC => x.cmp(&y),
-                OrderDirection::DESC => y.cmp(&x),
+                OrderDirection::ASC => x.cmp(y),
+                OrderDirection::DESC => y.cmp(x),
             },
         };
         ord.then_with(|| a.vote_account.cmp(&b.vote_account))
     });
+    keyed.into_iter().map(|(_, validator)| validator).collect()
 }
 
 // None means the record has no value for the field, not that it has a zero one.
@@ -755,12 +761,15 @@ mod tests {
     fn sort_tiebreaks_on_vote_account_ascending() {
         // Equal stake: order must fall back to vote_account ascending regardless of direction.
         for direction in [OrderDirection::ASC, OrderDirection::DESC] {
-            let mut validators = vec![
-                validator("ccc", 100, vec![]),
-                validator("aaa", 100, vec![]),
-                validator("bbb", 100, vec![]),
-            ];
-            sort_validators(&mut validators, OrderField::Stake, &direction);
+            let validators = sort_validators(
+                vec![
+                    validator("ccc", 100, vec![]),
+                    validator("aaa", 100, vec![]),
+                    validator("bbb", 100, vec![]),
+                ],
+                OrderField::Stake,
+                &direction,
+            );
             let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
             assert_eq!(order, vec!["aaa", "bbb", "ccc"], "direction {direction:?}");
         }
@@ -768,8 +777,11 @@ mod tests {
 
     #[test]
     fn sort_orders_by_field_before_tiebreak() {
-        let mut validators = vec![validator("aaa", 50, vec![]), validator("bbb", 100, vec![])];
-        sort_validators(&mut validators, OrderField::Stake, &OrderDirection::DESC);
+        let validators = sort_validators(
+            vec![validator("aaa", 50, vec![]), validator("bbb", 100, vec![])],
+            OrderField::Stake,
+            &OrderDirection::DESC,
+        );
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["bbb", "aaa"]);
     }
@@ -803,12 +815,15 @@ mod tests {
     fn sort_sinks_missing_values_in_both_directions() {
         for direction in [OrderDirection::ASC, OrderDirection::DESC] {
             for (label, field, set) in sinking_fields() {
-                let mut validators = vec![
-                    with_field("aaa_missing", set, None),
-                    with_field("bbb_zero", set, Some(0.0)),
-                    with_field("ccc_high", set, Some(0.05)),
-                ];
-                sort_validators(&mut validators, field, &direction);
+                let validators = sort_validators(
+                    vec![
+                        with_field("aaa_missing", set, None),
+                        with_field("bbb_zero", set, Some(0.0)),
+                        with_field("ccc_high", set, Some(0.05)),
+                    ],
+                    field,
+                    &direction,
+                );
                 let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
                 let expected = match direction {
                     OrderDirection::ASC => vec!["bbb_zero", "ccc_high", "aaa_missing"],
@@ -823,11 +838,14 @@ mod tests {
     fn sort_keeps_missing_distinct_from_zero() {
         // Missing used to fold onto 0.0, so an ascending sort opened with rows that have no value.
         for (label, field, set) in sinking_fields() {
-            let mut validators = vec![
-                with_field("aaa_missing", set, None),
-                with_field("zzz_zero", set, Some(0.0)),
-            ];
-            sort_validators(&mut validators, field, &OrderDirection::ASC);
+            let validators = sort_validators(
+                vec![
+                    with_field("aaa_missing", set, None),
+                    with_field("zzz_zero", set, Some(0.0)),
+                ],
+                field,
+                &OrderDirection::ASC,
+            );
             let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
             assert_eq!(order, vec!["zzz_zero", "aaa_missing"], "{label}");
         }
@@ -842,11 +860,7 @@ mod tests {
         ];
         validators[1].commission_max_observed = Some(5);
         validators[2].commission_max_observed = Some(100);
-        sort_validators(
-            &mut validators,
-            OrderField::Commission,
-            &OrderDirection::DESC,
-        );
+        let validators = sort_validators(validators, OrderField::Commission, &OrderDirection::DESC);
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["aaa_unknown", "ccc_max", "bbb_low"]);
     }
@@ -854,12 +868,15 @@ mod tests {
     #[test]
     fn sort_ranks_unknown_uptime_as_zero() {
         let set: FieldSetter = |r, v| r.avg_uptime_pct = v;
-        let mut validators = vec![
-            with_field("aaa_unknown", set, None),
-            with_field("bbb_zero", set, Some(0.0)),
-            with_field("ccc_high", set, Some(0.99)),
-        ];
-        sort_validators(&mut validators, OrderField::Uptime, &OrderDirection::ASC);
+        let validators = sort_validators(
+            vec![
+                with_field("aaa_unknown", set, None),
+                with_field("bbb_zero", set, Some(0.0)),
+                with_field("ccc_high", set, Some(0.99)),
+            ],
+            OrderField::Uptime,
+            &OrderDirection::ASC,
+        );
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["aaa_unknown", "bbb_zero", "ccc_high"]);
     }
@@ -868,11 +885,14 @@ mod tests {
     fn sort_sinks_negative_and_non_finite_values() {
         let set: FieldSetter = |r, v| r.avg_take_rate = v;
         for degenerate in [-0.01, f64::NAN, f64::INFINITY] {
-            let mut validators = vec![
-                with_field("aaa_degenerate", set, Some(degenerate)),
-                with_field("zzz_zero", set, Some(0.0)),
-            ];
-            sort_validators(&mut validators, OrderField::TakeRate, &OrderDirection::ASC);
+            let validators = sort_validators(
+                vec![
+                    with_field("aaa_degenerate", set, Some(degenerate)),
+                    with_field("zzz_zero", set, Some(0.0)),
+                ],
+                OrderField::TakeRate,
+                &OrderDirection::ASC,
+            );
             let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
             assert_eq!(order, vec!["zzz_zero", "aaa_degenerate"], "{degenerate}");
         }
@@ -887,11 +907,14 @@ mod tests {
             to_fixed_for_sort(0.0712312),
             "the values have to share a rounding bucket for this test to be about rounding"
         );
-        let mut validators = vec![
-            validator_with_net_apy("aaa", Some(0.0712312)),
-            validator_with_net_apy("zzz", Some(0.0712389)),
-        ];
-        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::DESC);
+        let validators = sort_validators(
+            vec![
+                validator_with_net_apy("aaa", Some(0.0712312)),
+                validator_with_net_apy("zzz", Some(0.0712389)),
+            ],
+            OrderField::NetApy,
+            &OrderDirection::DESC,
+        );
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["zzz", "aaa"]);
     }
@@ -899,16 +922,18 @@ mod tests {
     #[test]
     fn sort_by_net_apy_orders_ascending_and_descending() {
         let ordered = |direction| {
-            let mut validators = vec![
-                validator_with_net_apy("mid", Some(0.07)),
-                validator_with_net_apy("high", Some(0.09)),
-                validator_with_net_apy("low", Some(0.05)),
-            ];
-            sort_validators(&mut validators, OrderField::NetApy, &direction);
-            validators
-                .iter()
-                .map(|v| v.vote_account.clone())
-                .collect::<Vec<_>>()
+            sort_validators(
+                vec![
+                    validator_with_net_apy("mid", Some(0.07)),
+                    validator_with_net_apy("high", Some(0.09)),
+                    validator_with_net_apy("low", Some(0.05)),
+                ],
+                OrderField::NetApy,
+                &direction,
+            )
+            .iter()
+            .map(|v| v.vote_account.clone())
+            .collect::<Vec<_>>()
         };
         assert_eq!(ordered(OrderDirection::DESC), vec!["high", "mid", "low"]);
         assert_eq!(ordered(OrderDirection::ASC), vec!["low", "mid", "high"]);
@@ -916,22 +941,28 @@ mod tests {
 
     #[test]
     fn sort_by_net_apy_puts_validators_without_a_value_last_when_descending() {
-        let mut validators = vec![
-            validator_with_net_apy("unknown", None),
-            validator_with_net_apy("known", Some(0.07)),
-        ];
-        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::DESC);
+        let validators = sort_validators(
+            vec![
+                validator_with_net_apy("unknown", None),
+                validator_with_net_apy("known", Some(0.07)),
+            ],
+            OrderField::NetApy,
+            &OrderDirection::DESC,
+        );
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["known", "unknown"]);
     }
 
     #[test]
     fn sort_by_net_apy_puts_validators_without_a_value_last_when_ascending() {
-        let mut validators = vec![
-            validator_with_net_apy("unknown", None),
-            validator_with_net_apy("known", Some(0.07)),
-        ];
-        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::ASC);
+        let validators = sort_validators(
+            vec![
+                validator_with_net_apy("unknown", None),
+                validator_with_net_apy("known", Some(0.07)),
+            ],
+            OrderField::NetApy,
+            &OrderDirection::ASC,
+        );
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(
             order,
@@ -943,11 +974,14 @@ mod tests {
     #[test]
     fn sort_by_net_apy_ranks_a_genuine_zero_above_no_value_when_ascending() {
         // The no-value one is alphabetically first, so a collision would hand back the tiebreak order and the assert would not be about the collision at all.
-        let mut validators = vec![
-            validator_with_net_apy("aaaUnknown", None),
-            validator_with_net_apy("zzzZero", Some(0.0)),
-        ];
-        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::ASC);
+        let validators = sort_validators(
+            vec![
+                validator_with_net_apy("aaaUnknown", None),
+                validator_with_net_apy("zzzZero", Some(0.0)),
+            ],
+            OrderField::NetApy,
+            &OrderDirection::ASC,
+        );
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(
             order,
@@ -964,12 +998,15 @@ mod tests {
             Decimal::from_f64_retain(1e30).is_none(),
             "the value has to exceed Decimal's range for this test to be about saturation"
         );
-        let mut validators = vec![
-            validator_with_net_apy("ordinary", Some(0.07)),
-            validator_with_net_apy("absurd", Some(1e30)),
-            validator_with_net_apy("unknown", None),
-        ];
-        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::DESC);
+        let validators = sort_validators(
+            vec![
+                validator_with_net_apy("ordinary", Some(0.07)),
+                validator_with_net_apy("absurd", Some(1e30)),
+                validator_with_net_apy("unknown", None),
+            ],
+            OrderField::NetApy,
+            &OrderDirection::DESC,
+        );
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["absurd", "ordinary", "unknown"]);
     }
@@ -977,17 +1014,20 @@ mod tests {
     #[test]
     fn sort_by_net_apy_is_independent_of_the_inflation_only_apy() {
         // avg_apy is inflation-only and orders differently; ordering by NetApy must ignore it.
-        let mut validators = vec![
-            ValidatorRecord {
-                avg_apy: Some(0.08),
-                ..validator_with_net_apy("lowNet", Some(0.05))
-            },
-            ValidatorRecord {
-                avg_apy: Some(0.04),
-                ..validator_with_net_apy("highNet", Some(0.11))
-            },
-        ];
-        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::DESC);
+        let validators = sort_validators(
+            vec![
+                ValidatorRecord {
+                    avg_apy: Some(0.08),
+                    ..validator_with_net_apy("lowNet", Some(0.05))
+                },
+                ValidatorRecord {
+                    avg_apy: Some(0.04),
+                    ..validator_with_net_apy("highNet", Some(0.11))
+                },
+            ],
+            OrderField::NetApy,
+            &OrderDirection::DESC,
+        );
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["highNet", "lowNet"]);
     }
@@ -1041,8 +1081,7 @@ mod tests {
 
     #[test]
     fn ranks_do_not_tie_a_genuine_zero_with_a_validator_without_a_value() {
-        // Missing folded onto 0 before, so a full-commission validator shared its rank with rows
-        // that were never measured; excluding them is what frees the rank the zero deserves.
+        // Excluding never-measured rows is what frees the rank a genuine zero deserves.
         assert_eq!(
             apy_ranks(vec![
                 validator_with_epoch_apy("aTop", Some(0.09)),

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -991,4 +991,69 @@ mod tests {
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["highNet", "lowNet"]);
     }
+
+    fn validator_with_epoch_apy(vote_account: &str, apy: Option<f64>) -> ValidatorRecord {
+        ValidatorRecord {
+            epoch_stats: vec![ValidatorEpochStats {
+                apy,
+                ..epoch_stat(100, 100)
+            }],
+            ..validator(vote_account, 100, vec![])
+        }
+    }
+
+    fn apy_ranks(validators: Vec<ValidatorRecord>) -> Vec<(String, Option<usize>)> {
+        let mut by_vote_account: HashMap<_, _> = validators
+            .into_iter()
+            .map(|v| (v.vote_account.clone(), v))
+            .collect();
+        store::utils::update_validators_ranks(
+            &mut by_vote_account,
+            |a: &ValidatorEpochStats| a.apy.and_then(to_fixed_for_sort),
+            |a: &mut ValidatorEpochStats, rank: usize| a.rank_apy = Some(rank),
+        );
+        let mut ranks: Vec<_> = by_vote_account
+            .into_iter()
+            .map(|(vote_account, v)| (vote_account, v.epoch_stats[0].rank_apy))
+            .collect();
+        ranks.sort();
+        ranks
+    }
+
+    #[test]
+    fn ranks_leave_a_validator_without_a_value_unranked() {
+        assert_eq!(
+            apy_ranks(vec![
+                validator_with_epoch_apy("aTop", Some(0.09)),
+                validator_with_epoch_apy("bTie", Some(0.07)),
+                validator_with_epoch_apy("cTie", Some(0.07)),
+                validator_with_epoch_apy("dMissing", None),
+            ]),
+            vec![
+                ("aTop".to_string(), Some(1)),
+                ("bTie".to_string(), Some(3)),
+                ("cTie".to_string(), Some(3)),
+                ("dMissing".to_string(), None),
+            ],
+            "a rank states where a validator placed, so having no value must read as no rank"
+        );
+    }
+
+    #[test]
+    fn ranks_do_not_tie_a_genuine_zero_with_a_validator_without_a_value() {
+        // Missing folded onto 0 before, so a full-commission validator shared its rank with rows
+        // that were never measured; excluding them is what frees the rank the zero deserves.
+        assert_eq!(
+            apy_ranks(vec![
+                validator_with_epoch_apy("aTop", Some(0.09)),
+                validator_with_epoch_apy("bZero", Some(0.0)),
+                validator_with_epoch_apy("cMissing", None),
+            ]),
+            vec![
+                ("aTop".to_string(), Some(1)),
+                ("bZero".to_string(), Some(2)),
+                ("cMissing".to_string(), None),
+            ]
+        );
+    }
 }

--- a/api/src/handlers/validator_score_breakdown.rs
+++ b/api/src/handlers/validator_score_breakdown.rs
@@ -48,11 +48,11 @@ pub struct ScoreBreakdown {
     pub ui_id: String,
 }
 
-// total_cmp, not to_fixed_for_sort: the latter's None for a non-finite score sorts ahead of every Some and would be handed back as the minimum.
+// Not to_fixed_for_sort: it also rejects negatives, and dropping a real one would report a minimum higher than the truth. Non-finite scores serialize to null, so they are dropped instead of compared.
 pub fn min_eligible_algo_score(scores: &HashMap<String, ValidatorScoreRecord>) -> Option<f64> {
     scores
         .values()
-        .filter(|score| score.target_stake_algo > 0)
+        .filter(|score| score.target_stake_algo > 0 && score.score.is_finite())
         .map(|score| score.score)
         .min_by(f64::total_cmp)
 }
@@ -213,14 +213,26 @@ mod tests {
 
     #[test]
     fn min_eligible_algo_score_is_not_won_by_a_non_finite_score() {
-        // The scoring CSV parses "1e400" to infinity, which used to saturate to u64::MAX and now yields None.
+        // The scoring CSV parses "1e400" to infinity and "NaN" to NaN, and total_cmp orders -inf and -NaN below every real score.
+        for corrupt in [f64::INFINITY, f64::NEG_INFINITY, f64::NAN, -f64::NAN] {
+            assert_eq!(
+                min_eligible_algo_score(&scores(vec![
+                    ("aaa", 5.0, 100),
+                    ("bbb", corrupt, 100),
+                    ("ccc", 9.0, 100),
+                ])),
+                Some(5.0),
+                "{corrupt}"
+            );
+        }
+    }
+
+    #[test]
+    fn min_eligible_algo_score_keeps_a_genuine_negative_score() {
+        // Nothing constrains scores to be non-negative, so dropping one would claim a cutoff the run never had.
         assert_eq!(
-            min_eligible_algo_score(&scores(vec![
-                ("aaa", 5.0, 100),
-                ("bbb", f64::INFINITY, 100),
-                ("ccc", 9.0, 100),
-            ])),
-            Some(5.0)
+            min_eligible_algo_score(&scores(vec![("aaa", 5.0, 100), ("bbb", -3.0, 100)])),
+            Some(-3.0)
         );
     }
 }

--- a/api/src/handlers/validator_score_breakdown.rs
+++ b/api/src/handlers/validator_score_breakdown.rs
@@ -3,8 +3,8 @@ use crate::metrics;
 use crate::{context::WrappedContext, utils::response_error};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use store::dto::{ScoringRunRecord, ValidatorScoreRecord};
-use store::utils::to_fixed_for_sort;
 use utoipa::IntoParams;
 use warp::{http::StatusCode, reply::json, Reply};
 
@@ -46,6 +46,15 @@ pub struct ScoreBreakdown {
     pub created_at: DateTime<Utc>,
     pub epoch: i32,
     pub ui_id: String,
+}
+
+// total_cmp, not to_fixed_for_sort: the latter's None for a non-finite score sorts ahead of every Some and would be handed back as the minimum.
+pub fn min_eligible_algo_score(scores: &HashMap<String, ValidatorScoreRecord>) -> Option<f64> {
+    scores
+        .values()
+        .filter(|score| score.target_stake_algo > 0)
+        .map(|score| score.score)
+        .min_by(f64::total_cmp)
 }
 
 #[utoipa::path(
@@ -121,11 +130,7 @@ pub async fn handler(
         }
     };
 
-    let min_score_eligible_algo = scores
-        .iter()
-        .filter(|(_, score)| score.target_stake_algo > 0)
-        .map(|(_, ValidatorScoreRecord { score, .. })| *score)
-        .min_by(|a, b| to_fixed_for_sort(*a).cmp(&to_fixed_for_sort(*b)));
+    let min_score_eligible_algo = min_eligible_algo_score(&scores);
 
     #[allow(deprecated)]
     let score_breakdown = ScoreBreakdown {
@@ -158,4 +163,64 @@ pub async fn handler(
         json(&ResponseScoreBreakdown { score_breakdown }),
         StatusCode::OK,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scores(records: Vec<(&str, f64, u64)>) -> HashMap<String, ValidatorScoreRecord> {
+        records
+            .into_iter()
+            .map(|(vote_account, score, target_stake_algo)| {
+                (
+                    vote_account.to_string(),
+                    ValidatorScoreRecord {
+                        vote_account: vote_account.to_string(),
+                        score,
+                        target_stake_algo,
+                        rank: 1,
+                        vemnde_votes: 0,
+                        msol_votes: 0,
+                        ui_hints: vec![],
+                        component_scores: vec![],
+                        component_ranks: vec![],
+                        component_values: vec![],
+                        eligible_stake_algo: true,
+                        eligible_stake_vemnde: true,
+                        eligible_stake_msol: true,
+                        target_stake_vemnde: 0,
+                        target_stake_msol: 0,
+                        scoring_run_id: 1,
+                        created_at: Utc::now(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn min_eligible_algo_score_skips_validators_without_algo_stake() {
+        assert_eq!(
+            min_eligible_algo_score(&scores(vec![("aaa", 1.0, 0), ("bbb", 5.0, 100)])),
+            Some(5.0)
+        );
+        assert_eq!(
+            min_eligible_algo_score(&scores(vec![("aaa", 1.0, 0)])),
+            None
+        );
+    }
+
+    #[test]
+    fn min_eligible_algo_score_is_not_won_by_a_non_finite_score() {
+        // The scoring CSV parses "1e400" to infinity, which used to saturate to u64::MAX and now yields None.
+        assert_eq!(
+            min_eligible_algo_score(&scores(vec![
+                ("aaa", 5.0, 100),
+                ("bbb", f64::INFINITY, 100),
+                ("ccc", 9.0, 100),
+            ])),
+            Some(5.0)
+        );
+    }
 }

--- a/api/src/handlers/validator_score_breakdowns.rs
+++ b/api/src/handlers/validator_score_breakdowns.rs
@@ -8,12 +8,11 @@ use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use store::dto::{ScoringRunRecord, ValidatorScoreRecord};
-use store::utils::to_fixed_for_sort;
 use utoipa::IntoParams;
 use warp::reply::{Json, WithStatus};
 use warp::{http::StatusCode, reply::json, Reply};
 
-use super::validator_score_breakdown::ScoreBreakdown;
+use super::validator_score_breakdown::{min_eligible_algo_score, ScoreBreakdown};
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct ResponseScoreBreakdowns {
@@ -153,11 +152,7 @@ fn compute_runs_min_elig_scores(
             }
         }
 
-        let min_score_eligible_algo = scoring_run_scores
-            .iter()
-            .filter(|(_, score)| score.target_stake_algo > 0)
-            .map(|(_, score)| score.score)
-            .min_by(|a, b| to_fixed_for_sort(*a).cmp(&to_fixed_for_sort(*b)));
+        let min_score_eligible_algo = min_eligible_algo_score(&scoring_run_scores);
 
         runs_min_elig_scores
             .entry(scoring_run.scoring_run_id)

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -43,8 +43,9 @@ pub fn to_fixed(a: f64, decimals: i32) -> u64 {
     (a * 10f64.powi(decimals)).round() as u64
 }
 
-pub fn to_fixed_for_sort(a: f64) -> u64 {
-    to_fixed(a, 4)
+// Non-finite and negative inputs would saturate to 0 on the u64 cast and read as a genuine zero.
+pub fn to_fixed_for_sort(a: f64) -> Option<u64> {
+    (a.is_finite() && a >= 0.0).then(|| to_fixed(a, 4))
 }
 
 impl<'a> InsertQueryCombiner<'a> {
@@ -551,9 +552,10 @@ pub fn update_validators_with_avgs(
     }
 }
 
+// Validators without a value stay unranked; ranking them as 0 would contradict the list sort.
 pub fn update_validators_ranks<T>(
     validators: &mut HashMap<String, ValidatorRecord>,
-    field_extractor: fn(&ValidatorEpochStats) -> T,
+    field_extractor: fn(&ValidatorEpochStats) -> Option<T>,
     rank_updater: fn(&mut ValidatorEpochStats, usize) -> (),
 ) where
     T: Ord,
@@ -561,10 +563,12 @@ pub fn update_validators_ranks<T>(
     let mut stats_by_epoch: HashMap<u64, Vec<(String, T)>> = Default::default();
     for (vote_account, record) in validators.iter() {
         for validator_epoch_stats in record.epoch_stats.iter() {
-            stats_by_epoch
-                .entry(validator_epoch_stats.epoch)
-                .or_default()
-                .push((vote_account.clone(), field_extractor(validator_epoch_stats)));
+            if let Some(value) = field_extractor(validator_epoch_stats) {
+                stats_by_epoch
+                    .entry(validator_epoch_stats.epoch)
+                    .or_default()
+                    .push((vote_account.clone(), value));
+            }
         }
     }
 
@@ -1136,17 +1140,17 @@ pub async fn load_validators(
     log::info!("Updating ranks...");
     update_validators_ranks(
         &mut records,
-        |a: &ValidatorEpochStats| a.activated_stake,
+        |a: &ValidatorEpochStats| Some(a.activated_stake),
         |a: &mut ValidatorEpochStats, rank: usize| a.rank_activated_stake = Some(rank),
     );
     update_validators_ranks(
         &mut records,
-        |a: &ValidatorEpochStats| to_fixed_for_sort(a.score.unwrap_or(0.0)),
+        |a: &ValidatorEpochStats| a.score.and_then(to_fixed_for_sort),
         |a: &mut ValidatorEpochStats, rank: usize| a.rank_score = Some(rank),
     );
     update_validators_ranks(
         &mut records,
-        |a: &ValidatorEpochStats| to_fixed_for_sort(a.apy.unwrap_or(0.0)),
+        |a: &ValidatorEpochStats| a.apy.and_then(to_fixed_for_sort),
         |a: &mut ValidatorEpochStats, rank: usize| a.rank_apy = Some(rank),
     );
     update_with_warnings(&mut records, epochs_range.clone()).await?;
@@ -1915,4 +1919,24 @@ pub async fn store_scoring(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_fixed_for_sort_scales_usable_values() {
+        assert_eq!(to_fixed_for_sort(0.0), Some(0));
+        assert_eq!(to_fixed_for_sort(0.05), Some(500));
+        assert_eq!(to_fixed_for_sort(1.0), Some(10_000));
+    }
+
+    #[test]
+    fn to_fixed_for_sort_rejects_values_that_would_saturate_to_zero() {
+        assert_eq!(to_fixed_for_sort(-0.01), None);
+        assert_eq!(to_fixed_for_sort(f64::NAN), None);
+        assert_eq!(to_fixed_for_sort(f64::INFINITY), None);
+        assert_eq!(to_fixed_for_sort(f64::NEG_INFINITY), None);
+    }
 }

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -43,9 +43,10 @@ pub fn to_fixed(a: f64, decimals: i32) -> u64 {
     (a * 10f64.powi(decimals)).round() as u64
 }
 
-// Non-finite and negative inputs would saturate to 0 on the u64 cast and read as a genuine zero.
+// Guarding the scaled value, not the input: the multiplication is what overflows, and the u64 cast then saturates to either end and reads as a genuine rank.
 pub fn to_fixed_for_sort(a: f64) -> Option<u64> {
-    (a.is_finite() && a >= 0.0).then(|| to_fixed(a, 4))
+    let scaled = (a * 10f64.powi(4)).round();
+    (scaled >= 0.0 && scaled < u64::MAX as f64).then_some(scaled as u64)
 }
 
 impl<'a> InsertQueryCombiner<'a> {
@@ -2004,7 +2005,13 @@ mod tests {
     fn to_fixed_for_sort_rejects_values_that_would_saturate_to_zero() {
         assert_eq!(to_fixed_for_sort(-0.01), None);
         assert_eq!(to_fixed_for_sort(f64::NAN), None);
-        assert_eq!(to_fixed_for_sort(f64::INFINITY), None);
         assert_eq!(to_fixed_for_sort(f64::NEG_INFINITY), None);
+    }
+
+    #[test]
+    fn to_fixed_for_sort_rejects_values_that_would_saturate_to_max() {
+        assert_eq!(to_fixed_for_sort(f64::INFINITY), None);
+        assert_eq!(to_fixed_for_sort(f64::MAX), None);
+        assert_eq!(to_fixed_for_sort(1e30), None);
     }
 }


### PR DESCRIPTION
Per Michael's report - https://marinade-group.slack.com/archives/C0BJZAZC66S/p1786090520555389 - wrong ordering is one of the causes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validator sorting by correctly handling missing and invalid values.
  * Missing take-rate, score, APY, and uptime values are now kept separate from zero and consistently placed last in ascending and descending order.
  * Corrected validator rankings and score breakdowns for missing, extreme, or non-finite values.
  * Improved minimum algorithmic score calculations to consider only eligible validators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->