### PR TITLE
[collect] collect more detailed information about validators

### DIFF
--- a/collect/src/solana_service.rs
+++ b/collect/src/solana_service.rs
@@ -5,7 +5,7 @@ use crate::validators::*;
 use bincode::deserialize;
 use log::{info, warn};
 use rust_decimal::{prelude::ToPrimitive, Decimal};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use solana_account_decoder::validator_info;
 use solana_account_decoder::UiAccountEncoding;
@@ -226,7 +226,7 @@ fn is_plausible_node_version(version: &str) -> bool {
         })
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NodeContact {
     pub ip: Option<String>,
     pub gossip_port: Option<u16>,

--- a/collect/src/validators.rs
+++ b/collect/src/validators.rs
@@ -216,7 +216,7 @@ pub fn collect_validators_info(
                 .filter_map(|(identity, n)| n.ip.clone().map(|ip| (identity.clone(), ip)))
                 .collect();
             get_data_centers(
-                WhoisClient::new(whois, validator_params.whois_bearer_token),
+                WhoisClient::new(whois, validator_params.whois_bearer_token)?,
                 node_ips,
             )?
         }

--- a/collect/src/validators_performance.rs
+++ b/collect/src/validators_performance.rs
@@ -102,6 +102,9 @@ pub struct ValidatorsPerformanceSnapshot {
     pub slots_per_year: f64,
     pub cluster_inflation: Option<ClusterInflation>,
     pub validators: HashMap<String, ValidatorPerformance>,
+    // Every gossip node, not just the vote-account-joined subset in `validators`; absent from snapshots written before the field existed, which the backfill path still reads.
+    #[serde(default)]
+    pub nodes: HashMap<String, NodeContact>,
     pub rewards: Option<HashMap<String, ValidatorRewards>>,
 }
 
@@ -350,6 +353,7 @@ pub fn collect_validators_performance_info(
             slots_per_year: slot_params.slots_per_year,
             cluster_inflation,
             validators,
+            nodes: node_info,
             rewards,
         },
     )?;
@@ -423,5 +427,62 @@ mod tests {
             (supply as f64) < at_todays_rate * 0.8,
             "{supply} is not materially below the flat-rate {at_todays_rate}"
         );
+    }
+
+    // The backfill and finalized-performance paths replay snapshots written before `nodes` existed.
+    #[test]
+    fn a_snapshot_without_nodes_still_deserializes() {
+        let yaml = "
+epoch: 1000
+epoch_slot: 1
+transaction_count: 1
+created_at: '2026-07-31T00:00:00Z'
+cluster_inflation: null
+validators: {}
+rewards: null
+";
+        let snapshot: ValidatorsPerformanceSnapshot = serde_yaml::from_str(yaml).unwrap();
+        assert!(snapshot.nodes.is_empty());
+        assert_eq!(snapshot.slots_per_year, baseline_slots_per_year());
+    }
+
+    #[test]
+    fn a_node_survives_the_snapshot_round_trip() {
+        let node = NodeContact {
+            ip: Some("1.2.3.4".into()),
+            gossip_port: Some(8001),
+            version: Some("2.0.0".into()),
+            client_id: Some(3),
+            client_id_raw: Some("Agave".into()),
+            feature_set: Some(123),
+            shred_version: Some(456),
+            rpc_public: true,
+            pubsub_public: false,
+        };
+        let snapshot = ValidatorsPerformanceSnapshot {
+            epoch: 1000,
+            epoch_slot: 1,
+            transaction_count: 1,
+            created_at: "2026-07-31T00:00:00Z".into(),
+            slots_per_year: baseline_slots_per_year(),
+            cluster_inflation: None,
+            validators: Default::default(),
+            nodes: HashMap::from([("identityRoundTrip".to_string(), node)]),
+            rewards: None,
+        };
+
+        let restored: ValidatorsPerformanceSnapshot =
+            serde_yaml::from_str(&serde_yaml::to_string(&snapshot).unwrap()).unwrap();
+
+        let restored_node = restored.nodes.get("identityRoundTrip").unwrap();
+        assert_eq!(restored_node.ip.as_deref(), Some("1.2.3.4"));
+        assert_eq!(restored_node.gossip_port, Some(8001));
+        assert_eq!(restored_node.version.as_deref(), Some("2.0.0"));
+        assert_eq!(restored_node.client_id, Some(3));
+        assert_eq!(restored_node.client_id_raw.as_deref(), Some("Agave"));
+        assert_eq!(restored_node.feature_set, Some(123));
+        assert_eq!(restored_node.shred_version, Some(456));
+        assert!(restored_node.rpc_public);
+        assert!(!restored_node.pubsub_public);
     }
 }

--- a/collect/src/whois_service.rs
+++ b/collect/src/whois_service.rs
@@ -39,7 +39,9 @@ impl WhoisClient {
                     self.bearer_token.clone().unwrap_or("none".to_string())
                 ),
             )
-            .send()?;
+            .send()?
+            // Every IpInfo field is optional, so an error body would deserialize into an all-None answer indistinguishable from a genuinely unknown address.
+            .error_for_status()?;
         Ok(body.json()?)
     }
 }

