### PR TITLE
[GEN-8714][api] take rate implementation

### DIFF
--- a/api.md
+++ b/api.md
@@ -8,7 +8,7 @@ Query parameters:
 - `query_marinade_score` - Optional, if set, filters validators based on them having a positive score from Marinade.
 - `query_marinade_stake` - Optional, if set, filters validators based on them having stake from Marinade.
 - `query_with_names` - Optional, if set, filters validators based on them having/not having `info_name`.
-- `order_field` - Default `Stake`, possible values: `Stake`, `Credits`, `MndeVotes`.
+- `order_field` - Default `Stake`, possible values: `Stake`, `Credits`, `MarinadeScore`, `Apy`, `NetApy`, `Commission`, `Uptime`, `TakeRate`, `ExpectedTakeRate`.
 - `order_direction` - Default `DESC`, possible values: `ASC`, `DESC`.
 - `offset` - Default `0`.
 - `limit` - Default `100`.

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -14,7 +14,7 @@ use store::dto::{
 };
 use tokio::time::{sleep, timeout, Duration, Instant};
 
-use store::utils::ValidatorOverlays;
+use store::utils::{TakeRates, ValidatorOverlays};
 
 pub(crate) use store::utils::DEFAULT_CACHE_EPOCHS;
 pub(crate) const DEFAULT_COMPUTING_EPOCHS: u64 = 20;
@@ -96,7 +96,7 @@ impl ReadyFlag {
 pub struct PerEpochCache {
     pub epoch: u64,
     pub unique_delegators: HashMap<String, u64>,
-    pub take_rates: HashMap<String, f64>,
+    pub take_rates: TakeRates,
 }
 
 impl PerEpochCache {

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -75,6 +75,8 @@ pub enum OrderField {
     Commission,
     Uptime,
     TakeRate,
+    /// Orders by the commission-derived `expected_take_rate`; `TakeRate` orders by the measured `avg_take_rate`.
+    ExpectedTakeRate,
 }
 
 #[derive(Deserialize, Serialize, Debug, utoipa::ToSchema)]
@@ -222,10 +224,16 @@ fn get_field_extractor(order_field: OrderField) -> FieldExtractor {
                 a.avg_uptime_pct.and_then(to_fixed_for_sort).unwrap_or(0),
             ))
         },
+        // Same fraction-rounding trap as NetApy, but a degenerate value sinks here rather than saturating up: a take rate has no natural high end to saturate towards.
         OrderField::TakeRate => |a: &ValidatorRecord| {
             a.avg_take_rate
-                .and_then(to_fixed_for_sort)
-                .map(Decimal::from)
+                .filter(|rate| *rate >= 0.0)
+                .and_then(Decimal::from_f64_retain)
+        },
+        OrderField::ExpectedTakeRate => |a: &ValidatorRecord| {
+            a.expected_take_rate
+                .filter(|rate| *rate >= 0.0)
+                .and_then(Decimal::from_f64_retain)
         },
     }
 }
