### PR TITLE
[GEN-8006][collect] reuse the fetched vote accounts for credits

### DIFF
--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -60,10 +60,8 @@ pub fn get_stake_history(rpc_client: &RpcClient) -> anyhow::Result<StakeHistory>
     )?)
 }
 
-pub fn get_credits(rpc_client: &RpcClient, epoch: Epoch) -> anyhow::Result<HashMap<String, u64>> {
+pub fn get_credits(vote_accounts: &RpcVoteAccountStatus, epoch: Epoch) -> HashMap<String, u64> {
     info!("Getting credits");
-    let vote_accounts = rpc_client.get_vote_accounts()?;
-
     let mut credits = HashMap::new();
 
     for vote_account in vote_accounts
@@ -81,7 +79,7 @@ pub fn get_credits(rpc_client: &RpcClient, epoch: Epoch) -> anyhow::Result<HashM
         }
     }
 
-    Ok(credits)
+    credits
 }
 
 const CLIENT_IDS_CSV: &str = include_str!("../client-ids.csv");

--- a/collect/src/validators_performance.rs
+++ b/collect/src/validators_performance.rs
@@ -118,7 +118,7 @@ pub fn validators_performance(
             warn!("Attempt {attempt} to get block production failed: {err:?}, retrying in {backoff:?}")
         },
     )?;
-    let credits = get_credits(client, epoch)?;
+    let credits = get_credits(vote_accounts, epoch);
 
     for vote_account in vote_accounts
         .current


### PR DESCRIPTION
get_credits re-fetched getVoteAccounts (~300 KB) although its caller already held the same response, and only ever reads epoch_credits from it. The per-minute performance collector paid for that twice a minute.

Taking the data instead of the client also makes credits, activated stake, commission and delinquency come from one coherent read rather than two fetches that could straddle a slot boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved validator performance data collection by reusing available vote-account information.
  * Reduced redundant network requests during epoch credit processing.
* **Reliability**
  * Simplified credit retrieval and reduced errors related to additional RPC requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->