--- a/collect/src/whois_service.rs
+++ b/collect/src/whois_service.rs
@@ -21,16 +21,22 @@ pub struct IpInfo {
 pub struct WhoisClient {
     host: String,
     bearer_token: Option<String>,
+    // Held, not built per call: the connection pool lives on the client, so a fresh one per address re-does the TLS handshake for every lookup of a cluster-sized sweep.
+    client: reqwest::blocking::Client,
 }
 impl WhoisClient {
-    pub fn new(host: String, bearer_token: Option<String>) -> Self {
-        Self { host, bearer_token }
+    pub fn new(host: String, bearer_token: Option<String>) -> anyhow::Result<Self> {
+        Ok(Self {
+            host,
+            bearer_token,
+            client: reqwest::blocking::Client::builder().build()?,
+        })
     }
 
     pub fn get_ip_info(&self, ip: &String) -> anyhow::Result<IpInfo> {
         debug!("Fetching info about data centers: {}", &ip);
-        let client = reqwest::blocking::Client::builder().build()?;
-        let body = client
+        let body = self
+            .client
             .get(format!("{}/ip/{}", self.host.clone(), ip))
             .header(
                 "Authorization",

--- a/migrations/0023-node-observations.sql
+++ b/migrations/0023-node-observations.sql
@@ -1,0 +1,25 @@
+-- Keyed by identity, not vote_account: gossip returns identity natively and most nodes on the
+-- cluster have no vote account at all, so a vote-account key would drop them permanently.
+CREATE TABLE node_observations (
+  id BIGSERIAL NOT NULL,
+  identity TEXT NOT NULL,
+  ip TEXT NULL,
+  gossip_port INTEGER NULL,
+  version TEXT NULL,
+  client_id INTEGER NULL,
+  client_id_raw TEXT NULL,
+  feature_set BIGINT NULL,
+  shred_version INTEGER NULL,
+  rpc_public BOOLEAN NULL,
+  pubsub_public BOOLEAN NULL,
+  epoch_slot NUMERIC NOT NULL,
+  epoch NUMERIC NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+  PRIMARY KEY(id)
+);
+
+CREATE INDEX idx_node_observations_identity_created_at
+    ON node_observations(identity, created_at);
+CREATE INDEX idx_node_observations_ip_created_at
+    ON node_observations(ip, created_at);

--- a/migrations/0023-node-observations.sql
+++ b/migrations/0023-node-observations.sql
@@ -23,6 +23,6 @@ CREATE TABLE node_observations (
 );
 
 CREATE INDEX idx_node_observations_identity_created_at
-    ON node_observations(identity, created_at);
+    ON node_observations(identity, created_at DESC, id DESC);
 CREATE INDEX idx_node_observations_ip_last_seen_at
     ON node_observations(ip, last_seen_at);

--- a/migrations/0023-node-observations.sql
+++ b/migrations/0023-node-observations.sql
@@ -15,11 +15,14 @@ CREATE TABLE node_observations (
   epoch_slot NUMERIC NOT NULL,
   epoch NUMERIC NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  -- A row is written only when something changed, so created_at cannot answer "is this node still
+  -- here". Every run re-stamps this on the node's newest row, making each row an observed interval.
+  last_seen_at TIMESTAMP WITH TIME ZONE NOT NULL,
 
   PRIMARY KEY(id)
 );
 
 CREATE INDEX idx_node_observations_identity_created_at
     ON node_observations(identity, created_at);
-CREATE INDEX idx_node_observations_ip_created_at
-    ON node_observations(ip, created_at);
+CREATE INDEX idx_node_observations_ip_last_seen_at
+    ON node_observations(ip, last_seen_at);

--- a/migrations/0024-ip-info.sql
+++ b/migrations/0024-ip-info.sql
@@ -1,0 +1,18 @@
+-- Enrichment keyed by the address it describes, not by the validator sitting on it: the address is
+-- what moves, so one row per IP joined against the observation log gives location history for free.
+CREATE TABLE ip_info (
+  ip TEXT NOT NULL,
+  asn INTEGER NULL,
+  aso TEXT NULL,
+  continent TEXT NULL,
+  country_iso TEXT NULL,
+  country TEXT NULL,
+  city TEXT NULL,
+  coordinates_lat DOUBLE PRECISION NULL,
+  coordinates_lon DOUBLE PRECISION NULL,
+  fetched_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+  PRIMARY KEY(ip)
+);
+
+CREATE INDEX idx_ip_info_fetched_at ON ip_info(fetched_at);

--- a/migrations/0024-ip-info.sql
+++ b/migrations/0024-ip-info.sql
@@ -2,7 +2,7 @@
 -- what moves, so one row per IP joined against the observation log gives location history for free.
 CREATE TABLE ip_info (
   ip TEXT NOT NULL,
-  asn INTEGER NULL,
+  asn BIGINT NULL,
   aso TEXT NULL,
   continent TEXT NULL,
   country_iso TEXT NULL,

--- a/scripts/store-ip-info.bash
+++ b/scripts/store-ip-info.bash
@@ -7,7 +7,7 @@ BIN_DIR="${BIN_DIR:-"$SCRIPT_DIR/../target/debug"}"
 
 if [[ -z $POSTGRES_URL ]]
 then
-  echo "Env variable POSTGRES_URL is missing!"
+  echo "Env variable POSTGRES_URL is missing!" >&2
   exit 1
 fi
 

--- a/scripts/store-ip-info.bash
+++ b/scripts/store-ip-info.bash
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(dirname "$0")
+BIN_DIR="${BIN_DIR:-"$SCRIPT_DIR/../target/debug"}"
+
+if [[ -z $POSTGRES_URL ]]
+then
+  echo "Env variable POSTGRES_URL is missing!"
+  exit 1
+fi
+
+if [[ -z $WHOIS_BEARER_TOKEN ]]
+then
+  echo "Env variable WHOIS_BEARER_TOKEN is missing!" >&2
+  exit 1
+fi
+
+"$BIN_DIR/store" \
+  --postgres-url "$POSTGRES_URL" \
+  ip-info \
+    --whois "https://whois.marinade.finance" \
+    --whois-bearer-token "$WHOIS_BEARER_TOKEN" \
+    "$@"

--- a/scripts/store-node-observations.bash
+++ b/scripts/store-node-observations.bash
@@ -7,7 +7,7 @@ BIN_DIR="${BIN_DIR:-"$SCRIPT_DIR/../target/debug"}"
 
 if [[ -z $POSTGRES_URL ]]
 then
-  echo "Env variable POSTGRES_URL is missing!"
+  echo "Env variable POSTGRES_URL is missing!" >&2
   exit 1
 fi
 

--- a/scripts/store-node-observations.bash
+++ b/scripts/store-node-observations.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(dirname "$0")
+BIN_DIR="${BIN_DIR:-"$SCRIPT_DIR/../target/debug"}"
+
+if [[ -z $POSTGRES_URL ]]
+then
+  echo "Env variable POSTGRES_URL is missing!"
+  exit 1
+fi
+
+SNAPSHOT="$1"
+if [[ -z $SNAPSHOT ]]
+then
+  echo "Usage: $0 <snapshot-file>" >&2
+  exit 1
+fi
+
+"$BIN_DIR/store" \
+  --postgres-url "$POSTGRES_URL" \
+  node-observations \
+    --snapshot-file "$SNAPSHOT"

--- a/scripts/store-quick-changes.bash
+++ b/scripts/store-quick-changes.bash
@@ -7,3 +7,5 @@ SCRIPT_DIR=$(dirname "$0")
 "$SCRIPT_DIR/store-uptimes.bash" $@
 "$SCRIPT_DIR/store-commissions.bash" $@
 "$SCRIPT_DIR/store-versions.bash" $@
+# Last of the four: set -e aborts the rest of the chain on failure, and this is the writer with no consumers yet.
+"$SCRIPT_DIR/store-node-observations.bash" $@

--- a/scripts/store-quick-changes.bash
+++ b/scripts/store-quick-changes.bash
@@ -4,8 +4,8 @@ set -e
 
 SCRIPT_DIR=$(dirname "$0")
 
-"$SCRIPT_DIR/store-uptimes.bash" $@
-"$SCRIPT_DIR/store-commissions.bash" $@
-"$SCRIPT_DIR/store-versions.bash" $@
+"$SCRIPT_DIR/store-uptimes.bash" "$@"
+"$SCRIPT_DIR/store-commissions.bash" "$@"
+"$SCRIPT_DIR/store-versions.bash" "$@"
 # Last of the four: set -e aborts the rest of the chain on failure, and this is the writer with no consumers yet.
-"$SCRIPT_DIR/store-node-observations.bash" $@
+"$SCRIPT_DIR/store-node-observations.bash" "$@"

--- a/store/src/ip_info.rs
+++ b/store/src/ip_info.rs
@@ -217,7 +217,7 @@ pub async fn store_ip_info(
         return Ok(());
     }
 
-    let whois_client = Arc::new(WhoisClient::new(params.whois, params.whois_bearer_token));
+    let whois_client = Arc::new(WhoisClient::new(params.whois, params.whois_bearer_token)?);
     let mut upserted = 0;
     // Committed per chunk: a run killed part-way through keeps the lookups it already paid for,
     // instead of discarding the whole batch and starting over next time.

--- a/store/src/ip_info.rs
+++ b/store/src/ip_info.rs
@@ -1,0 +1,210 @@
+use chrono::{DateTime, Utc};
+use collect::whois_service::{IpInfo, WhoisClient};
+use log::{info, warn};
+use structopt::StructOpt;
+use tokio_postgres::Client;
+
+#[derive(Debug, StructOpt)]
+pub struct StoreIpInfoParams {
+    #[structopt(long = "whois", help = "Base URL for whois API.")]
+    whois: String,
+
+    #[structopt(
+        long = "whois-bearer-token",
+        help = "Bearer token to be used to fetch data from whois API"
+    )]
+    whois_bearer_token: Option<String>,
+
+    #[structopt(
+        long = "refresh-limit",
+        help = "How many already known IPs to re-fetch per run, oldest first.",
+        default_value = "21"
+    )]
+    refresh_limit: i64,
+
+    #[structopt(
+        long = "in-use-days",
+        help = "How recently an IP must have been observed to be worth re-fetching.",
+        default_value = "7"
+    )]
+    in_use_days: i32,
+}
+
+pub async fn select_unknown_ips(psql_client: &Client) -> anyhow::Result<Vec<String>> {
+    // NOT EXISTS rather than NOT IN: a single NULL on the right of NOT IN would discard every row.
+    Ok(psql_client
+        .query(
+            "
+        SELECT DISTINCT o.ip
+        FROM node_observations o
+        WHERE o.ip IS NOT NULL AND o.ip <> '127.0.0.1'
+          AND NOT EXISTS (SELECT 1 FROM ip_info i WHERE i.ip = o.ip)
+    ",
+            &[],
+        )
+        .await?
+        .iter()
+        .map(|row| row.get("ip"))
+        .collect())
+}
+
+pub async fn select_stale_ips(
+    psql_client: &Client,
+    refresh_limit: i64,
+    in_use_days: i32,
+) -> anyhow::Result<Vec<String>> {
+    // Restricted to addresses still in gossip: an IP the cluster left is not worth paying to recheck.
+    Ok(psql_client
+        .query(
+            "
+        SELECT i.ip
+        FROM ip_info i
+        WHERE EXISTS (
+            SELECT 1
+            FROM node_observations o
+            WHERE o.ip = i.ip AND o.created_at > now() - make_interval(days => $2)
+        )
+        ORDER BY i.fetched_at ASC
+        LIMIT $1
+    ",
+            &[&refresh_limit, &in_use_days],
+        )
+        .await?
+        .iter()
+        .map(|row| row.get("ip"))
+        .collect())
+}
+
+pub async fn upsert_ip_info(
+    psql_client: &Client,
+    fetched: &[(String, IpInfo)],
+    fetched_at: DateTime<Utc>,
+) -> anyhow::Result<u64> {
+    if fetched.is_empty() {
+        return Ok(0);
+    }
+
+    let ips: Vec<&str> = fetched.iter().map(|(ip, _)| ip.as_str()).collect();
+    let asns: Vec<Option<i32>> = fetched
+        .iter()
+        .map(|(_, info)| info.asn.map(|asn| asn as i32))
+        .collect();
+    let asos: Vec<Option<&str>> = fetched
+        .iter()
+        .map(|(_, info)| info.aso.as_deref())
+        .collect();
+    let continents: Vec<Option<&str>> = fetched
+        .iter()
+        .map(|(_, info)| info.continent.as_deref())
+        .collect();
+    let country_isos: Vec<Option<&str>> = fetched
+        .iter()
+        .map(|(_, info)| info.country_iso.as_deref())
+        .collect();
+    let countries: Vec<Option<&str>> = fetched
+        .iter()
+        .map(|(_, info)| info.country.as_deref())
+        .collect();
+    let cities: Vec<Option<&str>> = fetched
+        .iter()
+        .map(|(_, info)| info.city.as_deref())
+        .collect();
+    let lats: Vec<Option<f64>> = fetched
+        .iter()
+        .map(|(_, info)| info.coordinates.as_ref().map(|c| c.lat))
+        .collect();
+    let lons: Vec<Option<f64>> = fetched
+        .iter()
+        .map(|(_, info)| info.coordinates.as_ref().map(|c| c.lon))
+        .collect();
+    let fetched_ats: Vec<DateTime<Utc>> = vec![fetched_at; fetched.len()];
+
+    Ok(psql_client
+        .execute(
+            "
+        INSERT INTO ip_info (
+            ip, asn, aso, continent, country_iso, country, city,
+            coordinates_lat, coordinates_lon, fetched_at
+        )
+        SELECT * FROM UNNEST(
+            $1::TEXT[],
+            $2::INTEGER[],
+            $3::TEXT[],
+            $4::TEXT[],
+            $5::TEXT[],
+            $6::TEXT[],
+            $7::TEXT[],
+            $8::DOUBLE PRECISION[],
+            $9::DOUBLE PRECISION[],
+            $10::TIMESTAMP WITH TIME ZONE[]
+        )
+        ON CONFLICT (ip)
+        DO UPDATE SET
+            asn = EXCLUDED.asn,
+            aso = EXCLUDED.aso,
+            continent = EXCLUDED.continent,
+            country_iso = EXCLUDED.country_iso,
+            country = EXCLUDED.country,
+            city = EXCLUDED.city,
+            coordinates_lat = EXCLUDED.coordinates_lat,
+            coordinates_lon = EXCLUDED.coordinates_lon,
+            fetched_at = EXCLUDED.fetched_at
+    ",
+            &[
+                &ips,
+                &asns,
+                &asos,
+                &continents,
+                &country_isos,
+                &countries,
+                &cities,
+                &lats,
+                &lons,
+                &fetched_ats,
+            ],
+        )
+        .await?)
+}
+
+pub async fn store_ip_info(
+    params: StoreIpInfoParams,
+    psql_client: &mut Client,
+) -> anyhow::Result<()> {
+    info!("Storing IP info...");
+
+    let unknown = select_unknown_ips(psql_client).await?;
+    let stale = select_stale_ips(psql_client, params.refresh_limit, params.in_use_days).await?;
+    info!(
+        "{} IPs never looked up, {} due for a refresh",
+        unknown.len(),
+        stale.len()
+    );
+
+    let ips: Vec<String> = unknown.into_iter().chain(stale).collect();
+    if ips.is_empty() {
+        info!("Stored info about 0 IPs");
+        return Ok(());
+    }
+
+    let whois_client = WhoisClient::new(params.whois, params.whois_bearer_token);
+    // WhoisClient is a blocking reqwest client and this binary runs on tokio, so the whole batch
+    // goes to a blocking thread rather than each call fighting the runtime.
+    let fetched = tokio::task::spawn_blocking(move || {
+        let mut fetched = Vec::with_capacity(ips.len());
+        for ip in ips {
+            match whois_client.get_ip_info(&ip) {
+                Ok(info) => fetched.push((ip, info)),
+                // Left unstored on purpose: no row means select_unknown_ips offers it again next run.
+                Err(err) => warn!("Couldn't fetch info about IP {ip}: {err}"),
+            }
+        }
+        fetched
+    })
+    .await?;
+
+    let upserted = upsert_ip_info(psql_client, &fetched, Utc::now()).await?;
+
+    info!("Stored info about {upserted} IPs");
+
+    Ok(())
+}

