### PR TITLE
[GEN-8656][apy/api] sort by mev net apy per FE

### DIFF
--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -47,9 +47,17 @@ pub struct CachedBondFlags {
     pub protected: CachedFlag,
 }
 
+/// Latest net APY per vote account as apy-api served it, and when it last answered.
+#[derive(Default, Clone)]
+pub struct CachedNetApy {
+    pub values: HashMap<String, f64>,
+    pub last_success: Option<SystemTime>,
+}
+
 #[derive(Default)]
 pub struct Cache {
     pub bond_flags: CachedBondFlags,
+    pub net_apy: CachedNetApy,
     pub validators: CachedValidators,
     pub commissions: CachedCommissions,
     pub versions: CachedVersions,
@@ -125,6 +133,10 @@ impl Cache {
         let verified = self.bond_flags.verified.last_success?;
         let protected = self.bond_flags.protected.last_success?;
         Some(verified.min(protected))
+    }
+
+    pub fn net_apy_updated_at(&self) -> Option<SystemTime> {
+        self.net_apy.last_success
     }
 
     pub fn get_commissions(&self, vote_account: &String) -> Option<Vec<CommissionRecord>> {
@@ -237,6 +249,37 @@ fn resolve_flag(
     })
 }
 
+/// Bounded by age, not by a fallback count like the flags: this moves once per epoch, so reuse stays accurate until three days clear a real epoch.
+const MAX_NET_APY_REUSE: Duration = Duration::from_secs(3 * 24 * 3600);
+
+/// Never errors, unlike `resolve_flag`: a broken apy-api must not stop the validators cache refreshing, so it degrades to reusing and then to serving nothing.
+fn resolve_net_apy(
+    fetched: anyhow::Result<HashMap<String, f64>>,
+    last: CachedNetApy,
+) -> CachedNetApy {
+    let reason = match fetched {
+        Ok(values) if !values.is_empty() => {
+            return CachedNetApy {
+                values,
+                last_success: Some(SystemTime::now()),
+            }
+        }
+        Ok(_) => "apy-api lists no validator net APY".to_string(),
+        Err(err) => format!("Failed to load validator net APY: {err}"),
+    };
+
+    if last
+        .last_success
+        .is_some_and(|at| at.elapsed().is_ok_and(|age| age > MAX_NET_APY_REUSE))
+    {
+        error!("{reason}; the last known values outlived the epoch they describe, serving none");
+        return CachedNetApy::default();
+    }
+
+    error!("{reason}; reusing the last known values");
+    last
+}
+
 pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<()> {
     info!("Loading validators from DB");
     let warmup_timer = Instant::now();
@@ -251,18 +294,21 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
         .unwrap_or_default();
 
     // Scoped so the guard is released before the awaits below, not held to the end of the call.
-    let (scoring_url, bonds_url, last_flags) = {
+    let (scoring_url, bonds_url, apy_url, last_flags, last_net_apy) = {
         let ctx = context.read().await;
         (
             ctx.scoring_url.clone(),
             ctx.validator_bonds_api_url.clone(),
+            ctx.apy_api_url.clone(),
             ctx.cache.bond_flags.clone(),
+            ctx.cache.net_apy.clone(),
         )
     };
 
-    let (verified, protected) = tokio::join!(
+    let (verified, protected, net_apy) = tokio::join!(
         store::utils::load_verified_validators(&bonds_url),
         store::utils::load_protected_validators(&bonds_url),
+        store::utils::load_validator_net_apy(&apy_url),
     );
 
     let bond_flags = CachedBondFlags {
@@ -271,9 +317,12 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
     };
     context.write().await.cache.bond_flags = bond_flags.clone();
 
+    let net_apy = resolve_net_apy(net_apy, last_net_apy);
+
     let overlays = ValidatorOverlays {
         unique_delegators,
         take_rates,
+        net_apy: net_apy.values.clone(),
         verified: bond_flags.verified.vote_accounts,
         protected: bond_flags.protected.vote_accounts,
     };
@@ -287,11 +336,13 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
     )
     .await?;
 
+    // net_apy commits with the records carrying it, so its timestamp cannot outrun what is served.
     {
         let mut ctx = context.write().await;
         if let Some(refreshed) = refreshed {
             ctx.cache.per_epoch = Some(refreshed);
         }
+        ctx.cache.net_apy = net_apy;
         ctx.cache.validators.clone_from(&validators);
     }
 
@@ -588,5 +639,117 @@ mod tests {
             .is_err(),
             "a permanently broken upstream has to surface instead of freezing the list"
         );
+    }
+
+    fn net_apy(values: &[(&str, f64)], fetched_at: Option<SystemTime>) -> CachedNetApy {
+        CachedNetApy {
+            values: values
+                .iter()
+                .map(|(vote_account, apy)| (vote_account.to_string(), *apy))
+                .collect(),
+            last_success: fetched_at,
+        }
+    }
+
+    #[test]
+    fn a_successful_net_apy_answer_replaces_the_values_and_stamps_the_fetch_time() {
+        let resolved = resolve_net_apy(
+            Ok(HashMap::from([("voteTwo".to_string(), 0.09)])),
+            net_apy(&[("voteOne", 0.07)], Some(SystemTime::now())),
+        );
+
+        assert_eq!(
+            resolved.values,
+            HashMap::from([("voteTwo".to_string(), 0.09)])
+        );
+        assert!(
+            resolved.last_success.is_some(),
+            "consumers read this to tell a reused map from a fresh one"
+        );
+    }
+
+    #[test]
+    fn an_empty_net_apy_answer_reuses_the_last_known_values() {
+        let fetched_at = SystemTime::now();
+        let resolved = resolve_net_apy(
+            Ok(HashMap::new()),
+            net_apy(&[("voteOne", 0.07)], Some(fetched_at)),
+        );
+
+        assert_eq!(
+            resolved.values,
+            HashMap::from([("voteOne".to_string(), 0.07)]),
+            "apy-api knowing nobody is more likely an upstream fault than the truth"
+        );
+        assert_eq!(
+            resolved.last_success,
+            Some(fetched_at),
+            "a reused map has to keep reporting when upstream last answered"
+        );
+    }
+
+    #[test]
+    fn a_net_apy_fetch_failure_reuses_the_last_known_values_and_keeps_its_fetch_time() {
+        let fetched_at = SystemTime::now();
+        let resolved = resolve_net_apy(
+            Err(anyhow::anyhow!("apy api down")),
+            net_apy(&[("voteOne", 0.07)], Some(fetched_at)),
+        );
+
+        assert_eq!(
+            resolved.values,
+            HashMap::from([("voteOne".to_string(), 0.07)])
+        );
+        assert_eq!(resolved.last_success, Some(fetched_at));
+    }
+
+    #[test]
+    fn a_net_apy_fetch_failure_on_a_cold_start_serves_no_values_instead_of_failing() {
+        let resolved = resolve_net_apy(
+            Err(anyhow::anyhow!("apy api down")),
+            CachedNetApy::default(),
+        );
+
+        assert!(resolved.values.is_empty());
+        assert_eq!(
+            resolved.last_success, None,
+            "a cold process must report null rather than a fetch time it never had"
+        );
+    }
+
+    #[test]
+    fn net_apy_values_that_outlived_the_reuse_bound_are_dropped() {
+        let resolved = resolve_net_apy(
+            Err(anyhow::anyhow!("apy api down")),
+            net_apy(
+                &[("voteOne", 0.07)],
+                Some(SystemTime::now() - MAX_NET_APY_REUSE - Duration::from_secs(60)),
+            ),
+        );
+
+        assert!(
+            resolved.values.is_empty(),
+            "a permanently broken apy-api has to stop looking like current data"
+        );
+        assert_eq!(
+            resolved.last_success, None,
+            "with nothing served there is no fetch time to report"
+        );
+    }
+
+    #[test]
+    fn net_apy_values_inside_the_reuse_bound_survive_the_outage() {
+        let fetched_at = SystemTime::now() - MAX_NET_APY_REUSE + Duration::from_secs(60);
+        let resolved = resolve_net_apy(
+            Err(anyhow::anyhow!("apy api down")),
+            net_apy(&[("voteOne", 0.07)], Some(fetched_at)),
+        );
+
+        assert_eq!(
+            resolved.values,
+            HashMap::from([("voteOne".to_string(), 0.07)]),
+            "the rolling APY still describes the epoch it was computed for"
+        );
+        assert_eq!(resolved.last_success, Some(fetched_at));
     }
 }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -9,6 +9,7 @@ pub struct Context {
     pub blacklist_path: String,
     pub scoring_url: String,
     pub validator_bonds_api_url: String,
+    pub apy_api_url: String,
     pub cache: Cache,
 }
 
