### PR TITLE
[store] call the validator-bonds flag endpoints under /v1

### DIFF
--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -798,7 +798,7 @@ pub async fn load_protected_validators(base: &str) -> anyhow::Result<HashSet<Str
     .await
 }
 
-// `base` is the validator-bonds API base URL; `/validators/{flag}` is appended here.
+// `base` is the validator-bonds API base URL; `/v1/validators/{flag}` is appended here.
 async fn load_validator_flag<T, F>(
     base: &str,
     flag: &str,
@@ -808,7 +808,7 @@ where
     T: serde::de::DeserializeOwned,
     F: FnOnce(T) -> Vec<String>,
 {
-    let url = format!("{}/validators/{flag}", base.trim_end_matches('/'));
+    let url = format!("{}/v1/validators/{flag}", base.trim_end_matches('/'));
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(HTTP_TIMEOUT_S))
         .build()?;

--- a/store/tests/protected_validators.rs
+++ b/store/tests/protected_validators.rs
@@ -14,7 +14,7 @@ async fn protected_stub(body: &'static str) -> String {
             stream.read_until(b'\n', &mut request_line).await.unwrap();
             let request_line = String::from_utf8_lossy(&request_line).to_string();
             assert!(
-                request_line.contains("/validators/protected"),
+                request_line.contains("/v1/validators/protected"),
                 "the stub answers the protected-validators endpoint only: {request_line}"
             );
             let response = format!(


### PR DESCRIPTION
I need to make changes to how validator bonds define a protected validator (https://marinade-group.slack.com/archives/C0BJZAZC66S/p1786171658277399?thread_ts=1786007411.934379&cid=C0BJZAZC66S)
With that, I want to migrate to /v1, as we usually use in marinade.

Both /validators/verified and /validators/protected move behind the /v1 prefix. Merge only after validator-bonds serves /v1 in production.

**REQUIRED** to first deploy changes from https://github.com/marinade-finance/delegation-strategy-2/pull/246#issue-5110700329