--- a/store/src/ip_info.rs
+++ b/store/src/ip_info.rs
@@ -48,7 +48,13 @@ fn is_worth_looking_up(ip: &str) -> bool {
                 && !v4.is_broadcast()
                 && !v4.is_documentation()
         }
-        Ok(IpAddr::V6(v6)) => !v6.is_loopback() && !v6.is_unspecified(),
+        Ok(IpAddr::V6(v6)) => {
+            !v6.is_loopback()
+                && !v6.is_unspecified()
+                && !v6.is_multicast()
+                && !v6.is_unique_local()
+                && !v6.is_unicast_link_local()
+        }
         Err(_) => false,
     }
 }
@@ -268,6 +274,10 @@ mod tests {
         assert!(!is_worth_looking_up("0.0.0.0"));
         assert!(!is_worth_looking_up("255.255.255.255"));
         assert!(!is_worth_looking_up("::1"));
+        assert!(!is_worth_looking_up("::"));
+        assert!(!is_worth_looking_up("fc00::1"));
+        assert!(!is_worth_looking_up("fe80::1"));
+        assert!(!is_worth_looking_up("ff02::1"));
     }
 
     // parse_socket_addr splits on the last colon without validating, so the column can hold this.

--- a/store/src/ip_info.rs
+++ b/store/src/ip_info.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use collect::whois_service::{IpInfo, WhoisClient};
 use log::{info, warn};
+use std::net::IpAddr;
+use std::sync::Arc;
 use structopt::StructOpt;
 use tokio_postgres::Client;
 
@@ -30,21 +32,49 @@ pub struct StoreIpInfoParams {
     in_use_days: i32,
 }
 