@@ -531,6 +539,7 @@ mod tests {
             avg_apy: None,
             unique_delegators: None,
             avg_take_rate: None,
+            expected_take_rate: None,
             net_apy: None,
             incidents: Vec::new(),
             verified: false,
@@ -801,7 +810,35 @@ mod tests {
             ("take_rate", OrderField::TakeRate, |r, v| {
                 r.avg_take_rate = v
             }),
+            (
+                "expected_take_rate",
+                OrderField::ExpectedTakeRate,
+                |r, v| r.expected_take_rate = v,
+            ),
         ]
+    }
+
+    #[test]
+    fn sort_orders_the_two_take_rates_independently() {
+        // Measured and expected disagree by design, so one must not be sorting by the other.
+        let validators = sort_validators(
+            vec![
+                ValidatorRecord {
+                    avg_take_rate: Some(0.0),
+                    expected_take_rate: Some(0.06),
+                    ..validator("aaa_idle", 100, vec![])
+                },
+                ValidatorRecord {
+                    avg_take_rate: Some(0.05),
+                    expected_take_rate: Some(0.05),
+                    ..validator("bbb_busy", 100, vec![])
+                },
+            ],
+            OrderField::ExpectedTakeRate,
+            &OrderDirection::ASC,
+        );
+        let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+        assert_eq!(order, vec!["bbb_busy", "aaa_idle"]);
     }
 
     fn validator_with_net_apy(vote_account: &str, net_apy: Option<f64>) -> ValidatorRecord {
@@ -895,6 +932,40 @@ mod tests {
             );
             let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
             assert_eq!(order, vec!["zzz_zero", "aaa_degenerate"], "{degenerate}");
+        }
+    }
+
+    #[test]
+    fn sort_separates_take_rates_differing_below_four_decimals() {
+        // Mainnet's actual collision: 5% inflation commission with 0 bps MEV against the same with 10 bps.
+        const LOWER: f64 = 0.13635962633635962;
+        const HIGHER: f64 = 0.13638048552938048;
+        assert_eq!(
+            to_fixed_for_sort(LOWER),
+            to_fixed_for_sort(HIGHER),
+            "the values have to share a rounding bucket for this test to be about rounding"
+        );
+        let fields: [(&str, OrderField, FieldSetter); 2] = [
+            ("take_rate", OrderField::TakeRate, |r, v| {
+                r.avg_take_rate = v
+            }),
+            (
+                "expected_take_rate",
+                OrderField::ExpectedTakeRate,
+                |r, v| r.expected_take_rate = v,
+            ),
+        ];
+        for (label, field, set) in fields {
+            let validators = sort_validators(
+                vec![
+                    with_field("aaa_lower", set, Some(LOWER)),
+                    with_field("zzz_higher", set, Some(HIGHER)),
+                ],
+                field,
+                &OrderDirection::DESC,
+            );
+            let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+            assert_eq!(order, vec!["zzz_higher", "aaa_lower"], "{label}");
         }
     }
 

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -206,9 +206,12 @@ fn get_field_extractor(order_field: OrderField) -> FieldExtractor {
         OrderField::MarinadeScore => {
             |a: &ValidatorRecord| a.score.and_then(to_fixed_for_sort).map(Decimal::from)
         }
-        OrderField::Apy => {
-            |a: &ValidatorRecord| a.avg_apy.and_then(to_fixed_for_sort).map(Decimal::from)
-        }
+        // Shares NetApy's `ratio^n - 1` derivation but is computed here instead of served by apy-api, so an unrepresentable value sinks rather than being crowned.
+        OrderField::Apy => |a: &ValidatorRecord| {
+            a.avg_apy
+                .filter(|apy| *apy >= 0.0)
+                .and_then(Decimal::from_f64_retain)
+        },
         // Deliberately not to_fixed_for_sort: rounding a fraction-valued APY to 4 decimals is what
         // collapses hundreds of validators into one bucket and makes the column look unsorted.
         // Saturating up is safe because apy-api derives this as `ratio^n - 1` from a positive ratio, so an unrepresentable value is always the high end.
@@ -818,6 +821,21 @@ mod tests {
         ]
     }
 
