### PR TITLE
[GEN-8245][GEN-8658] fixing not available api processing 

### DIFF
--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -196,16 +196,16 @@ fn resolve_flag(
     flag: &str,
     fetched: anyhow::Result<HashSet<String>>,
     last: CachedFlag,
-) -> anyhow::Result<CachedFlag> {
+) -> CachedFlag {
     // An empty list is more often an upstream fault than the truth, so it is believed only once it
     // survives the same bound a failure gets.
     let err = match fetched {
         Ok(vote_accounts) if !vote_accounts.is_empty() => {
-            return Ok(CachedFlag {
+            return CachedFlag {
                 vote_accounts,
                 consecutive_fallbacks: 0,
                 last_success: Some(SystemTime::now()),
-            })
+            }
         }
         Ok(_) => None,
         Err(err) => Some(err),
@@ -214,12 +214,18 @@ fn resolve_flag(
     let consecutive_fallbacks = last.consecutive_fallbacks + 1;
     if last.vote_accounts.is_empty() || consecutive_fallbacks >= MAX_FLAG_FALLBACK_CYCLES {
         return match err {
-            None => Ok(CachedFlag {
+            None => CachedFlag {
                 vote_accounts: HashSet::new(),
                 consecutive_fallbacks: 0,
                 last_success: Some(SystemTime::now()),
-            }),
-            Some(err) => Err(err),
+            },
+            Some(err) => {
+                error!("Failed to load {flag} validators, reporting the flags as unknown: {err}");
+                // A default's `last_success: None` is what surfaces the outage on the response, as
+                // a null bond_flags_updated_at. Failing here instead would strand the whole
+                // validators load, which readiness gates on.
+                CachedFlag::default()
+            }
         };
     }
 
@@ -231,10 +237,10 @@ fn resolve_flag(
             "Failed to load {flag} validators, reusing the last known list ({consecutive_fallbacks}/{MAX_FLAG_FALLBACK_CYCLES}): {err}"
         ),
     }
-    Ok(CachedFlag {
+    CachedFlag {
         consecutive_fallbacks,
         ..last
-    })
+    }
 }
 
 pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<()> {
@@ -266,8 +272,8 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
     );
 
     let bond_flags = CachedBondFlags {
-        verified: resolve_flag("verified", verified, last_flags.verified)?,
-        protected: resolve_flag("protected", protected, last_flags.protected)?,
+        verified: resolve_flag("verified", verified, last_flags.verified),
+        protected: resolve_flag("protected", protected, last_flags.protected),
     };
     context.write().await.cache.bond_flags = bond_flags.clone();
 
@@ -486,8 +492,7 @@ mod tests {
             "protected",
             Ok(HashSet::from(["voteTwo".to_string()])),
             flag(&["voteOne"], 2),
-        )
-        .unwrap();
+        );
 
         assert_eq!(
             resolved.vote_accounts,
@@ -502,8 +507,7 @@ mod tests {
 
     #[test]
     fn an_empty_answer_holds_the_last_known_list_until_it_repeats() {
-        let resolved =
-            resolve_flag("protected", Ok(HashSet::new()), flag(&["voteOne"], 1)).unwrap();
+        let resolved = resolve_flag("protected", Ok(HashSet::new()), flag(&["voteOne"], 1));
 
         assert_eq!(
             resolved.vote_accounts,
@@ -519,8 +523,7 @@ mod tests {
             "protected",
             Ok(HashSet::new()),
             flag(&["voteOne"], MAX_FLAG_FALLBACK_CYCLES - 1),
-        )
-        .unwrap();
+        );
 
         assert!(
             resolved.vote_accounts.is_empty(),
@@ -532,8 +535,7 @@ mod tests {
 
     #[test]
     fn an_empty_answer_on_a_cold_start_is_taken_at_face_value() {
-        let resolved =
-            resolve_flag("protected", Ok(HashSet::new()), CachedFlag::default()).unwrap();
+        let resolved = resolve_flag("protected", Ok(HashSet::new()), CachedFlag::default());
 
         assert!(
             resolved.vote_accounts.is_empty(),
@@ -552,8 +554,7 @@ mod tests {
                 last_success: Some(fetched_at),
                 ..flag(&["voteOne"], 1)
             },
-        )
-        .unwrap();
+        );
 
         assert_eq!(resolved.vote_accounts, flag(&["voteOne"], 0).vote_accounts);
         assert_eq!(resolved.consecutive_fallbacks, 2);
@@ -565,28 +566,35 @@ mod tests {
     }
 
     #[test]
-    fn a_fetch_failure_with_nothing_to_reuse_propagates() {
+    fn a_fetch_failure_with_nothing_to_reuse_reports_unknown() {
+        let resolved = resolve_flag(
+            "protected",
+            Err(anyhow::anyhow!("bonds api down")),
+            CachedFlag::default(),
+        );
+
+        assert!(resolved.vote_accounts.is_empty());
         assert!(
-            resolve_flag(
-                "protected",
-                Err(anyhow::anyhow!("bonds api down")),
-                CachedFlag::default(),
-            )
-            .is_err(),
-            "a cold process has no list to fall back to"
+            resolved.last_success.is_none(),
+            "a cold process has no list to fall back to, and must not claim upstream answered"
         );
     }
 
     #[test]
     fn the_fallback_is_bounded() {
+        let resolved = resolve_flag(
+            "protected",
+            Err(anyhow::anyhow!("bonds api down")),
+            flag(&["voteOne"], MAX_FLAG_FALLBACK_CYCLES - 1),
+        );
+
         assert!(
-            resolve_flag(
-                "protected",
-                Err(anyhow::anyhow!("bonds api down")),
-                flag(&["voteOne"], MAX_FLAG_FALLBACK_CYCLES - 1),
-            )
-            .is_err(),
+            resolved.vote_accounts.is_empty(),
             "a permanently broken upstream has to surface instead of freezing the list"
+        );
+        assert!(
+            resolved.last_success.is_none(),
+            "dropping the list without dropping its fetch time would read as a fresh empty list"
         );
     }
 }

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -221,9 +221,7 @@ fn resolve_flag(
             },
             Some(err) => {
                 error!("Failed to load {flag} validators, reporting the flags as unknown: {err}");
-                // A default's `last_success: None` is what surfaces the outage on the response, as
-                // a null bond_flags_updated_at. Failing here instead would strand the whole
-                // validators load, which readiness gates on.
+                // Erroring instead would strand the validators load, which readiness gates on.
                 CachedFlag::default()
             }
         };
@@ -275,13 +273,11 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
         verified: resolve_flag("verified", verified, last_flags.verified),
         protected: resolve_flag("protected", protected, last_flags.protected),
     };
-    context.write().await.cache.bond_flags = bond_flags.clone();
-
     let overlays = ValidatorOverlays {
         unique_delegators,
         take_rates,
-        verified: bond_flags.verified.vote_accounts,
-        protected: bond_flags.protected.vote_accounts,
+        verified: bond_flags.verified.vote_accounts.clone(),
+        protected: bond_flags.protected.vote_accounts.clone(),
     };
 
     let validators = store::utils::load_validators(
@@ -293,17 +289,19 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
     )
     .await?;
 
+    let validators_len = validators.len();
     {
+        // Flags publish with the records they stamped, so their timestamp cannot outrun them.
         let mut ctx = context.write().await;
         if let Some(refreshed) = refreshed {
             ctx.cache.per_epoch = Some(refreshed);
         }
-        ctx.cache.validators.clone_from(&validators);
+        ctx.cache.bond_flags = bond_flags;
+        ctx.cache.validators = validators;
     }
 
     info!(
-        "Loaded {} validators to cache in {} ms",
-        validators.len(),
+        "Loaded {validators_len} validators to cache in {} ms",
         warmup_timer.elapsed().as_millis()
     );
 
@@ -316,15 +314,10 @@ pub async fn warm_commissions_cache(context: &WrappedContext) -> anyhow::Result<
         store::utils::load_commissions(&context.read().await.psql_client, DEFAULT_CACHE_EPOCHS)
             .await?;
 
-    context
-        .write()
-        .await
-        .cache
-        .commissions
-        .clone_from(&commissions);
+    let commissions_len = commissions.len();
+    context.write().await.cache.commissions = commissions;
     info!(
-        "Loaded {} commissions to cache in {} ms",
-        commissions.len(),
+        "Loaded {commissions_len} commissions to cache in {} ms",
         warmup_timer.elapsed().as_millis()
     );
 
@@ -337,10 +330,10 @@ pub async fn warm_versions_cache(context: &WrappedContext) -> anyhow::Result<()>
         store::utils::load_versions(&context.read().await.psql_client, DEFAULT_CACHE_EPOCHS)
             .await?;
 
-    context.write().await.cache.versions.clone_from(&versions);
+    let versions_len = versions.len();
+    context.write().await.cache.versions = versions;
     info!(
-        "Loaded {} versions to cache in {} ms",
-        versions.len(),
+        "Loaded {versions_len} versions to cache in {} ms",
         warmup_timer.elapsed().as_millis()
     );
 
@@ -352,10 +345,10 @@ pub async fn warm_uptimes_cache(context: &WrappedContext) -> anyhow::Result<()> 
     let uptimes =
         store::utils::load_uptimes(&context.read().await.psql_client, DEFAULT_CACHE_EPOCHS).await?;
 
-    context.write().await.cache.uptimes.clone_from(&uptimes);
+    let uptimes_len = uptimes.len();
+    context.write().await.cache.uptimes = uptimes;
     info!(
-        "Loaded {} uptimes to cache in {} ms",
-        uptimes.len(),
+        "Loaded {uptimes_len} uptimes to cache in {} ms",
         warmup_timer.elapsed().as_millis()
     );
 
@@ -382,6 +375,22 @@ pub async fn warm_scores_cache(context: &WrappedContext) -> anyhow::Result<()> {
 
     let last_scoring_run =
         store::utils::load_last_scoring_run(&context.read().await.psql_client).await?;
+    let scoring_run_id = last_scoring_run.as_ref().map(|run| run.scoring_run_id);
+    let cached_scoring_run_id = context
+        .read()
+        .await
+        .cache
+        .validators_single_run_scores
+        .scoring_run
+        .as_ref()
+        .map(|run| run.scoring_run_id);
+
+    // The id is a max over the whole table, so a run backfilling an older epoch bumps it too.
+    if scoring_run_id.is_some() && scoring_run_id == cached_scoring_run_id {
+        info!("Scoring run unchanged, keeping the cached scores");
+        return Ok(());
+    }
+
     let scores = match &last_scoring_run {
         Some(scoring_run) => {
             store::utils::load_scores(
@@ -395,39 +404,26 @@ pub async fn warm_scores_cache(context: &WrappedContext) -> anyhow::Result<()> {
     let multi_run_scores =
         store::scoring::load_all_scores(&context.read().await.psql_client).await?;
 
-    let last_scoring_run =
-        store::utils::load_last_scoring_run(&context.read().await.psql_client).await?;
-
     let multi_run_scoring_runs =
         store::scoring::load_scoring_runs(&context.read().await.psql_client).await?;
 
     let scores_len = scores.len();
     let multi_run_scores_len: usize = multi_run_scores.values().map(|v| v.len()).sum();
 
-    context
-        .write()
-        .await
-        .cache
-        .validators_single_run_scores
-        .clone_from(&CachedSingleRunScores {
-            scoring_run: last_scoring_run,
-            scores,
-        });
+    context.write().await.cache.validators_single_run_scores = CachedSingleRunScores {
+        scoring_run: last_scoring_run,
+        scores,
+    };
     info!(
         "Loaded {} single run scores to cache in {} ms",
         scores_len,
         warmup_timer.elapsed().as_millis()
     );
 
-    context
-        .write()
-        .await
-        .cache
-        .validators_multi_run_scores
-        .clone_from(&CachedMultiRunScores {
-            scoring_runs: Some(multi_run_scoring_runs),
-            scores: multi_run_scores,
-        });
+    context.write().await.cache.validators_multi_run_scores = CachedMultiRunScores {
+        scoring_runs: Some(multi_run_scoring_runs),
+        scores: multi_run_scores,
+    };
     info!(
         "Loaded {} multiple run scores to cache in {} ms",
         multi_run_scores_len,

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -18,7 +18,7 @@ use std::{
 };
 use tokio::join;
 use tokio::sync::Semaphore;
-use tokio_postgres::{types::ToSql, Client};
+use tokio_postgres::{types::ToSql, Client, GenericClient};
 
 /// Default number of recent epochs the API loads/serves (validators, uptimes, events, ...).
 pub const DEFAULT_CACHE_EPOCHS: u64 = 80;
@@ -73,6 +73,10 @@ impl<'a> InsertQueryCombiner<'a> {
     }
 
     pub async fn execute(&self, client: &mut Client) -> anyhow::Result<Option<u64>> {
+        self.execute_in(&*client).await
+    }
+
+    pub async fn execute_in(&self, client: &impl GenericClient) -> anyhow::Result<Option<u64>> {
         if self.insertions == 0 {
             return Ok(None);
         }
@@ -1840,7 +1844,10 @@ pub async fn store_scoring(
     component_weights: Vec<f64>,
     scores: Vec<ValidatorScoringCsvRow>,
 ) -> anyhow::Result<()> {
-    let scoring_run_result = psql_client
+    // One transaction, so MAX(scoring_run_id) never becomes visible ahead of that run's scores.
+    let tx = psql_client.transaction().await?;
+
+    let scoring_run_result = tx
         .query_one(
             "INSERT INTO scoring_runs (created_at, epoch, components, component_weights, ui_id)
             VALUES (now(), $1, $2, $3, $4) RETURNING scoring_run_id;",
@@ -1936,8 +1943,10 @@ pub async fn store_scoring(
             ];
             query.add(&mut params);
         }
-        query.execute(psql_client).await?;
+        query.execute_in(&tx).await?;
     }
+
+    tx.commit().await?;
 
     Ok(())
 }

--- a/store/tests/store_scoring_atomicity_sql.rs
+++ b/store/tests/store_scoring_atomicity_sql.rs
@@ -1,0 +1,130 @@
+mod common;
+
+use common::{migrated_client, skip_without_database, POSTGRES_URL_ENV};
+use rust_decimal::Decimal;
+use store::dto::ValidatorScoringCsvRow;
+use store::utils::{load_last_scoring_run, load_scores, store_scoring};
+use tokio_postgres::{Client, NoTls};
+
+fn score_row(vote_account: &str, rank: i32) -> ValidatorScoringCsvRow {
+    ValidatorScoringCsvRow {
+        vote_account: vote_account.to_string(),
+        score: 1.0,
+        rank,
+        vemnde_votes: Decimal::ZERO,
+        msol_votes: Decimal::ZERO,
+        ui_hints: String::new(),
+        eligible_stake_algo: true,
+        eligible_stake_vemnde: true,
+        eligible_stake_msol: true,
+        normalized_dc_concentration: 1.0,
+        normalized_grace_skip_rate: 1.0,
+        normalized_adjusted_credits: 1.0,
+        avg_dc_concentration: 1.0,
+        avg_grace_skip_rate: 1.0,
+        avg_adjusted_credits: 1.0,
+        rank_dc_concentration: rank,
+        rank_grace_skip_rate: rank,
+        rank_adjusted_credits: rank,
+        target_stake_algo: Decimal::ZERO,
+        target_stake_vemnde: Decimal::ZERO,
+        target_stake_msol: Decimal::ZERO,
+    }
+}
+
+async fn observer(schema: &str) -> Client {
+    let url = std::env::var(POSTGRES_URL_ENV).unwrap();
+    let (client, connection) = tokio_postgres::connect(&url, NoTls).await.unwrap();
+    tokio::spawn(async move {
+        if let Err(err) = connection.await {
+            panic!("postgres connection error: {err}");
+        }
+    });
+    client
+        .batch_execute(&format!("SET search_path TO {schema}"))
+        .await
+        .unwrap();
+    client
+}
+
+// `scores` is the only table this test locks, so any other backend parked on a lock is the writer
+// having already run its scoring_runs INSERT. Keyed on the wait rather than on
+// pg_stat_activity.query, which still names the previous statement while the next one parses.
+async fn await_writer_blocked_on_scores(observer: &Client) {
+    for _ in 0..100 {
+        let blocked: i64 = observer
+            .query_one(
+                "SELECT count(*) FROM pg_stat_activity
+                WHERE datname = current_database()
+                  AND wait_event_type = 'Lock'
+                  AND pid <> pg_backend_pid()",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        if blocked > 0 {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!(
+        "the writer never reached its scores INSERT, so the assertion below would prove nothing"
+    );
+}
+
+#[tokio::test]
+async fn a_scoring_run_stays_invisible_until_its_scores_are_committed() {
+    let schema = "ds_test_store_scoring_atomicity";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+    let observer = observer(schema).await;
+
+    observer
+        .batch_execute("BEGIN; LOCK TABLE scores IN ACCESS EXCLUSIVE MODE")
+        .await
+        .unwrap();
+
+    let writer = tokio::spawn(async move {
+        store_scoring(
+            &mut client,
+            700,
+            "atomicity".to_string(),
+            vec!["COMMISSION_ADJUSTED_CREDITS"],
+            vec![1.0],
+            vec![score_row("voteOne", 1), score_row("voteTwo", 2)],
+        )
+        .await
+        .unwrap();
+        client
+    });
+
+    await_writer_blocked_on_scores(&observer).await;
+    assert!(
+        load_last_scoring_run(&observer).await.unwrap().is_none(),
+        "the cache gate reads MAX(scoring_run_id), so the run must not surface before its scores"
+    );
+
+    observer.batch_execute("COMMIT").await.unwrap();
+    let client = writer.await.unwrap();
+
+    let run = load_last_scoring_run(&observer)
+        .await
+        .unwrap()
+        .expect("the run surfaces once committed");
+    assert_eq!(
+        load_scores(&observer, run.scoring_run_id)
+            .await
+            .unwrap()
+            .len(),
+        2,
+        "the run and every one of its scores become visible together"
+    );
+
+    client
+        .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
Adding fixes for `/protected` processing and performance cache reloading

---

Keep the validators API serving while validator-bonds is unavailable, and stop the cache warmer repeating work that has not changed.

- Degrade the bonds `verified`/`protected` flags to unknown instead of failing the whole validators load, so a broken bonds API no longer keeps the API out of readiness
- Reuse cached scores when the scoring run id has not moved, since rebuilding every run each cycle was the warmer's dominant cost
- Wrap the scoring upload in a transaction so a run id is never readable before its scores, which the new gate would otherwise pin until the next run
- Publish the bond flags together with the validator records they stamped, so `bond_flags_updated_at` cannot claim a freshness the records lack
- Add a regression test for that atomicity, since a second replica reads scores while an upload is in flight
- Replace the cache's `clone_from` copies with moves, dropping a deep copy of every cached collection under the write lock