-pub async fn select_unknown_ips(psql_client: &Client) -> anyhow::Result<Vec<String>> {
+// Small because each entry costs a whois round trip: the point is to commit progress often, not to
+// batch the writes.
+const UPSERT_CHUNK_SIZE: usize = 50;
+
+// gossip carries whatever a node advertises, and parse_socket_addr does not validate it, so the
+// column can hold a hostname or an unroutable address that whois can only answer nothing about.
+fn is_worth_looking_up(ip: &str) -> bool {
+    match ip.parse::<IpAddr>() {
+        Ok(IpAddr::V4(v4)) => {
+            !v4.is_private()
+                && !v4.is_loopback()
+                && !v4.is_link_local()
+                && !v4.is_unspecified()
+                && !v4.is_broadcast()
+                && !v4.is_documentation()
+        }
+        Ok(IpAddr::V6(v6)) => !v6.is_loopback() && !v6.is_unspecified(),
+        Err(_) => false,
+    }
+}
+
+// Bounded by the same in-use window as the refresh: without it a first run faces every address the
+// cluster has ever advertised, which is unbounded in history and mostly no longer reachable.
+pub async fn select_unknown_ips(
+    psql_client: &Client,
+    in_use_days: i32,
+) -> anyhow::Result<Vec<String>> {
     // NOT EXISTS rather than NOT IN: a single NULL on the right of NOT IN would discard every row.
     Ok(psql_client
         .query(
             "
         SELECT DISTINCT o.ip
         FROM node_observations o
-        WHERE o.ip IS NOT NULL AND o.ip <> '127.0.0.1'
+        WHERE o.ip IS NOT NULL
+          AND o.last_seen_at > now() - make_interval(days => $1)
           AND NOT EXISTS (SELECT 1 FROM ip_info i WHERE i.ip = o.ip)
     ",
-            &[],
+            &[&in_use_days],
         )
         .await?
         .iter()
         .map(|row| row.get("ip"))
+        .filter(|ip: &String| is_worth_looking_up(ip))
         .collect())
 }
 
@@ -53,7 +83,8 @@ pub async fn select_stale_ips(
     refresh_limit: i64,
     in_use_days: i32,
 ) -> anyhow::Result<Vec<String>> {
-    // Restricted to addresses still in gossip: an IP the cluster left is not worth paying to recheck.
+    // last_seen_at, not created_at: the latter only moves when a node changes, so a node that sits
+    // still for longer than the window would drop out of the rotation precisely for being stable.
     Ok(psql_client
         .query(
             "
@@ -62,7 +93,7 @@ pub async fn select_stale_ips(
         WHERE EXISTS (
             SELECT 1
             FROM node_observations o
-            WHERE o.ip = i.ip AND o.created_at > now() - make_interval(days => $2)
+            WHERE o.ip = i.ip AND o.last_seen_at > now() - make_interval(days => $2)
         )
         ORDER BY i.fetched_at ASC
         LIMIT $1
@@ -85,9 +116,9 @@ pub async fn upsert_ip_info(
     }
 
     let ips: Vec<&str> = fetched.iter().map(|(ip, _)| ip.as_str()).collect();
-    let asns: Vec<Option<i32>> = fetched
+    let asns: Vec<Option<i64>> = fetched
         .iter()
-        .map(|(_, info)| info.asn.map(|asn| asn as i32))
+        .map(|(_, info)| info.asn.map(|asn| asn as i64))
         .collect();
     let asos: Vec<Option<&str>> = fetched
         .iter()
@@ -128,7 +159,7 @@ pub async fn upsert_ip_info(
         )
         SELECT * FROM UNNEST(
             $1::TEXT[],
-            $2::INTEGER[],
+            $2::BIGINT[],
             $3::TEXT[],
             $4::TEXT[],
             $5::TEXT[],
@@ -172,7 +203,7 @@ pub async fn store_ip_info(
 ) -> anyhow::Result<()> {
     info!("Storing IP info...");
 
-    let unknown = select_unknown_ips(psql_client).await?;
+    let unknown = select_unknown_ips(psql_client, params.in_use_days).await?;
     let stale = select_stale_ips(psql_client, params.refresh_limit, params.in_use_days).await?;
     info!(
         "{} IPs never looked up, {} due for a refresh",
@@ -186,25 +217,63 @@ pub async fn store_ip_info(
         return Ok(());
     }
 
-    let whois_client = WhoisClient::new(params.whois, params.whois_bearer_token);
-    // WhoisClient is a blocking reqwest client and this binary runs on tokio, so the whole batch
-    // goes to a blocking thread rather than each call fighting the runtime.
-    let fetched = tokio::task::spawn_blocking(move || {
-        let mut fetched = Vec::with_capacity(ips.len());
-        for ip in ips {
-            match whois_client.get_ip_info(&ip) {
-                Ok(info) => fetched.push((ip, info)),
-                // Left unstored on purpose: no row means select_unknown_ips offers it again next run.
-                Err(err) => warn!("Couldn't fetch info about IP {ip}: {err}"),
+    let whois_client = Arc::new(WhoisClient::new(params.whois, params.whois_bearer_token));
+    let mut upserted = 0;
+    // Committed per chunk: a run killed part-way through keeps the lookups it already paid for,
+    // instead of discarding the whole batch and starting over next time.
+    for chunk in ips.chunks(UPSERT_CHUNK_SIZE) {
+        let chunk = chunk.to_vec();
+        let whois_client = whois_client.clone();
+        // WhoisClient is a blocking reqwest client and this binary runs on tokio, so the chunk goes
+        // to a blocking thread rather than each call fighting the runtime.
+        let fetched = tokio::task::spawn_blocking(move || {
+            let mut fetched = Vec::with_capacity(chunk.len());
+            for ip in chunk {
+                match whois_client.get_ip_info(&ip) {
+                    Ok(info) => fetched.push((ip, info)),
+                    // Left unstored on purpose: no row means select_unknown_ips offers it again next run.
+                    Err(err) => warn!("Couldn't fetch info about IP {ip}: {err}"),
+                }
             }
-        }
-        fetched
-    })
-    .await?;
+            fetched
+        })
+        .await?;
 
-    let upserted = upsert_ip_info(psql_client, &fetched, Utc::now()).await?;
+        upserted += upsert_ip_info(psql_client, &fetched, Utc::now()).await?;
+    }
 
     info!("Stored info about {upserted} IPs");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routable_addresses_are_looked_up() {
+        assert!(is_worth_looking_up("1.1.1.1"));
+        assert!(is_worth_looking_up("8.8.8.8"));
+        assert!(is_worth_looking_up("2606:4700:4700::1111"));
+    }
+
+    #[test]
+    fn unroutable_addresses_are_skipped() {
+        assert!(!is_worth_looking_up("127.0.0.1"));
+        assert!(!is_worth_looking_up("10.0.0.1"));
+        assert!(!is_worth_looking_up("172.16.0.1"));
+        assert!(!is_worth_looking_up("192.168.1.1"));
+        assert!(!is_worth_looking_up("169.254.0.1"));
+        assert!(!is_worth_looking_up("0.0.0.0"));
+        assert!(!is_worth_looking_up("255.255.255.255"));
+        assert!(!is_worth_looking_up("::1"));
+    }
+
+    // parse_socket_addr splits on the last colon without validating, so the column can hold this.
+    #[test]
+    fn a_non_address_is_skipped_rather_than_sent_to_whois() {
+        assert!(!is_worth_looking_up("some-host.example.com"));
+        assert!(!is_worth_looking_up(""));
+    }
 }

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod dto;
 pub mod groups;
+pub mod ip_info;
+pub mod node_observations;
 pub mod rewards;
 pub mod scoring;
 pub mod utils;

--- a/store/src/main.rs
+++ b/store/src/main.rs
@@ -3,7 +3,9 @@ use cluster_info::{store_cluster_info, StoreClusterInfoParams};
 use collect::validators_jito::JitoAccountType;
 use commissions::{store_commissions, StoreCommissionsParams};
 use env_logger::Env;
+use ip_info::{store_ip_info, StoreIpInfoParams};
 use ls_open_epochs::{list_open_epochs, LsOpenEpochsParams};
+use node_observations::{store_node_observations, StoreNodeObservationsParams};
 use openssl::ssl::{SslConnector, SslMethod};
 use postgres_openssl::MakeTlsConnector;
 use store::validators_block_rewards::{store_block_rewards, StoreBlockRewardsParams};
@@ -37,6 +39,8 @@ enum StoreCommand {
     Uptime(StoreUptimeParams),
     Commissions(StoreCommissionsParams),
     Versions(StoreVersionsParams),
+    NodeObservations(StoreNodeObservationsParams),
+    IpInfo(StoreIpInfoParams),
     ClusterInfo(StoreClusterInfoParams),
     Validators(StoreValidatorsParams),
     ValidatorsBlockRewards(StoreBlockRewardsParams),
@@ -51,7 +55,9 @@ pub mod close_epoch;
 pub mod cluster_info;
 pub mod commissions;
 pub mod dto;
+pub mod ip_info;
 pub mod ls_open_epochs;
+pub mod node_observations;
 pub mod uptime;
 pub mod utils;
 pub mod validators;
@@ -85,6 +91,10 @@ async fn main() -> anyhow::Result<()> {
         StoreCommand::Versions(store_params) => {
             store_versions(store_params, &mut psql_client).await
         }
+        StoreCommand::NodeObservations(store_params) => {
+            store_node_observations(store_params, &mut psql_client).await
+        }
+        StoreCommand::IpInfo(store_params) => store_ip_info(store_params, &mut psql_client).await,
         StoreCommand::ClusterInfo(store_params) => {
             store_cluster_info(store_params, &mut psql_client).await
         }

--- a/store/src/node_observations.rs
+++ b/store/src/node_observations.rs
@@ -52,6 +52,35 @@ struct ObservationRow {
     client_id_raw: Option<String>,
 }
 
+// Re-stamps the node's newest row instead of appending one, so an unchanged node stays a single row
+// while still proving it was in gossip at this instant.
+async fn touch_last_seen(
+    psql_client: &Client,
+    identities: &[String],
+    last_seen_at: DateTime<Utc>,
+) -> anyhow::Result<u64> {
+    if identities.is_empty() {
+        return Ok(0);
+    }
+
+    Ok(psql_client
+        .execute(
+            "
+        UPDATE node_observations o
+        SET last_seen_at = $2
+        FROM (
+            SELECT DISTINCT ON (identity) id
+            FROM node_observations
+            WHERE identity = ANY($1)
+            ORDER BY identity, created_at DESC, id DESC
+        ) newest
+        WHERE o.id = newest.id
+    ",
+            &[&identities, &last_seen_at],
+        )
+        .await?)
+}
+
 pub async fn store_node_observations(
     params: StoreNodeObservationsParams,
     psql_client: &mut Client,
@@ -104,22 +133,28 @@ pub async fn store_node_observations(
 
     // Comparing in Rust, not SQL: a node that gained or lost an address must count as changed, and
     // NULL = NULL in SQL is UNKNOWN.
-    let rows_to_insert: Vec<_> = snapshot
-        .nodes
-        .into_iter()
-        .map(|(identity, node)| ObservationRow {
+    let mut unchanged_identities: Vec<String> = Vec::new();
+    let mut rows_to_insert: Vec<ObservationRow> = Vec::new();
+    for (identity, node) in snapshot.nodes {
+        let row = ObservationRow {
             key: NodeKey::from(&node),
             client_id_raw: node.client_id_raw,
             identity,
-        })
-        .filter(|row| previous.get(&row.identity) != Some(&row.key))
-        .collect();
+        };
+        if previous.get(&row.identity) == Some(&row.key) {
+            unchanged_identities.push(row.identity);
+        } else {
+            rows_to_insert.push(row);
+        }
+    }
+
+    let touched = touch_last_seen(psql_client, &unchanged_identities, snapshot_created_at).await?;
 
     let mut insertions = 0;
     for chunk in rows_to_insert.chunks(DEFAULT_CHUNK_SIZE) {
         let mut query = InsertQueryCombiner::new(
             "node_observations".to_string(),
-            "identity, ip, gossip_port, version, client_id, client_id_raw, feature_set, shred_version, rpc_public, pubsub_public, epoch_slot, epoch, created_at".to_string(),
+            "identity, ip, gossip_port, version, client_id, client_id_raw, feature_set, shred_version, rpc_public, pubsub_public, epoch_slot, epoch, created_at, last_seen_at".to_string(),
         );
         for row in chunk {
             let mut params: Vec<&(dyn ToSql + Sync)> = vec![
@@ -136,13 +171,14 @@ pub async fn store_node_observations(
                 &snapshot_epoch_slot,
                 &snapshot_epoch,
                 &snapshot_created_at,
+                &snapshot_created_at,
             ];
             query.add(&mut params);
         }
         insertions += query.execute(psql_client).await?.unwrap_or(0);
     }
 
-    info!("Stored {insertions} node observation changes");
+    info!("Stored {insertions} node observation changes, {touched} nodes unchanged");
 
     Ok(())
 }

--- a/store/src/node_observations.rs
+++ b/store/src/node_observations.rs
@@ -91,7 +91,7 @@ pub async fn store_node_observations(
     let snapshot: ValidatorsPerformanceSnapshot = serde_yaml::from_reader(snapshot_file)?;
     let snapshot_epoch_slot: Decimal = snapshot.epoch_slot.into();
     let snapshot_epoch: Decimal = snapshot.epoch.into();
-    let snapshot_created_at: DateTime<Utc> = snapshot.created_at.parse().unwrap();
+    let snapshot_created_at: DateTime<Utc> = snapshot.created_at.parse()?;
 
     info!("Loaded the snapshot");
 

--- a/store/src/node_observations.rs
+++ b/store/src/node_observations.rs
@@ -1,0 +1,148 @@
+use crate::utils::InsertQueryCombiner;
+use chrono::{DateTime, Utc};
+use collect::solana_service::NodeContact;
+use collect::validators_performance::ValidatorsPerformanceSnapshot;
+use log::info;
+use rust_decimal::prelude::*;
+use serde_yaml;
+use std::collections::HashMap;
+use structopt::StructOpt;
+use tokio_postgres::{types::ToSql, Client};
+
+#[derive(Debug, StructOpt)]
+pub struct StoreNodeObservationsParams {
+    #[structopt(long = "snapshot-file")]
+    snapshot_path: String,
+}
+
+const DEFAULT_CHUNK_SIZE: usize = 500;
+
+// Only what a new row is worth recording for. client_id_raw renders per answering RPC rather than
+// per node, and an epoch in here would re-insert every node at each rollover the way versions does.
+#[derive(PartialEq)]
+struct NodeKey {
+    ip: Option<String>,
+    gossip_port: Option<i32>,
+    version: Option<String>,
+    client_id: Option<i32>,
+    feature_set: Option<i64>,
+    shred_version: Option<i32>,
+    rpc_public: Option<bool>,
+    pubsub_public: Option<bool>,
+}
+
+impl From<&NodeContact> for NodeKey {
+    fn from(node: &NodeContact) -> Self {
+        Self {
+            ip: node.ip.clone(),
+            gossip_port: node.gossip_port.map(|p| p as i32),
+            version: node.version.clone(),
+            client_id: node.client_id.map(|id| id as i32),
+            feature_set: node.feature_set.map(|f| f as i64),
+            shred_version: node.shred_version.map(|s| s as i32),
+            rpc_public: Some(node.rpc_public),
+            pubsub_public: Some(node.pubsub_public),
+        }
+    }
+}
+
+struct ObservationRow {
+    identity: String,
+    key: NodeKey,
+    client_id_raw: Option<String>,
+}
+
+pub async fn store_node_observations(
+    params: StoreNodeObservationsParams,
+    psql_client: &mut Client,
+) -> anyhow::Result<()> {
+    info!("Storing node observations...");
+
+    let snapshot_file = std::fs::File::open(params.snapshot_path)?;
+    let snapshot: ValidatorsPerformanceSnapshot = serde_yaml::from_reader(snapshot_file)?;
+    let snapshot_epoch_slot: Decimal = snapshot.epoch_slot.into();
+    let snapshot_epoch: Decimal = snapshot.epoch.into();
+    let snapshot_created_at: DateTime<Utc> = snapshot.created_at.parse().unwrap();
+
+    info!("Loaded the snapshot");
+
+    let mut previous: HashMap<String, NodeKey> = Default::default();
+    for row in psql_client
+        .query(
+            "
+        SELECT DISTINCT ON (identity)
+            identity,
+            ip,
+            gossip_port,
+            version,
+            client_id,
+            feature_set,
+            shred_version,
+            rpc_public,
+            pubsub_public
+        FROM node_observations
+        ORDER BY identity, created_at DESC, id DESC
+    ",
+            &[],
+        )
+        .await?
+    {
+        previous.insert(
+            row.get("identity"),
+            NodeKey {
+                ip: row.get("ip"),
+                gossip_port: row.get("gossip_port"),
+                version: row.get("version"),
+                client_id: row.get("client_id"),
+                feature_set: row.get("feature_set"),
+                shred_version: row.get("shred_version"),
+                rpc_public: row.get("rpc_public"),
+                pubsub_public: row.get("pubsub_public"),
+            },
+        );
+    }
+
+    // Comparing in Rust, not SQL: a node that gained or lost an address must count as changed, and
+    // NULL = NULL in SQL is UNKNOWN.
+    let rows_to_insert: Vec<_> = snapshot
+        .nodes
+        .into_iter()
+        .map(|(identity, node)| ObservationRow {
+            key: NodeKey::from(&node),
+            client_id_raw: node.client_id_raw,
+            identity,
+        })
+        .filter(|row| previous.get(&row.identity) != Some(&row.key))
+        .collect();
+
+    let mut insertions = 0;
+    for chunk in rows_to_insert.chunks(DEFAULT_CHUNK_SIZE) {
+        let mut query = InsertQueryCombiner::new(
+            "node_observations".to_string(),
+            "identity, ip, gossip_port, version, client_id, client_id_raw, feature_set, shred_version, rpc_public, pubsub_public, epoch_slot, epoch, created_at".to_string(),
+        );
+        for row in chunk {
+            let mut params: Vec<&(dyn ToSql + Sync)> = vec![
+                &row.identity,
+                &row.key.ip,
+                &row.key.gossip_port,
+                &row.key.version,
+                &row.key.client_id,
+                &row.client_id_raw,
+                &row.key.feature_set,
+                &row.key.shred_version,
+                &row.key.rpc_public,
+                &row.key.pubsub_public,
+                &snapshot_epoch_slot,
+                &snapshot_epoch,
+                &snapshot_created_at,
+            ];
+            query.add(&mut params);
+        }
+        insertions += query.execute(psql_client).await?.unwrap_or(0);
+    }
+
+    info!("Stored {insertions} node observation changes");
+
+    Ok(())
+}

--- a/store/src/node_observations.rs
+++ b/store/src/node_observations.rs
@@ -67,7 +67,7 @@ async fn touch_last_seen(
         .execute(
             "
         UPDATE node_observations o
-        SET last_seen_at = $2
+        SET last_seen_at = GREATEST(o.last_seen_at, $2)
         FROM (
             SELECT DISTINCT ON (identity) id
             FROM node_observations

--- a/store/tests/ip_info_sql.rs
+++ b/store/tests/ip_info_sql.rs
@@ -1,0 +1,149 @@
+mod common;
+
+use chrono::{DateTime, Duration, Utc};
+use collect::whois_service::{Coordinates, IpInfo};
+use common::{migrated_client, skip_without_database};
+use store::ip_info::{select_stale_ips, select_unknown_ips, upsert_ip_info};
+use tokio_postgres::Client;
+
+fn info(city: Option<&str>) -> IpInfo {
+    IpInfo {
+        asn: Some(64500),
+        aso: Some("Test ISP".into()),
+        coordinates: Some(Coordinates { lat: 1.5, lon: 2.5 }),
+        continent: Some("Europe".into()),
+        country_iso: Some("CZ".into()),
+        country: Some("Czechia".into()),
+        city: city.map(Into::into),
+    }
+}
+
+async fn observe(client: &Client, identity: &str, ip: Option<&str>, age: &str) {
+    client
+        .execute(
+            "INSERT INTO node_observations (identity, ip, epoch_slot, epoch, created_at)
+             VALUES ($1, $2, 0, 1000, now() - $3::text::interval)",
+            &[&identity, &ip, &age],
+        )
+        .await
+        .unwrap();
+}
+
+async fn enrich(client: &Client, ip: &str, fetched_at: DateTime<Utc>) {
+    upsert_ip_info(client, &[(ip.to_string(), info(Some("Brno")))], fetched_at)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn only_addresses_never_looked_up_are_offered() {
+    let schema = "ds_test_ip_info_unknown";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    observe(&client, "identityA", Some("1.1.1.1"), "1 minute").await;
+    observe(&client, "identityA", Some("1.1.1.1"), "2 minutes").await;
+    observe(&client, "identityB", Some("2.2.2.2"), "1 minute").await;
+    observe(&client, "identityC", None, "1 minute").await;
+    observe(&client, "identityD", Some("127.0.0.1"), "1 minute").await;
+    enrich(&client, "2.2.2.2", Utc::now()).await;
+
+    let unknown = select_unknown_ips(&client).await.unwrap();
+
+    assert_eq!(unknown, vec!["1.1.1.1".to_string()]);
+}
+
+#[tokio::test]
+async fn the_refresh_takes_the_oldest_addresses_up_to_the_limit() {
+    let schema = "ds_test_ip_info_rotation_order";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    for (ip, days) in [("1.1.1.1", 1), ("2.2.2.2", 3), ("3.3.3.3", 2)] {
+        observe(&client, "identityShared", Some(ip), "1 minute").await;
+        enrich(&client, ip, Utc::now() - Duration::days(days)).await;
+    }
+
+    let stale = select_stale_ips(&client, 2, 7).await.unwrap();
+
+    assert_eq!(stale, vec!["2.2.2.2".to_string(), "3.3.3.3".to_string()]);
+}
+
+#[tokio::test]
+async fn an_address_the_cluster_left_is_not_refreshed() {
+    let schema = "ds_test_ip_info_rotation_in_use";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    observe(&client, "identityStillHere", Some("1.1.1.1"), "1 hour").await;
+    observe(&client, "identityGone", Some("2.2.2.2"), "30 days").await;
+    enrich(&client, "1.1.1.1", Utc::now() - Duration::days(9)).await;
+    enrich(&client, "2.2.2.2", Utc::now() - Duration::days(10)).await;
+
+    let stale = select_stale_ips(&client, 10, 7).await.unwrap();
+
+    assert_eq!(stale, vec!["1.1.1.1".to_string()]);
+}
+
+#[tokio::test]
+async fn a_refresh_overwrites_every_field_including_back_to_null() {
+    let schema = "ds_test_ip_info_upsert";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    // Fixed instants, not now(): timestamptz keeps microseconds and Utc::now() carries nanoseconds.
+    let first: DateTime<Utc> = "2026-07-30T00:00:00Z".parse().unwrap();
+    assert_eq!(
+        upsert_ip_info(
+            &client,
+            &[("1.1.1.1".to_string(), info(Some("Brno")))],
+            first
+        )
+        .await
+        .unwrap(),
+        1
+    );
+
+    let row = client
+        .query_one("SELECT * FROM ip_info WHERE ip = '1.1.1.1'", &[])
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, Option<i32>>("asn"), Some(64500));
+    assert_eq!(
+        row.get::<_, Option<String>>("city").as_deref(),
+        Some("Brno")
+    );
+    assert_eq!(row.get::<_, Option<f64>>("coordinates_lat"), Some(1.5));
+    assert_eq!(row.get::<_, DateTime<Utc>>("fetched_at"), first);
+
+    let second: DateTime<Utc> = "2026-07-31T00:00:00Z".parse().unwrap();
+    assert_eq!(
+        upsert_ip_info(&client, &[("1.1.1.1".to_string(), info(None))], second)
+            .await
+            .unwrap(),
+        1
+    );
+
+    let row = client
+        .query_one("SELECT * FROM ip_info WHERE ip = '1.1.1.1'", &[])
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, Option<String>>("city"), None);
+    assert_eq!(row.get::<_, DateTime<Utc>>("fetched_at"), second);
+    assert_eq!(
+        client
+            .query_one("SELECT count(*) FROM ip_info", &[])
+            .await
+            .unwrap()
+            .get::<_, i64>(0),
+        1
+    );
+}

--- a/store/tests/ip_info_sql.rs
+++ b/store/tests/ip_info_sql.rs
@@ -18,12 +18,14 @@ fn info(city: Option<&str>) -> IpInfo {
     }
 }
 
-async fn observe(client: &Client, identity: &str, ip: Option<&str>, age: &str) {
+// created_at deliberately far older than last_seen_at: that gap is what the rotation must survive,
+// since a node only gets a new row when it changes.
+async fn observe(client: &Client, identity: &str, ip: Option<&str>, last_seen_age: &str) {
     client
         .execute(
-            "INSERT INTO node_observations (identity, ip, epoch_slot, epoch, created_at)
-             VALUES ($1, $2, 0, 1000, now() - $3::text::interval)",
-            &[&identity, &ip, &age],
+            "INSERT INTO node_observations (identity, ip, epoch_slot, epoch, created_at, last_seen_at)
+             VALUES ($1, $2, 0, 1000, now() - interval '365 days', now() - $3::text::interval)",
+            &[&identity, &ip, &last_seen_age],
         )
         .await
         .unwrap();
@@ -48,11 +50,38 @@ async fn only_addresses_never_looked_up_are_offered() {
     observe(&client, "identityB", Some("2.2.2.2"), "1 minute").await;
     observe(&client, "identityC", None, "1 minute").await;
     observe(&client, "identityD", Some("127.0.0.1"), "1 minute").await;
+    observe(&client, "identityE", Some("10.0.0.1"), "1 minute").await;
+    observe(&client, "identityF", Some("3.3.3.3"), "30 days").await;
     enrich(&client, "2.2.2.2", Utc::now()).await;
 
-    let unknown = select_unknown_ips(&client).await.unwrap();
+    let unknown = select_unknown_ips(&client, 7).await.unwrap();
 
     assert_eq!(unknown, vec!["1.1.1.1".to_string()]);
+}
+
+// The whole point of last_seen_at: a node that has not changed in a year is still in the cluster,
+// and its address must stay eligible for enrichment.
+#[tokio::test]
+async fn an_unchanged_node_is_still_offered_for_lookup_and_refresh() {
+    let schema = "ds_test_ip_info_stable_node";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    observe(&client, "identityStable", Some("1.1.1.1"), "1 minute").await;
+
+    assert_eq!(
+        select_unknown_ips(&client, 7).await.unwrap(),
+        vec!["1.1.1.1".to_string()]
+    );
+
+    enrich(&client, "1.1.1.1", Utc::now() - Duration::days(9)).await;
+
+    assert_eq!(
+        select_stale_ips(&client, 10, 7).await.unwrap(),
+        vec!["1.1.1.1".to_string()]
+    );
 }
 
 #[tokio::test]
@@ -116,7 +145,7 @@ async fn a_refresh_overwrites_every_field_including_back_to_null() {
         .query_one("SELECT * FROM ip_info WHERE ip = '1.1.1.1'", &[])
         .await
         .unwrap();
-    assert_eq!(row.get::<_, Option<i32>>("asn"), Some(64500));
+    assert_eq!(row.get::<_, Option<i64>>("asn"), Some(64500));
     assert_eq!(
         row.get::<_, Option<String>>("city").as_deref(),
         Some("Brno")
@@ -146,4 +175,26 @@ async fn a_refresh_overwrites_every_field_including_back_to_null() {
             .get::<_, i64>(0),
         1
     );
+}
+
+// 4-byte ASNs run past i32::MAX, and the column is what decides whether they survive the round trip.
+#[tokio::test]
+async fn a_32_bit_asn_survives_storage() {
+    let schema = "ds_test_ip_info_wide_asn";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    let mut wide = info(Some("Brno"));
+    wide.asn = Some(u32::MAX);
+    upsert_ip_info(&client, &[("1.1.1.1".to_string(), wide)], Utc::now())
+        .await
+        .unwrap();
+
+    let row = client
+        .query_one("SELECT * FROM ip_info WHERE ip = '1.1.1.1'", &[])
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, Option<i64>>("asn"), Some(u32::MAX as i64));
 }

--- a/store/tests/node_observations_sql.rs
+++ b/store/tests/node_observations_sql.rs
@@ -1,0 +1,415 @@
+mod common;
+
+use collect::slot_params::baseline_slots_per_year;
+use collect::solana_service::NodeContact;
+use collect::validators_performance::ValidatorsPerformanceSnapshot;
+use common::{migrated_client, skip_without_database, write_yaml};
+use store::node_observations::{store_node_observations, StoreNodeObservationsParams};
+use structopt::StructOpt;
+use tokio_postgres::{Client, Row};
+
+const EPOCH: u64 = 1000;
+
+fn node(ip: Option<&str>) -> NodeContact {
+    NodeContact {
+        ip: ip.map(Into::into),
+        gossip_port: Some(8001),
+        version: Some("2.0.0".into()),
+        client_id: Some(3),
+        client_id_raw: Some("Agave".into()),
+        feature_set: Some(123),
+        shred_version: Some(456),
+        rpc_public: false,
+        pubsub_public: false,
+    }
+}
+
+fn snapshot(
+    epoch: u64,
+    epoch_slot: u64,
+    created_at: &str,
+    nodes: Vec<(&str, NodeContact)>,
+) -> ValidatorsPerformanceSnapshot {
+    ValidatorsPerformanceSnapshot {
+        epoch,
+        epoch_slot,
+        transaction_count: 1,
+        created_at: created_at.into(),
+        slots_per_year: baseline_slots_per_year(),
+        cluster_inflation: None,
+        validators: Default::default(),
+        nodes: nodes
+            .into_iter()
+            .map(|(identity, node)| (identity.to_string(), node))
+            .collect(),
+        rewards: None,
+    }
+}
+
+async fn run(client: &mut Client, name: &str, snapshot: &ValidatorsPerformanceSnapshot) {
+    let path = write_yaml(name, &serde_yaml::to_string(snapshot).unwrap());
+    store_node_observations(
+        StoreNodeObservationsParams::from_iter(["store", "--snapshot-file", &path]),
+        client,
+    )
+    .await
+    .unwrap();
+    std::fs::remove_file(path).unwrap();
+}
+
+async fn count(client: &Client) -> i64 {
+    client
+        .query_one("SELECT count(*) FROM node_observations", &[])
+        .await
+        .unwrap()
+        .get(0)
+}
+
+async fn rows_for(client: &Client, identity: &str) -> Vec<Row> {
+    client
+        .query(
+            "SELECT * FROM node_observations WHERE identity = $1 ORDER BY created_at, id",
+            &[&identity],
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn a_first_run_records_every_node_field() {
+    let schema = "ds_test_node_observations_first_run";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            10,
+            "2026-07-31T00:00:00Z",
+            vec![
+                ("identityA", node(Some("1.2.3.4"))),
+                ("identityB", node(Some("5.6.7.8"))),
+                ("identityC", node(None)),
+            ],
+        ),
+    )
+    .await;
+
+    assert_eq!(count(&client).await, 3);
+
+    let rows = rows_for(&client, "identityA").await;
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(
+        row.get::<_, Option<String>>("ip").as_deref(),
+        Some("1.2.3.4")
+    );
+    assert_eq!(row.get::<_, Option<i32>>("gossip_port"), Some(8001));
+    assert_eq!(
+        row.get::<_, Option<String>>("version").as_deref(),
+        Some("2.0.0")
+    );
+    assert_eq!(row.get::<_, Option<i32>>("client_id"), Some(3));
+    assert_eq!(
+        row.get::<_, Option<String>>("client_id_raw").as_deref(),
+        Some("Agave")
+    );
+    assert_eq!(row.get::<_, Option<i64>>("feature_set"), Some(123));
+    assert_eq!(row.get::<_, Option<i32>>("shred_version"), Some(456));
+    assert_eq!(row.get::<_, Option<bool>>("rpc_public"), Some(false));
+    assert_eq!(row.get::<_, Option<bool>>("pubsub_public"), Some(false));
+
+    let unaddressed = rows_for(&client, "identityC").await;
+    assert_eq!(unaddressed.len(), 1);
+    assert_eq!(unaddressed[0].get::<_, Option<String>>("ip"), None);
+}
+
+#[tokio::test]
+async fn an_identical_second_run_records_nothing() {
+    let schema = "ds_test_node_observations_identical";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    let nodes = vec![
+        ("identityA", node(Some("1.2.3.4"))),
+        ("identityB", node(None)),
+    ];
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH, 10, "2026-07-31T00:00:00Z", nodes.clone()),
+    )
+    .await;
+    assert_eq!(count(&client).await, 2);
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH, 20, "2026-07-31T00:01:00Z", nodes),
+    )
+    .await;
+    assert_eq!(count(&client).await, 2);
+}
+
+#[tokio::test]
+async fn an_ip_change_appends_exactly_one_row_and_keeps_the_old_one() {
+    let schema = "ds_test_node_observations_ip_change";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            10,
+            "2026-07-31T00:00:00Z",
+            vec![("identityA", node(Some("1.2.3.4")))],
+        ),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            20,
+            "2026-07-31T00:01:00Z",
+            vec![("identityA", node(Some("9.9.9.9")))],
+        ),
+    )
+    .await;
+
+    let rows = rows_for(&client, "identityA").await;
+    assert_eq!(rows.len(), 2);
+    assert_eq!(
+        rows[0].get::<_, Option<String>>("ip").as_deref(),
+        Some("1.2.3.4")
+    );
+    assert_eq!(
+        rows[1].get::<_, Option<String>>("ip").as_deref(),
+        Some("9.9.9.9")
+    );
+}
+
+// The versions table keys on epoch too, so every validator re-inserts at each rollover. This table must not.
+#[tokio::test]
+async fn an_epoch_rollover_alone_records_nothing() {
+    let schema = "ds_test_node_observations_rollover";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    let nodes = vec![("identityA", node(Some("1.2.3.4")))];
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH, 431_000, "2026-07-31T00:00:00Z", nodes.clone()),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH + 1, 5, "2026-07-31T00:01:00Z", nodes),
+    )
+    .await;
+
+    assert_eq!(count(&client).await, 1);
+}
+
+#[tokio::test]
+async fn a_client_id_raw_only_change_records_nothing() {
+    let schema = "ds_test_node_observations_client_id_raw";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    let mut renamed = node(Some("1.2.3.4"));
+    renamed.client_id_raw = Some("Unknown(3)".into());
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            10,
+            "2026-07-31T00:00:00Z",
+            vec![("identityA", node(Some("1.2.3.4")))],
+        ),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            20,
+            "2026-07-31T00:01:00Z",
+            vec![("identityA", renamed)],
+        ),
+    )
+    .await;
+
+    assert_eq!(count(&client).await, 1);
+    assert_eq!(
+        rows_for(&client, "identityA").await[0]
+            .get::<_, Option<String>>("client_id_raw")
+            .as_deref(),
+        Some("Agave")
+    );
+}
+
+#[tokio::test]
+async fn gaining_and_losing_an_address_both_record() {
+    let schema = "ds_test_node_observations_null_transitions";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            10,
+            "2026-07-31T00:00:00Z",
+            vec![("identityA", node(None))],
+        ),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            20,
+            "2026-07-31T00:01:00Z",
+            vec![("identityA", node(Some("1.2.3.4")))],
+        ),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            30,
+            "2026-07-31T00:02:00Z",
+            vec![("identityA", node(None))],
+        ),
+    )
+    .await;
+
+    let ips: Vec<Option<String>> = rows_for(&client, "identityA")
+        .await
+        .iter()
+        .map(|row| row.get("ip"))
+        .collect();
+    assert_eq!(ips, vec![None, Some("1.2.3.4".to_string()), None]);
+}
+
+// The coverage promise: this table is fed from gossip, so a node that votes for nothing still lands.
+#[tokio::test]
+async fn a_node_with_no_vote_account_is_recorded() {
+    let schema = "ds_test_node_observations_non_voting";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    let mut snapshot = snapshot(
+        EPOCH,
+        10,
+        "2026-07-31T00:00:00Z",
+        vec![("identityRpcOnly", node(Some("1.2.3.4")))],
+    );
+    snapshot.validators = Default::default();
+    run(&mut client, schema, &snapshot).await;
+
+    assert_eq!(rows_for(&client, "identityRpcOnly").await.len(), 1);
+}
+
+// 1200 nodes cross the 500-row chunk boundary; unchunked this would head for the 65535-parameter cap.
+#[tokio::test]
+async fn more_nodes_than_one_chunk_are_all_recorded() {
+    let schema = "ds_test_node_observations_chunking";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    let identities: Vec<String> = (0..1200).map(|i| format!("identityChunk{i}")).collect();
+    let nodes: Vec<(&str, NodeContact)> = identities
+        .iter()
+        .map(|identity| (identity.as_str(), node(Some("1.2.3.4"))))
+        .collect();
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH, 10, "2026-07-31T00:00:00Z", nodes.clone()),
+    )
+    .await;
+    assert_eq!(count(&client).await, 1200);
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH, 20, "2026-07-31T00:01:00Z", nodes),
+    )
+    .await;
+    assert_eq!(count(&client).await, 1200);
+}
+
+#[tokio::test]
+async fn an_rpc_public_flip_records_a_row() {
+    let schema = "ds_test_node_observations_rpc_public";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    let mut serving = node(Some("1.2.3.4"));
+    serving.rpc_public = true;
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            10,
+            "2026-07-31T00:00:00Z",
+            vec![("identityA", node(Some("1.2.3.4")))],
+        ),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            20,
+            "2026-07-31T00:01:00Z",
+            vec![("identityA", serving)],
+        ),
+    )
+    .await;
+
+    let flags: Vec<Option<bool>> = rows_for(&client, "identityA")
+        .await
+        .iter()
+        .map(|row| row.get("rpc_public"))
+        .collect();
+    assert_eq!(flags, vec![Some(false), Some(true)]);
+}