@@ -19,6 +20,7 @@ impl Context {
         blacklist_path: String,
         scoring_url: String,
         validator_bonds_api_url: String,
+        apy_api_url: String,
     ) -> anyhow::Result<Self> {
         Ok(Self {
             psql_client,
@@ -26,6 +28,7 @@ impl Context {
             blacklist_path,
             scoring_url,
             validator_bonds_api_url,
+            apy_api_url,
             cache: Cache::new(),
         })
     }

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -28,6 +28,8 @@ pub struct ResponseValidators {
     total_count: usize,
     /// When validator-bonds last answered for the `verified`/`protected` flags. Older than a few minutes means the flags are being reused because that API is failing.
     bond_flags_updated_at: Option<DateTime<Utc>>,
+    /// When apy-api last answered for `net_apy`. Older than a few minutes means those values are being reused because that API is failing.
+    net_apy_updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
@@ -67,6 +69,8 @@ pub enum OrderField {
     Credits,
     MarinadeScore,
     Apy,
+    /// Orders by the MEV-inclusive `net_apy`, which is what the validators list renders; `Apy` orders by the inflation-only `avg_apy`.
+    NetApy,
     Commission,
     Uptime,
     TakeRate,
@@ -172,6 +176,14 @@ fn get_field_extractor(order_field: OrderField) -> Box<dyn Fn(&ValidatorRecord) 
         }
         OrderField::Apy => Box::new(|a: &ValidatorRecord| {
             Decimal::from(to_fixed_for_sort(a.avg_apy.unwrap_or(0.0)))
+        }),
+        // Deliberately not to_fixed_for_sort: rounding a fraction-valued APY to 4 decimals is what
+        // collapses hundreds of validators into one bucket and makes the column look unsorted.
+        // Saturating up is safe because apy-api derives this as `ratio^n - 1` from a positive ratio, so an unrepresentable value is always the high end.
+        OrderField::NetApy => Box::new(|a: &ValidatorRecord| {
+            a.net_apy
+                .map(|net_apy| Decimal::from_f64_retain(net_apy).unwrap_or(Decimal::MAX))
+                .unwrap_or(Decimal::ZERO)
         }),
         OrderField::Commission => {
             Box::new(|a: &ValidatorRecord| Decimal::from(a.commission_max_observed.unwrap_or(100)))
@@ -343,12 +355,13 @@ pub async fn handler(
 
     let validators = get_validators(context.clone(), config).await;
 
-    let bond_flags_updated_at = context
-        .read()
-        .await
-        .cache
-        .bond_flags_updated_at()
-        .map(DateTime::<Utc>::from);
+    let (bond_flags_updated_at, net_apy_updated_at) = {
+        let cache = &context.read().await.cache;
+        (
+            cache.bond_flags_updated_at().map(DateTime::<Utc>::from),
+            cache.net_apy_updated_at().map(DateTime::<Utc>::from),
+        )
+    };
 
     Ok(match validators {
         Ok((validators, total_count)) => {
@@ -359,6 +372,7 @@ pub async fn handler(
                     validators_aggregated,
                     total_count,
                     bond_flags_updated_at,
+                    net_apy_updated_at,
                 }),
                 StatusCode::OK,
             )
@@ -492,6 +506,7 @@ mod tests {
             avg_apy: None,
             unique_delegators: None,
             avg_take_rate: None,
+            net_apy: None,
             incidents: Vec::new(),
             verified: false,
             protected: false,
@@ -738,5 +753,95 @@ mod tests {
         sort_validators(&mut validators, OrderField::Stake, &OrderDirection::DESC);
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["bbb", "aaa"]);
+    }
+
+    fn validator_with_net_apy(vote_account: &str, net_apy: Option<f64>) -> ValidatorRecord {
+        ValidatorRecord {
+            net_apy,
+            ..validator(vote_account, 100, vec![])
+        }
+    }
+
+    #[test]
+    fn sort_by_net_apy_separates_values_differing_below_four_decimals() {
+        // Both values round to the same 4-decimal bucket, and the higher one is alphabetically last,
+        // so rounding would hand back the reverse order instead of ordering by the real value.
+        assert_eq!(
+            to_fixed_for_sort(0.0712389),
+            to_fixed_for_sort(0.0712312),
+            "the values have to share a rounding bucket for this test to be about rounding"
+        );
+        let mut validators = vec![
+            validator_with_net_apy("aaa", Some(0.0712312)),
+            validator_with_net_apy("zzz", Some(0.0712389)),
+        ];
+        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::DESC);
+        let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+        assert_eq!(order, vec!["zzz", "aaa"]);
+    }
+
+    #[test]
+    fn sort_by_net_apy_orders_ascending_and_descending() {
+        let ordered = |direction| {
+            let mut validators = vec![
+                validator_with_net_apy("mid", Some(0.07)),
+                validator_with_net_apy("high", Some(0.09)),
+                validator_with_net_apy("low", Some(0.05)),
+            ];
+            sort_validators(&mut validators, OrderField::NetApy, &direction);
+            validators
+                .iter()
+                .map(|v| v.vote_account.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(ordered(OrderDirection::DESC), vec!["high", "mid", "low"]);
+        assert_eq!(ordered(OrderDirection::ASC), vec!["low", "mid", "high"]);
+    }
+
+    #[test]
+    fn sort_by_net_apy_puts_validators_without_a_value_last_when_descending() {
+        let mut validators = vec![
+            validator_with_net_apy("unknown", None),
+            validator_with_net_apy("known", Some(0.07)),
+        ];
+        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::DESC);
+        let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+        assert_eq!(order, vec!["known", "unknown"]);
+    }
+
+    #[test]
+    fn sort_by_net_apy_ranks_a_value_too_large_for_decimal_above_the_ordinary_ones() {
+        // apy-api drops only non-finite points, so an extreme bump can still serve a value that
+        // Decimal cannot hold; it must not land in the same bucket as a validator with no value.
+        assert!(
+            Decimal::from_f64_retain(1e30).is_none(),
+            "the value has to exceed Decimal's range for this test to be about saturation"
+        );
+        let mut validators = vec![
+            validator_with_net_apy("ordinary", Some(0.07)),
+            validator_with_net_apy("absurd", Some(1e30)),
+            validator_with_net_apy("unknown", None),
+        ];
+        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::DESC);
+        let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+        assert_eq!(order, vec!["absurd", "ordinary", "unknown"]);
+    }
+
+    #[test]
+    fn sort_by_net_apy_is_independent_of_the_inflation_only_apy() {
+        // avg_apy is inflation-only and orders differently; ordering by NetApy must ignore it.
+        let mut validators = vec![
+            ValidatorRecord {
+                avg_apy: Some(0.08),
+                ..validator_with_net_apy("lowNet", Some(0.05))
+            },
+            ValidatorRecord {
+                avg_apy: Some(0.04),
+                ..validator_with_net_apy("highNet", Some(0.11))
+            },
+        ];
+        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::DESC);
+        let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+        assert_eq!(order, vec!["highNet", "lowNet"]);
     }
 }

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use crate::context::WrappedContext;
@@ -106,11 +107,24 @@ pub struct GetValidatorsConfig {
     pub epochs: usize,
 }
 
+// One guard for the records and the timestamps: read apart, a warm landing in between makes the timestamps describe values this response does not carry.
 pub async fn get_validators(
     context: WrappedContext,
     config: GetValidatorsConfig,
-) -> anyhow::Result<(Vec<ValidatorRecord>, usize)> {
-    let validators = context.read().await.cache.get_validators();
+) -> anyhow::Result<(
+    Vec<ValidatorRecord>,
+    usize,
+    Option<DateTime<Utc>>,
+    Option<DateTime<Utc>>,
+)> {
+    let (validators, bond_flags_updated_at, net_apy_updated_at) = {
+        let cache = &context.read().await.cache;
+        (
+            cache.get_validators(),
+            cache.bond_flags_updated_at().map(DateTime::<Utc>::from),
+            cache.net_apy_updated_at().map(DateTime::<Utc>::from),
+        )
+    };
 
     let mut validators = filter_validators(validators, &config);
     let total_count = validators.len();
@@ -147,7 +161,7 @@ pub async fn get_validators(
         })
         .collect();
 
-    Ok((page, total_count))
+    Ok((page, total_count, bond_flags_updated_at, net_apy_updated_at))
 }
 
 // Tiebreak on vote_account: ties inherit HashMap iteration order otherwise, which changes
@@ -159,23 +173,32 @@ fn sort_validators(
 ) {
     let field_extractor = get_field_extractor(order_field);
     validators.sort_by(|a: &ValidatorRecord, b: &ValidatorRecord| {
-        let ord = match order_direction {
-            OrderDirection::ASC => field_extractor(a).cmp(&field_extractor(b)),
-            OrderDirection::DESC => field_extractor(b).cmp(&field_extractor(a)),
+        // A missing value is not a zero one, so it stays last whichever way the present ones go.
+        let ord = match (field_extractor(a), field_extractor(b)) {
+            (None, None) => Ordering::Equal,
+            (None, Some(_)) => Ordering::Greater,
+            (Some(_), None) => Ordering::Less,
+            (Some(x), Some(y)) => match order_direction {
+                OrderDirection::ASC => x.cmp(&y),
+                OrderDirection::DESC => y.cmp(&x),
+            },
         };
         ord.then_with(|| a.vote_account.cmp(&b.vote_account))
     });
 }
 
-fn get_field_extractor(order_field: OrderField) -> Box<dyn Fn(&ValidatorRecord) -> Decimal> {
+// None means the record has no value for the field, not that it has a zero one.
+type FieldExtractor = Box<dyn Fn(&ValidatorRecord) -> Option<Decimal>>;
+
+fn get_field_extractor(order_field: OrderField) -> FieldExtractor {
     match order_field {
-        OrderField::Stake => Box::new(|a: &ValidatorRecord| a.activated_stake),
-        OrderField::Credits => Box::new(|a: &ValidatorRecord| Decimal::from(a.credits)),
-        OrderField::MarinadeScore => {
-            Box::new(|a: &ValidatorRecord| Decimal::from(to_fixed_for_sort(a.score.unwrap_or(0.0))))
-        }
+        OrderField::Stake => Box::new(|a: &ValidatorRecord| Some(a.activated_stake)),
+        OrderField::Credits => Box::new(|a: &ValidatorRecord| Some(Decimal::from(a.credits))),
+        OrderField::MarinadeScore => Box::new(|a: &ValidatorRecord| {
+            Some(Decimal::from(to_fixed_for_sort(a.score.unwrap_or(0.0))))
+        }),
         OrderField::Apy => Box::new(|a: &ValidatorRecord| {
-            Decimal::from(to_fixed_for_sort(a.avg_apy.unwrap_or(0.0)))
+            Some(Decimal::from(to_fixed_for_sort(a.avg_apy.unwrap_or(0.0))))
         }),
         // Deliberately not to_fixed_for_sort: rounding a fraction-valued APY to 4 decimals is what
         // collapses hundreds of validators into one bucket and makes the column look unsorted.
@@ -183,16 +206,19 @@ fn get_field_extractor(order_field: OrderField) -> Box<dyn Fn(&ValidatorRecord) 
         OrderField::NetApy => Box::new(|a: &ValidatorRecord| {
             a.net_apy
                 .map(|net_apy| Decimal::from_f64_retain(net_apy).unwrap_or(Decimal::MAX))
-                .unwrap_or(Decimal::ZERO)
         }),
-        OrderField::Commission => {
-            Box::new(|a: &ValidatorRecord| Decimal::from(a.commission_max_observed.unwrap_or(100)))
-        }
+        OrderField::Commission => Box::new(|a: &ValidatorRecord| {
+            Some(Decimal::from(a.commission_max_observed.unwrap_or(100)))
+        }),
         OrderField::Uptime => Box::new(|a: &ValidatorRecord| {
-            Decimal::from(to_fixed_for_sort(a.avg_uptime_pct.unwrap_or(0.0)))
+            Some(Decimal::from(to_fixed_for_sort(
+                a.avg_uptime_pct.unwrap_or(0.0),
+            )))
         }),
         OrderField::TakeRate => Box::new(|a: &ValidatorRecord| {
-            Decimal::from(to_fixed_for_sort(a.avg_take_rate.unwrap_or(0.0)))
+            Some(Decimal::from(to_fixed_for_sort(
+                a.avg_take_rate.unwrap_or(0.0),
+            )))
         }),
     }
 }
@@ -355,16 +381,8 @@ pub async fn handler(
 
     let validators = get_validators(context.clone(), config).await;
 
-    let (bond_flags_updated_at, net_apy_updated_at) = {
-        let cache = &context.read().await.cache;
-        (
-            cache.bond_flags_updated_at().map(DateTime::<Utc>::from),
-            cache.net_apy_updated_at().map(DateTime::<Utc>::from),
-        )
-    };
-
     Ok(match validators {
-        Ok((validators, total_count)) => {
+        Ok((validators, total_count, bond_flags_updated_at, net_apy_updated_at)) => {
             let validators_aggregated = store::utils::aggregate_validators(&validators);
             warp::reply::with_status(
                 json(&ResponseValidators {
@@ -807,6 +825,37 @@ mod tests {
         sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::DESC);
         let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
         assert_eq!(order, vec!["known", "unknown"]);
+    }
+
+    #[test]
+    fn sort_by_net_apy_puts_validators_without_a_value_last_when_ascending() {
+        let mut validators = vec![
+            validator_with_net_apy("unknown", None),
+            validator_with_net_apy("known", Some(0.07)),
+        ];
+        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::ASC);
+        let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+        assert_eq!(
+            order,
+            vec!["known", "unknown"],
+            "no value must not read as the lowest APY"
+        );
+    }
+
+    #[test]
+    fn sort_by_net_apy_ranks_a_genuine_zero_above_no_value_when_ascending() {
+        // The no-value one is alphabetically first, so a collision would hand back the tiebreak order and the assert would not be about the collision at all.
+        let mut validators = vec![
+            validator_with_net_apy("aaaUnknown", None),
+            validator_with_net_apy("zzzZero", Some(0.0)),
+        ];
+        sort_validators(&mut validators, OrderField::NetApy, &OrderDirection::ASC);
+        let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+        assert_eq!(
+            order,
+            vec!["zzzZero", "aaaUnknown"],
+            "apy-api serves 0.0 for a full-commission validator and omits one with no comparable rate"
+        );
     }
 
     #[test]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -41,6 +41,13 @@ pub struct Params {
     )]
     validator_bonds_api_url: String,
 
+    #[structopt(
+        long = "apy-api-url",
+        env = "APY_API_URL",
+        default_value = "https://apy.marinade.finance"
+    )]
+    apy_api_url: String,
+
     #[structopt(long = "glossary-path")]
     glossary_path: String,
 
@@ -79,6 +86,7 @@ async fn main() -> anyhow::Result<()> {
         params.blacklist_path,
         params.scoring_url,
         params.validator_bonds_api_url,
+        params.apy_api_url,
     )?));
     cache::spawn_cache_warmer(context.clone());
     let cors = warp::cors()

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -332,6 +332,8 @@ pub struct ValidatorRecord {
     pub avg_apy: Option<f64>,
     pub unique_delegators: Option<u64>,
     pub avg_take_rate: Option<f64>,
+    /// Latest point of the apy-api 14-day rolling staker APY, a fraction like `avg_apy` but MEV-inclusive where `avg_apy` is inflation-only. Null for a validator apy-api has no rewards data for.
+    pub net_apy: Option<f64>,
     pub incidents: Vec<IncidentRecord>,
     #[serde(default)]
     pub verified: bool,

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -798,6 +798,41 @@ pub async fn load_protected_validators(base: &str) -> anyhow::Result<HashSet<Str
     .await
 }
 
+#[derive(serde::Deserialize)]
+struct LatestValidatorApyRecord {
+    apy: f64,
+}
+
+// `what` names the upstream in the status error; it is the only part of this that differs per caller.
+async fn fetch_json<T: serde::de::DeserializeOwned>(url: &str, what: &str) -> anyhow::Result<T> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(HTTP_TIMEOUT_S))
+        .build()?;
+    let resp = client.get(url).send().await?;
+    anyhow::ensure!(
+        resp.status().is_success(),
+        "{what} returned {}",
+        resp.status()
+    );
+    Ok(resp.json::<T>().await?)
+}
+
+// `base` is the apy-api base URL; the rolling window is fixed by that endpoint, so it is deliberately not a parameter here.
+pub async fn load_validator_net_apy(base: &str) -> anyhow::Result<HashMap<String, f64>> {
+    let url = format!(
+        "{}/v1/rolling-apy/validator/latest/all",
+        base.trim_end_matches('/')
+    );
+    Ok(fetch_json::<HashMap<String, LatestValidatorApyRecord>>(
+        &url,
+        "latest validator net APY endpoint",
+    )
+    .await?
+    .into_iter()
+    .map(|(vote_account, record)| (vote_account, record.apy))
+    .collect())
+}
+
 // `base` is the validator-bonds API base URL; `/validators/{flag}` is appended here.
 async fn load_validator_flag<T, F>(
     base: &str,
@@ -809,23 +844,16 @@ where
     F: FnOnce(T) -> Vec<String>,
 {
     let url = format!("{}/validators/{flag}", base.trim_end_matches('/'));
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(HTTP_TIMEOUT_S))
-        .build()?;
-    let resp = client.get(&url).send().await?;
-    anyhow::ensure!(
-        resp.status().is_success(),
-        "{flag} endpoint returned {}",
-        resp.status()
-    );
-    Ok(vote_accounts(resp.json::<T>().await?).into_iter().collect())
+    let resp = fetch_json::<T>(&url, &format!("{flag} endpoint")).await?;
+    Ok(vote_accounts(resp).into_iter().collect())
 }
 
-/// Per-record values the SQL query does not provide: the BigQuery-derived pair from the epoch cache, and the validator-bonds flags the caller resolved.
+/// Per-record values the SQL query does not provide: the BigQuery-derived pair from the epoch cache, the apy-api net APY, and the validator-bonds flags the caller resolved.
 #[derive(Default)]
 pub struct ValidatorOverlays {
     pub unique_delegators: HashMap<String, u64>,
     pub take_rates: HashMap<String, f64>,
+    pub net_apy: HashMap<String, f64>,
     pub verified: HashSet<String>,
     pub protected: HashSet<String>,
 }
@@ -1054,6 +1082,7 @@ pub async fn load_validators(
                     avg_apy: None,
                     unique_delegators: None,
                     avg_take_rate: None,
+                    net_apy: None,
                     incidents: Vec::new(),
                     verified: false,
                     protected: false,
@@ -1201,6 +1230,11 @@ pub async fn load_validators(
     log::info!("Updating take rates...");
     for (vote_account, record) in records.iter_mut() {
         record.avg_take_rate = overlays.take_rates.get(vote_account).copied();
+    }
+
+    log::info!("Updating net APY...");
+    for (vote_account, record) in records.iter_mut() {
+        record.net_apy = overlays.net_apy.get(vote_account).copied();
     }
 
     log::info!("Records prepared...");

--- a/store/tests/store_client_columns_sql.rs
+++ b/store/tests/store_client_columns_sql.rs
@@ -410,6 +410,7 @@ async fn load_validators_labels_the_record_and_its_epoch_stats() {
     let overlays = ValidatorOverlays {
         verified: HashSet::from(["voteReported".to_string()]),
         protected: HashSet::from(["voteRegistered".to_string()]),
+        net_apy: HashMap::from([("voteRegistered".to_string(), 0.0712389)]),
         ..Default::default()
     };
     let validators = load_validators(&client, unreachable_scoring_url, 1, 1, &overlays)
@@ -429,6 +430,17 @@ async fn load_validators_labels_the_record_and_its_epoch_stats() {
         "the two flags are stamped independently"
     );
     assert!(!validators.get("voteRegistered").unwrap().verified);
+
+    assert_eq!(
+        validators.get("voteRegistered").unwrap().net_apy,
+        Some(0.0712389),
+        "the apy-api value must reach the record unrounded"
+    );
+    assert_eq!(
+        validators.get("voteReported").unwrap().net_apy,
+        None,
+        "a vote account apy-api has no value for stays null instead of sorting as zero-ish data"
+    );
 
     for (vote_account, expected) in [
         ("voteRegistered", "Frankendancer + JitoBAM"),

--- a/store/tests/validator_net_apy.rs
+++ b/store/tests/validator_net_apy.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+use store::utils::load_validator_net_apy;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+async fn net_apy_stub(status_line: &'static str, body: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            let (socket, _) = listener.accept().await.unwrap();
+            let mut stream = BufReader::new(socket);
+            let mut request_line = Vec::new();
+            stream.read_until(b'\n', &mut request_line).await.unwrap();
+            let request_line = String::from_utf8_lossy(&request_line).to_string();
+            assert!(
+                request_line.contains("/v1/rolling-apy/validator/latest/all"),
+                "the stub answers the latest-net-APY endpoint only: {request_line}"
+            );
+            assert!(
+                !request_line.contains("window="),
+                "the window is fixed by apy-api, so this loader must not send one: {request_line}"
+            );
+            let response = format!(
+                "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        }
+    });
+    format!("http://127.0.0.1:{port}")
+}
+
+#[tokio::test]
+async fn the_apy_is_taken_at_full_precision_and_keyed_by_vote_account() {
+    let base = net_apy_stub(
+        "HTTP/1.1 200 OK",
+        r#"{"voteOne":{"apy":0.07123456789,"time":1735689600},"voteTwo":{"apy":0.0712345,"time":1735689600}}"#,
+    )
+    .await;
+
+    assert_eq!(
+        load_validator_net_apy(&base).await.unwrap(),
+        HashMap::from([
+            ("voteOne".to_string(), 0.07123456789),
+            ("voteTwo".to_string(), 0.0712345),
+        ]),
+        "values must arrive unrounded, otherwise near-equal validators tie and the sort looks broken"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_answer_is_reported_as_an_answer() {
+    let base = net_apy_stub("HTTP/1.1 200 OK", "{}").await;
+
+    assert_eq!(
+        load_validator_net_apy(&base).await.unwrap(),
+        HashMap::new(),
+        "an empty map is a successful answer; only the caller decides whether to act on it"
+    );
+}
+
+#[tokio::test]
+async fn a_failing_endpoint_is_an_error_not_an_empty_map() {
+    let base = net_apy_stub("HTTP/1.1 503 Service Unavailable", "{}").await;
+
+    assert!(
+        load_validator_net_apy(&base).await.is_err(),
+        "a failure must not be indistinguishable from apy-api knowing nobody"
+    );
+}


### PR DESCRIPTION
Processing apy-api endpoint that FE needs to work smoothly in the explorer page.

- https://github.com/marinade-finance/apy-api/pull/69
- https://github.com/marinade-finance/ops-infra/pull/2684

----

Serve MEV-inclusive net APY on the validators list and let clients sort by it, so Explore can rank validators by the number it shows.

- Add `net_apy` from apy-api's fixed 14-day rolling staker APY, which counts MEV where `avg_apy` is inflation-only
- Add a `NetApy` order field comparing at full precision, since the shared 4-decimal rounding buckets fraction-valued APYs and leaves the column looking unsorted
- Reuse the last known values when apy-api fails, bounded to three days, so a broken upstream neither blocks the cache refresh nor freezes APYs indefinitely
- Report `net_apy_updated_at` with the records it describes, so clients can tell a reused map from a fresh one
- Add `APY_API_URL` for the new upstream, defaulting to production
- @dualisimo expecting it requires the marinade-web counterparts: `latest/all` ships on apy-api's `sort-by-mev-net-apy` branch, and Explore still sorts by the inflation-only `Apy`, so users see no change until both land


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validator net APY data to validator listings.
  * Added sorting by net APY, preserving decimal precision and placing missing values last.
  * Added net APY freshness timestamps to validator responses.
  * Validator records now include optional MEV-inclusive, 14-day rolling staker APY.

* **Bug Fixes**
  * Recent APY values are retained during temporary service failures.
  * APY data older than three days is discarded to prevent stale results.

* **Tests**
  * Added coverage for successful, empty, failed, expired, and unavailable APY responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->