### PR TITLE
[GEN-8245][events] keep direct-staking PSR out of validator settlement totals

### DIFF
--- a/collect/src/validators_events.rs
+++ b/collect/src/validators_events.rs
@@ -78,10 +78,13 @@ async fn query_validator_settlements(
     let project_table_name = format!("{GOOGLE_BQ_PROJECT_ID}.{GOOGLE_BQ_DATASET}.{table_name}");
     info!("Querying BigQuery for settlements from epoch {from_epoch} from project table {project_table_name}");
 
+    // Direct-staking PSR is charged to the same bonds and shares these tables, and it is attributed
+    // per staker elsewhere; summed in here it would silently inflate a validator's PSR totals.
     let query = format!(
         "SELECT epoch, vote_account, reason, meta, CAST(SUM(amount) AS INT64) AS amount \
          FROM `{project_table_name}` \
          WHERE epoch >= {from_epoch} AND vote_account IS NOT NULL \
+           AND product <> 'single-validator' \
          GROUP BY epoch, vote_account, reason, meta \
          ORDER BY epoch DESC"
     );


### PR DESCRIPTION
Direct staking is charged to the same two bonds and lands in the same BigQuery tables, tagged product='single-validator'. The events query sums by (epoch, vote_account, reason, meta), so without the predicate those amounts merge into a validator's SAM PSR totals with nothing to tell them apart afterwards.

Deploy only after stakes-etl migrations/005 is applied; until then the column does not exist and the collector fails on the query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated BigQuery settlement results to exclude entries for single-validator products while preserving existing epoch and vote-account filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->