+    // Fields keyed through Decimal::from_f64_retain rather than to_fixed_for_sort, so they share a degenerate-value and a sub-bucket contract.
+    fn precise_fraction_fields() -> Vec<(&'static str, OrderField, FieldSetter)> {
+        vec![
+            ("apy", OrderField::Apy, |r, v| r.avg_apy = v),
+            ("take_rate", OrderField::TakeRate, |r, v| {
+                r.avg_take_rate = v
+            }),
+            (
+                "expected_take_rate",
+                OrderField::ExpectedTakeRate,
+                |r, v| r.expected_take_rate = v,
+            ),
+        ]
+    }
+
     #[test]
     fn sort_orders_the_two_take_rates_independently() {
         // Measured and expected disagree by design, so one must not be sorting by the other.
@@ -920,24 +938,29 @@ mod tests {
 
     #[test]
     fn sort_sinks_negative_and_non_finite_values() {
-        let set: FieldSetter = |r, v| r.avg_take_rate = v;
         for degenerate in [-0.01, f64::NAN, f64::INFINITY] {
-            let validators = sort_validators(
-                vec![
-                    with_field("aaa_degenerate", set, Some(degenerate)),
-                    with_field("zzz_zero", set, Some(0.0)),
-                ],
-                OrderField::TakeRate,
-                &OrderDirection::ASC,
-            );
-            let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
-            assert_eq!(order, vec!["zzz_zero", "aaa_degenerate"], "{degenerate}");
+            for (label, field, set) in precise_fraction_fields() {
+                let validators = sort_validators(
+                    vec![
+                        with_field("aaa_degenerate", set, Some(degenerate)),
+                        with_field("zzz_zero", set, Some(0.0)),
+                    ],
+                    field,
+                    &OrderDirection::ASC,
+                );
+                let order: Vec<_> = validators.iter().map(|v| v.vote_account.clone()).collect();
+                assert_eq!(
+                    order,
+                    vec!["zzz_zero", "aaa_degenerate"],
+                    "{label} / {degenerate}"
+                );
+            }
         }
     }
 
     #[test]
-    fn sort_separates_take_rates_differing_below_four_decimals() {
-        // Mainnet's actual collision: 5% inflation commission with 0 bps MEV against the same with 10 bps.
+    fn sort_separates_fraction_fields_differing_below_four_decimals() {
+        // Mainnet's actual take-rate collision: 5% inflation commission with 0 bps MEV against the same with 10 bps.
         const LOWER: f64 = 0.13635962633635962;
         const HIGHER: f64 = 0.13638048552938048;
         assert_eq!(
@@ -945,17 +968,7 @@ mod tests {
             to_fixed_for_sort(HIGHER),
             "the values have to share a rounding bucket for this test to be about rounding"
         );
-        let fields: [(&str, OrderField, FieldSetter); 2] = [
-            ("take_rate", OrderField::TakeRate, |r, v| {
-                r.avg_take_rate = v
-            }),
-            (
-                "expected_take_rate",
-                OrderField::ExpectedTakeRate,
-                |r, v| r.expected_take_rate = v,
-            ),
-        ];
-        for (label, field, set) in fields {
+        for (label, field, set) in precise_fraction_fields() {
             let validators = sort_validators(
                 vec![
                     with_field("aaa_lower", set, Some(LOWER)),
@@ -1120,7 +1133,7 @@ mod tests {
             .collect();
         store::utils::update_validators_ranks(
             &mut by_vote_account,
-            |a: &ValidatorEpochStats| a.apy.and_then(to_fixed_for_sort),
+            |a: &ValidatorEpochStats| a.apy.and_then(Decimal::from_f64_retain),
             |a: &mut ValidatorEpochStats, rank: usize| a.rank_apy = Some(rank),
         );
         let mut ranks: Vec<_> = by_vote_account
@@ -1147,6 +1160,26 @@ mod tests {
                 ("dMissing".to_string(), None),
             ],
             "a rank states where a validator placed, so having no value must read as no rank"
+        );
+    }
+
+    #[test]
+    fn ranks_separate_apys_differing_below_four_decimals() {
+        assert_eq!(
+            to_fixed_for_sort(0.0712312),
+            to_fixed_for_sort(0.0712389),
+            "the values have to share a rounding bucket for this test to be about rounding"
+        );
+        assert_eq!(
+            apy_ranks(vec![
+                validator_with_epoch_apy("aLower", Some(0.0712312)),
+                validator_with_epoch_apy("bHigher", Some(0.0712389)),
+            ]),
+            vec![
+                ("aLower".to_string(), Some(2)),
+                ("bHigher".to_string(), Some(1)),
+            ],
+            "rounding used to hand both validators the same rank"
         );
     }
 

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -1133,7 +1133,11 @@ mod tests {
             .collect();
         store::utils::update_validators_ranks(
             &mut by_vote_account,
-            |a: &ValidatorEpochStats| a.apy.and_then(Decimal::from_f64_retain),
+            |a: &ValidatorEpochStats| {
+                a.apy
+                    .filter(|apy| *apy >= 0.0)
+                    .and_then(Decimal::from_f64_retain)
+            },
             |a: &mut ValidatorEpochStats, rank: usize| a.rank_apy = Some(rank),
         );
         let mut ranks: Vec<_> = by_vote_account

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -350,6 +350,8 @@ pub struct ValidatorRecord {
     pub avg_apy: Option<f64>,
     pub unique_delegators: Option<u64>,
     pub avg_take_rate: Option<f64>,
+    /// What the validator's current fee settings imply it keeps, as a fraction: its inflation, MEV and block-reward commissions weighted by the cluster reward mix. Forward-looking where `avg_take_rate` measures realized rewards, so two validators on the same fee settings read the same here regardless of size or block-production luck. Taking no commission anywhere floors it at the cluster block share, not at 0, because block rewards go wholly to the producer unless it also shares them through Jito's PriorityFeeDistribution. Null for a validator whose advertised commission is unknown.
+    pub expected_take_rate: Option<f64>,
     /// Latest point of the apy-api 14-day rolling staker APY, a fraction like `avg_apy` but MEV-inclusive where `avg_apy` is inflation-only. Null for a validator apy-api has no rewards data for.
     pub net_apy: Option<f64>,
     pub incidents: Vec<IncidentRecord>,

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -6,6 +6,7 @@ use crate::dto::{
     ValidatorScoreRecord, ValidatorScoreV2Record, ValidatorScoringCsvRow, ValidatorWarning,
     ValidatorsAggregated, VersionRecord,
 };
+use crate::validators_jito::get_last_jito_info;
 use chrono::{DateTime, Utc};
 use google_cloud_bigquery::client::{Client as BqClient, ClientConfig as BqClientConfig};
 use google_cloud_bigquery::http::job::query::QueryRequest;
@@ -221,6 +222,10 @@ async fn get_apy_calculators(
 /// Window (in epochs) over which per-validator downtime incidents are collected for the
 /// `incidents` field on `/validators`.
 const DEFAULT_INCIDENTS_WINDOW_EPOCHS: u64 = 90;
+
+/// How far back to accept a validator's latest Jito commissions. Wide enough to survive an epoch
+/// with no distribution account written, short enough that a long-departed validator reads as absent.
+const DEFAULT_JITO_COMMISSION_EPOCHS: u64 = 10;
 
 /// Loads all downtime incidents (each a distinct `DOWN` interval in the `uptimes` table) per
 /// validator over the last `epochs` epochs. Each `DOWN` row is one incident and includes
@@ -689,11 +694,28 @@ async fn scalar_u64(bq_client: &BqClient, query: String) -> anyhow::Result<Optio
     }
 }
 
+/// Cluster-wide split of the window's rewards across the three components, as fractions of the
+/// total pot. Each counts both sides, so a validator choosing to share its block rewards moves
+/// lamports between the sides without moving the weight every validator's take rate is scaled by.
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub struct RewardMixShares {
+    pub inflation: f64,
+    pub mev: f64,
+    pub block: f64,
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct TakeRates {
+    pub measured: HashMap<String, f64>,
+    pub shares: Option<RewardMixShares>,
+}
+
 /// Per-validator take rate over the last `TAKE_RATE_WINDOW_DAYS`, computed directly from BigQuery
 /// reward tables: `validator_rewards / total_rewards` where validator = inflation + MEV + block
 /// commission and total = staker + validator rewards. Windowed by `epochs.epoch_end_time` (same as
 /// apy-api). Reward tables are epoch-partitioned, so the resolved lower epoch is filtered on each.
-pub async fn load_take_rates() -> anyhow::Result<HashMap<String, f64>> {
+/// Also returns the cluster reward mix, which the same scan already has to compute.
+pub async fn load_take_rates() -> anyhow::Result<TakeRates> {
     let (config, _) = BqClientConfig::new_with_auth().await?;
     let bq_client = BqClient::new(config).await?;
 
@@ -714,13 +736,20 @@ pub async fn load_take_rates() -> anyhow::Result<HashMap<String, f64>> {
     };
 
     let query = format!(
-        "SELECT vote_account, CAST(take_rate AS STRING) AS take_rate FROM (
+        "SELECT
+            vote_account,
+            CAST(take_rate AS STRING) AS take_rate,
+            CAST(inflation_share AS STRING) AS inflation_share,
+            CAST(mev_share AS STRING) AS mev_share,
+            CAST(block_share AS STRING) AS block_share
+        FROM (
             WITH stakers AS (
                 SELECT
                     stakes.vote_account AS vote_account,
                     stakes.epoch AS epoch,
                     SUM(COALESCE(inflation.amount, 0)) AS staker_inflation,
-                    SUM(COALESCE(mev.amount, 0)) AS staker_mev
+                    SUM(COALESCE(mev.amount, 0)) AS staker_mev,
+                    SUM(COALESCE(prio.amount, 0)) AS staker_blocks
                 FROM `{ds}.stakes` stakes
                 LEFT JOIN `{ds}.rewards_inflation` inflation
                     ON stakes.stake_account = inflation.stake_account
@@ -728,40 +757,58 @@ pub async fn load_take_rates() -> anyhow::Result<HashMap<String, f64>> {
                 LEFT JOIN `{ds}.rewards_mev` mev
                     ON stakes.stake_account = mev.stake_account
                     AND stakes.epoch = mev.epoch AND mev.epoch >= {min_epoch}
+                -- rewards_validators_blocks is gross, so what Jito's PriorityFeeDistribution passed through has to come off the validator's keep rather than add to the pot.
+                LEFT JOIN `{ds}.rewards_jito_priority_fee` prio
+                    ON stakes.stake_account = prio.stake_account
+                    AND stakes.epoch = prio.epoch AND prio.epoch >= {min_epoch}
                 WHERE stakes.vote_account IS NOT NULL AND stakes.epoch >= {min_epoch}
                 GROUP BY stakes.vote_account, stakes.epoch
+            ),
+            per_validator AS (
+                SELECT
+                    stakers.vote_account AS vote_account,
+                    SUM(staker_inflation + COALESCE(vi.amount, 0)) AS inflation_total,
+                    SUM(staker_mev + COALESCE(vm.amount, 0)) AS mev_total,
+                    SUM(COALESCE(vb.amount, 0)) AS block_total,
+                    -- GREATEST guards the epochs where the two tables attribute one distribution to different sides of a boundary.
+                    SUM(COALESCE(vi.amount, 0) + COALESCE(vm.amount, 0)
+                        + GREATEST(COALESCE(vb.amount, 0) - staker_blocks, 0)) AS validator_total
+                FROM stakers
+                -- Pre-aggregate to one row per (vote_account, epoch) so raw duplicate keys can't fan out the SUM().
+                LEFT JOIN (
+                    SELECT vote_account, epoch, SUM(amount) AS amount
+                    FROM `{ds}.rewards_validators_inflation`
+                    WHERE epoch >= {min_epoch}
+                    GROUP BY vote_account, epoch
+                ) vi
+                    ON stakers.vote_account = vi.vote_account AND stakers.epoch = vi.epoch
+                LEFT JOIN (
+                    SELECT vote_account, epoch, SUM(amount) AS amount
+                    FROM `{ds}.rewards_validators_mev`
+                    WHERE epoch >= {min_epoch}
+                    GROUP BY vote_account, epoch
+                ) vm
+                    ON stakers.vote_account = vm.vote_account AND stakers.epoch = vm.epoch
+                LEFT JOIN (
+                    SELECT vote_account, epoch, SUM(amount) AS amount
+                    FROM `{ds}.rewards_validators_blocks`
+                    WHERE epoch >= {min_epoch}
+                    GROUP BY vote_account, epoch
+                ) vb
+                    ON stakers.vote_account = vb.vote_account AND stakers.epoch = vb.epoch
+                GROUP BY stakers.vote_account
             )
             SELECT
-                stakers.vote_account AS vote_account,
-                SAFE_DIVIDE(
-                    SUM(COALESCE(vi.amount, 0) + COALESCE(vm.amount, 0) + COALESCE(vb.amount, 0)),
-                    SUM(staker_inflation + staker_mev
-                        + COALESCE(vi.amount, 0) + COALESCE(vm.amount, 0) + COALESCE(vb.amount, 0))
-                ) AS take_rate
-            FROM stakers
-            -- Pre-aggregate to one row per (vote_account, epoch) so raw duplicate keys can't fan out the SUM().
-            LEFT JOIN (
-                SELECT vote_account, epoch, SUM(amount) AS amount
-                FROM `{ds}.rewards_validators_inflation`
-                WHERE epoch >= {min_epoch}
-                GROUP BY vote_account, epoch
-            ) vi
-                ON stakers.vote_account = vi.vote_account AND stakers.epoch = vi.epoch
-            LEFT JOIN (
-                SELECT vote_account, epoch, SUM(amount) AS amount
-                FROM `{ds}.rewards_validators_mev`
-                WHERE epoch >= {min_epoch}
-                GROUP BY vote_account, epoch
-            ) vm
-                ON stakers.vote_account = vm.vote_account AND stakers.epoch = vm.epoch
-            LEFT JOIN (
-                SELECT vote_account, epoch, SUM(amount) AS amount
-                FROM `{ds}.rewards_validators_blocks`
-                WHERE epoch >= {min_epoch}
-                GROUP BY vote_account, epoch
-            ) vb
-                ON stakers.vote_account = vb.vote_account AND stakers.epoch = vb.epoch
-            GROUP BY stakers.vote_account
+                vote_account,
+                SAFE_DIVIDE(validator_total, inflation_total + mev_total + block_total) AS take_rate,
+                -- Windowed over the already-grouped rows, so the cluster mix costs no extra scan.
+                SAFE_DIVIDE(SUM(inflation_total) OVER (), SUM(inflation_total + mev_total + block_total) OVER ())
+                    AS inflation_share,
+                SAFE_DIVIDE(SUM(mev_total) OVER (), SUM(inflation_total + mev_total + block_total) OVER ())
+                    AS mev_share,
+                SAFE_DIVIDE(SUM(block_total) OVER (), SUM(inflation_total + mev_total + block_total) OVER ())
+                    AS block_share
+            FROM per_validator
         )
         WHERE take_rate IS NOT NULL"
     );
@@ -776,14 +823,53 @@ pub async fn load_take_rates() -> anyhow::Result<HashMap<String, f64>> {
         .query::<Row>(GOOGLE_BQ_PROJECT_ID, request)
         .await?;
 
-    let mut records: HashMap<String, f64> = Default::default();
+    let mut measured: HashMap<String, f64> = Default::default();
+    // Identical on every row by construction, so the last one read is the cluster mix.
+    let mut shares = None;
     while let Some(row) = iter.next().await? {
         let vote_account = row.column::<String>(0)?;
         let take_rate_str = row.column::<String>(1)?;
-        records.insert(vote_account, take_rate_str.parse()?);
+        measured.insert(vote_account, take_rate_str.parse()?);
+        shares = match (
+            row.column::<Option<String>>(2)?,
+            row.column::<Option<String>>(3)?,
+            row.column::<Option<String>>(4)?,
+        ) {
+            (Some(inflation), Some(mev), Some(block)) => Some(RewardMixShares {
+                inflation: inflation.parse()?,
+                mev: mev.parse()?,
+                block: block.parse()?,
+            }),
+            _ => shares,
+        };
     }
 
-    Ok(records)
+    Ok(TakeRates { measured, shares })
+}
+
+/// What the validator's own fee settings imply it keeps, weighted by the cluster reward mix.
+/// Renormalized over the components it actually earns: a validator not running Jito receives no MEV
+/// at all, so crediting it a 0% MEV commission would dilute the rate it takes on what it does earn.
+/// None when the inflation commission is unknown, which is the one component no validator can opt out of.
+pub fn expected_take_rate(
+    shares: RewardMixShares,
+    inflation_commission_pct: Option<i32>,
+    mev_commission_bps: Option<i32>,
+    priority_commission_bps: Option<i32>,
+) -> Option<f64> {
+    let mut weighted = (f64::from(inflation_commission_pct?) / 100.0) * shares.inflation;
+    let mut weight = shares.inflation;
+
+    if let Some(bps) = mev_commission_bps {
+        weighted += (f64::from(bps) / 10_000.0) * shares.mev;
+        weight += shares.mev;
+    }
+    // Block rewards are always earned, and absent a Jito PriorityFeeDistribution account none of them
+    // are shared: SIMD-0096 pays every priority fee to the block producer.
+    weighted += priority_commission_bps.map_or(1.0, |bps| f64::from(bps) / 10_000.0) * shares.block;
+    weight += shares.block;
+
+    (weight > 0.0).then_some(weighted / weight)
 }
 
 #[derive(serde::Deserialize)]
@@ -864,7 +950,7 @@ where
 #[derive(Default)]
 pub struct ValidatorOverlays {
     pub unique_delegators: HashMap<String, u64>,
-    pub take_rates: HashMap<String, f64>,
+    pub take_rates: TakeRates,
     pub net_apy: HashMap<String, f64>,
     pub verified: HashSet<String>,
     pub protected: HashSet<String>,
@@ -1091,6 +1177,7 @@ pub async fn load_validators(
                     avg_apy: None,
                     unique_delegators: None,
                     avg_take_rate: None,
+                    expected_take_rate: None,
                     net_apy: None,
                     incidents: Vec::new(),
                     verified: false,
@@ -1237,8 +1324,27 @@ pub async fn load_validators(
     }
 
     log::info!("Updating take rates...");
+    let mut mev_commissions: HashMap<String, i32> = Default::default();
+    let mut priority_commissions: HashMap<String, i32> = Default::default();
+    // get_last_jito_info keys on (vote_account, epoch): the two distribution accounts resolve their last epoch separately, splitting one validator across two records.
+    for jito in get_last_jito_info(psql_client, DEFAULT_JITO_COMMISSION_EPOCHS).await? {
+        if let Some(bps) = jito.mev_commission_bps {
+            mev_commissions.insert(jito.vote_account.clone(), bps);
+        }
+        if let Some(bps) = jito.priority_commission_bps {
+            priority_commissions.insert(jito.vote_account, bps);
+        }
+    }
     for (vote_account, record) in records.iter_mut() {
-        record.avg_take_rate = overlays.take_rates.get(vote_account).copied();
+        record.avg_take_rate = overlays.take_rates.measured.get(vote_account).copied();
+        record.expected_take_rate = overlays.take_rates.shares.and_then(|shares| {
+            expected_take_rate(
+                shares,
+                record.commission_advertised,
+                mev_commissions.get(vote_account).copied(),
+                priority_commissions.get(vote_account).copied(),
+            )
+        });
     }
 
     log::info!("Updating net APY...");
@@ -2084,5 +2190,81 @@ mod tests {
         assert_eq!(to_fixed_for_sort(f64::INFINITY), None);
         assert_eq!(to_fixed_for_sort(f64::MAX), None);
         assert_eq!(to_fixed_for_sort(1e30), None);
+    }
+
+    // Roughly mainnet's mix at epoch 1015, so the numbers below read against something real.
+    const MIX: RewardMixShares = RewardMixShares {
+        inflation: 0.90,
+        mev: 0.044,
+        block: 0.056,
+    };
+
+    fn approx(actual: Option<f64>, expected: f64) {
+        let actual = actual.expect("expected a rate");
+        assert!(
+            (actual - expected).abs() < 1e-12,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn expected_take_rate_floors_at_the_block_share_for_a_zero_fee_validator() {
+        // HelixNode's shape: 0% inflation, 0% MEV, no priority-fee account. It measures ~5.6%.
+        approx(expected_take_rate(MIX, Some(0), Some(0), None), MIX.block);
+    }
+
+    #[test]
+    fn expected_take_rate_reaches_one_when_every_component_is_fully_taken() {
+        approx(
+            expected_take_rate(MIX, Some(100), Some(10_000), Some(10_000)),
+            1.0,
+        );
+    }
+
+    #[test]
+    fn expected_take_rate_weights_each_commission_by_its_component() {
+        approx(
+            expected_take_rate(MIX, Some(5), Some(1_000), None),
+            0.05 * MIX.inflation + 0.1 * MIX.mev + MIX.block,
+        );
+    }
+
+    #[test]
+    fn expected_take_rate_drops_below_the_floor_when_block_rewards_are_shared() {
+        // The two validators on Jito's PriorityFeeDistribution at 0 bps keep none of their priority fees.
+        approx(expected_take_rate(MIX, Some(0), Some(0), Some(0)), 0.0);
+    }
+
+    #[test]
+    fn expected_take_rate_renormalizes_when_the_validator_earns_no_mev() {
+        // Without Jito there is no MEV to take a cut of, so the MEV weight must leave the denominator
+        // rather than count as a 0% commission and dilute the rate.
+        let no_jito = expected_take_rate(MIX, Some(10), None, None);
+        approx(
+            no_jito,
+            (0.1 * MIX.inflation + MIX.block) / (MIX.inflation + MIX.block),
+        );
+
+        let diluted = 0.1 * MIX.inflation + MIX.block;
+        assert!(
+            no_jito.unwrap() > diluted,
+            "renormalizing must read higher than crediting a 0% MEV commission"
+        );
+    }
+
+    #[test]
+    fn expected_take_rate_is_unknown_without_an_inflation_commission() {
+        // Inflation rewards are earned by every validator, so a missing commission cannot renormalize away the way a missing MEV one does.
+        assert_eq!(expected_take_rate(MIX, None, Some(0), Some(0)), None);
+    }
+
+    #[test]
+    fn expected_take_rate_needs_at_least_one_component_to_weigh() {
+        let empty = RewardMixShares {
+            inflation: 0.0,
+            mev: 0.0,
+            block: 0.0,
+        };
+        assert_eq!(expected_take_rate(empty, Some(5), Some(1_000), None), None);
     }
 }

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1296,12 +1296,12 @@ pub async fn load_validators(
     );
     update_validators_ranks(
         &mut records,
-        |a: &ValidatorEpochStats| a.score.and_then(to_fixed_for_sort),
+        |a: &ValidatorEpochStats| a.score.and_then(Decimal::from_f64_retain),
         |a: &mut ValidatorEpochStats, rank: usize| a.rank_score = Some(rank),
     );
     update_validators_ranks(
         &mut records,
-        |a: &ValidatorEpochStats| a.apy.and_then(to_fixed_for_sort),
+        |a: &ValidatorEpochStats| a.apy.and_then(Decimal::from_f64_retain),
         |a: &mut ValidatorEpochStats, rank: usize| a.rank_apy = Some(rank),
     );
     update_with_warnings(&mut records, epochs_range.clone()).await?;

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1301,7 +1301,11 @@ pub async fn load_validators(
     );
     update_validators_ranks(
         &mut records,
-        |a: &ValidatorEpochStats| a.apy.and_then(Decimal::from_f64_retain),
+        |a: &ValidatorEpochStats| {
+            a.apy
+                .filter(|apy| *apy >= 0.0)
+                .and_then(Decimal::from_f64_retain)
+        },
         |a: &mut ValidatorEpochStats, rank: usize| a.rank_apy = Some(rank),
     );
     update_with_warnings(&mut records, epochs_range.clone()).await?;


### PR DESCRIPTION
Implementation of the take rate 
* https://marinade-group.slack.com/archives/C0BJZAZC66S/p1786388985720919?thread_ts=1786388496.321699&cid=C0BJZAZC66S
* https://marinade-group.slack.com/archives/C0BJZAZC66S/p1786093360539109?thread_ts=1786090520.555389&cid=C0BJZAZC66S

---

Expose a forward-looking take rate on `/validators`, so validators can be compared on their current fee settings rather than on the rewards they happened to earn.

- Add `expected_take_rate`, derived from a validator's inflation, MEV and block-reward commissions and weighted by a cluster reward mix the existing take-rate scan now computes alongside, so two validators on identical settings read
identically regardless of size or block-production luck
- Count block rewards passed to stakers through Jito's PriorityFeeDistribution, so a validator that shares them stops reading as having kept them — the largest sharer measured 16.0% before and 9.1% after
- Add `ExpectedTakeRate` to `order_field`
- Key take-rate and APY sorting and ranking off exact decimals rather than 4-decimal rounding, which was collapsing 558 of 632 distinct APY values into shared buckets ordered alphabetically


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added validator sorting by expected take rate.
  - Added expected take rate information to validator records.
  - Improved take-rate reporting with inflation, MEV, block rewards, and priority-fee components.
  - Added commission data support for more accurate expected take-rate calculations.
  - Updated API documentation with supported validator sorting options.

- **Bug Fixes**
  - Improved take-rate and APY sorting accuracy by preserving precise values.
  - Improved handling of invalid or missing values in rankings and reward calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->