### PR TITLE
[trivial] fix overflow during build that happened due to `.or(...)` chain reaching limits of 128 recursion

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,4 +1,4 @@
-// warp `.or()` chains nest one type layer per route; the route list exceeds the default 128.
+// The `.or(...)` chain of route handles in main function requires this limit to be higher than default 128.
 #![recursion_limit = "256"]
 
 use crate::context::{Context, WrappedContext};

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,3 +1,6 @@
+// warp `.or()` chains nest one type layer per route; the route list exceeds the default 128.
+#![recursion_limit = "256"]
+
 use crate::context::{Context, WrappedContext};
 use crate::handlers::{
     admin_score_upload, cluster_stats, commissions, config, docs, events, global_unstake_hints,


### PR DESCRIPTION
There is this section in `api/src/main.rs` that caused overflow during build when new routes were added recently.

```rs
    let routes = top_level
        .or(route_api_docs_oas)
        .or(route_api_docs_html)
        /// and many more...
        .or(route_workflow_metrics_upload)
        .with(cors);
```

Simple fix by increasing recursion limit from default 128 to 256.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for deeply nested request routes, helping prevent compilation issues in complex API configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->