--- a/store/tests/node_observations_sql.rs
+++ b/store/tests/node_observations_sql.rs
@@ -451,6 +451,41 @@ async fn an_unchanged_node_keeps_one_row_but_advances_last_seen_at() {
     );
 }
 
+// Backfilling an old snapshot must not shorten the observed interval, or the address drops out of the in-use window ip-info selects on.
+#[tokio::test]
+async fn a_replayed_older_snapshot_does_not_move_last_seen_at_backward() {
+    let schema = "ds_test_node_observations_replay";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    let nodes = vec![("identityA", node(Some("1.2.3.4")))];
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH, 20, "2026-08-30T00:00:00Z", nodes.clone()),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH, 10, "2026-07-31T00:00:00Z", nodes),
+    )
+    .await;
+
+    let rows = rows_for(&client, "identityA").await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].get::<_, DateTime<Utc>>("created_at"),
+        "2026-08-30T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    );
+    assert_eq!(
+        rows[0].get::<_, DateTime<Utc>>("last_seen_at"),
+        "2026-08-30T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    );
+}
+
 // A node that stops gossiping must stop advancing, or the departure is invisible.
 #[tokio::test]
 async fn a_node_absent_from_the_snapshot_keeps_its_old_last_seen_at() {

--- a/store/tests/node_observations_sql.rs
+++ b/store/tests/node_observations_sql.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use chrono::{DateTime, Utc};
 use collect::slot_params::baseline_slots_per_year;
 use collect::solana_service::NodeContact;
 use collect::validators_performance::ValidatorsPerformanceSnapshot;
@@ -412,4 +413,129 @@ async fn an_rpc_public_flip_records_a_row() {
         .map(|row| row.get("rpc_public"))
         .collect();
     assert_eq!(flags, vec![Some(false), Some(true)]);
+}
+
+// The gap P1 of the review turned on: an unchanged node appends nothing, so only last_seen_at can
+// still prove it is in the cluster.
+#[tokio::test]
+async fn an_unchanged_node_keeps_one_row_but_advances_last_seen_at() {
+    let schema = "ds_test_node_observations_last_seen";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    let nodes = vec![("identityA", node(Some("1.2.3.4")))];
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH, 10, "2026-07-31T00:00:00Z", nodes.clone()),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(EPOCH, 20, "2026-08-30T00:00:00Z", nodes),
+    )
+    .await;
+
+    let rows = rows_for(&client, "identityA").await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].get::<_, DateTime<Utc>>("created_at"),
+        "2026-07-31T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    );
+    assert_eq!(
+        rows[0].get::<_, DateTime<Utc>>("last_seen_at"),
+        "2026-08-30T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    );
+}
+
+// A node that stops gossiping must stop advancing, or the departure is invisible.
+#[tokio::test]
+async fn a_node_absent_from_the_snapshot_keeps_its_old_last_seen_at() {
+    let schema = "ds_test_node_observations_departed";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            10,
+            "2026-07-31T00:00:00Z",
+            vec![
+                ("identityStays", node(Some("1.2.3.4"))),
+                ("identityLeaves", node(Some("5.6.7.8"))),
+            ],
+        ),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            20,
+            "2026-08-30T00:00:00Z",
+            vec![("identityStays", node(Some("1.2.3.4")))],
+        ),
+    )
+    .await;
+
+    assert_eq!(
+        rows_for(&client, "identityLeaves").await[0].get::<_, DateTime<Utc>>("last_seen_at"),
+        "2026-07-31T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    );
+    assert_eq!(
+        rows_for(&client, "identityStays").await[0].get::<_, DateTime<Utc>>("last_seen_at"),
+        "2026-08-30T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    );
+}
+
+// A changed node gets a fresh row; the superseded one must keep the last_seen_at it actually had.
+#[tokio::test]
+async fn a_changed_node_does_not_advance_the_superseded_row() {
+    let schema = "ds_test_node_observations_superseded";
+    if skip_without_database(schema) {
+        return;
+    }
+    let mut client = migrated_client(schema).await.unwrap();
+
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            10,
+            "2026-07-31T00:00:00Z",
+            vec![("identityA", node(Some("1.2.3.4")))],
+        ),
+    )
+    .await;
+    run(
+        &mut client,
+        schema,
+        &snapshot(
+            EPOCH,
+            20,
+            "2026-08-30T00:00:00Z",
+            vec![("identityA", node(Some("9.9.9.9")))],
+        ),
+    )
+    .await;
+
+    let rows = rows_for(&client, "identityA").await;
+    assert_eq!(rows.len(), 2);
+    assert_eq!(
+        rows[0].get::<_, DateTime<Utc>>("last_seen_at"),
+        "2026-07-31T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    );
+    assert_eq!(
+        rows[1].get::<_, DateTime<Utc>>("last_seen_at"),
+        "2026-08-30T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+    );
 }

--- a/store/tests/store_client_columns_sql.rs
+++ b/store/tests/store_client_columns_sql.rs
@@ -77,6 +77,7 @@ async fn run_store_versions(client: &mut Client, name: &str, fields: &ClientFiel
         slots_per_year: baseline_slots_per_year(),
         cluster_inflation: None,
         validators,
+        nodes: Default::default(),
         rewards: None,
     };
     let path = write_yaml(name, &serde_yaml::to_string(&snapshot).unwrap());


### PR DESCRIPTION
Idea to enhance the data gathering about validators - coming from the discussion and request at https://marinade-group.slack.com/archives/C0BJZAZC66S/p1786979468874989?thread_ts=1786979465.398279&cid=C0BJZAZC66S

This PR is about gathering more detailed data. It does not include any API updates, but it may (hopefully) support some upcoming feature requests for the explorer project.

One side effect worth naming: the whois client now treats a non-2xx answer as a failure, which makes `validators.dc_*` stickier - a failed lookup leaves the previously stored values in place instead of blanking them. The API schema and endpoints are unchanged.

Ops-infra update: https://github.com/marinade-finance/ops-infra/pull/2773


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added storage for node observations, including gossip metadata, visibility, epoch, and timestamp information.
  - Added IP enrichment storage for ASN, organization, geographic location, and coordinates.
  - Added command-line operations and scripts for saving node observations and IP information.
  - Validator performance snapshots now retain cluster node contact data.

- **Bug Fixes**
  - Improved handling of missing snapshot data and repeated observation updates.
  - Failed IP lookups remain eligible for later retries.
  - Improved validation and handling of unsuccessful enrichment responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
