### PR TITLE
[GEN-8375] fix null validator version bug

### DIFF
--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1201,6 +1201,11 @@ pub async fn load_validators(
                     rugged_commission_occurrences: 0,
                 });
 
+            // Gossip can miss a node for a whole epoch, leaving that epoch's row versionless; rows arrive epoch-DESC, so this lands the newest epoch that observed a version.
+            if record.version.is_none() {
+                record.version = row.get("version");
+            }
+
             let seeding_epoch = *seeding_epochs.entry(vote_account.clone()).or_insert(epoch);
             // Gating all three on max_observed keeps them from one row; stopping one epoch below the record's own is what makes that row the newest closed epoch rather than whichever older row still happens to have the column. commission_advertised deliberately stays on the open epoch that seeded the record.
             if record.commission_max_observed.is_none() && epoch + 1 >= seeding_epoch {

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1207,17 +1207,18 @@ pub async fn load_validators(
                 });
 
             // Rows are newest-first, so project all node metadata from the first usable row.
-            let has_node_metadata = [
-                rpc_public.is_some(),
-                version.is_some(),
-                stored_client_id.is_some(),
-                client_id_raw.is_some(),
-                feature_set.is_some(),
-                shred_version.is_some(),
-            ]
-            .into_iter()
-            .any(|present| present);
-            if has_node_metadata && !projected_node_metadata.contains(&vote_account) {
+            let has_node_metadata = rpc_public.is_some()
+                || pubsub_public.is_some()
+                || gossip_port.is_some()
+                || version.is_some()
+                || stored_client_id.is_some()
+                || client_id_raw.is_some()
+                || feature_set.is_some()
+                || shred_version.is_some();
+            if has_node_metadata
+                && row.get::<_, &str>("identity") == record.identity
+                && !projected_node_metadata.contains(&vote_account)
+            {
                 record.version = version.clone();
                 record.client_id = client_id;
                 record.client_name = client_name(client_id);
@@ -1295,9 +1296,9 @@ pub async fn load_validators(
                 client_id_raw,
                 feature_set,
                 shred_version,
-                gossip_port: row.get::<_, Option<i32>>("gossip_port").map(|n| n as u16),
+                gossip_port,
                 rpc_public,
-                pubsub_public: row.get("pubsub_public"),
+                pubsub_public,
                 activated_stake: row.get::<_, Decimal>("activated_stake"),
                 marinade_stake: row.get::<_, Decimal>("marinade_stake"),
                 foundation_stake: row.get::<_, Decimal>("foundation_stake"),

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1071,6 +1071,7 @@ pub async fn load_validators(
         log::info!("Aggregating validator records...");
         let mut records: HashMap<_, _> = Default::default();
         let mut seeding_epochs: HashMap<String, u64> = Default::default();
+        let mut projected_node_metadata: HashSet<String> = Default::default();
         for row in rows {
             let vote_account: String = row.get("vote_account");
             let epoch: u64 = row.get::<_, Decimal>("epoch").try_into().unwrap();
@@ -1122,11 +1123,13 @@ pub async fn load_validators(
                 .as_ref()
                 .and_then(|c| c.dc_concentration_by_country.get(&dc_country).cloned());
 
+            let version: Option<String> = row.get("version");
+            let stored_client_id = row.get::<_, Option<i32>>("client_id").map(|n| n as u16);
             let client_id_raw: Option<String> = row.get("client_id_raw");
-            let client_id = effective_client_id(
-                row.get::<_, Option<i32>>("client_id").map(|n| n as u16),
-                client_id_raw.as_deref(),
-            );
+            let client_id = effective_client_id(stored_client_id, client_id_raw.as_deref());
+            let feature_set = row.get::<_, Option<i64>>("feature_set").map(|n| n as u32);
+            let shred_version = row.get::<_, Option<i32>>("shred_version").map(|n| n as u16);
+            let rpc_public: Option<bool> = row.get("rpc_public");
 
             let record = records
                 .entry(vote_account.clone())
@@ -1158,17 +1161,17 @@ pub async fn load_validators(
                     commission_advertised: row.get::<_, Option<i32>>("commission_advertised"),
                     commission_effective: row.get::<_, Option<i32>>("commission_effective"),
                     commission_aggregated: None,
-                    version: row.get("version"),
+                    version: version.clone(),
                     client_id,
                     client_name: client_name(client_id),
                     client_label: client_label(client_id),
                     client_vendor: client_vendor(client_id),
                     client_lineage: client_lineage(client_id),
                     client_id_raw: client_id_raw.clone(),
-                    feature_set: row.get::<_, Option<i64>>("feature_set").map(|n| n as u32),
-                    shred_version: row.get::<_, Option<i32>>("shred_version").map(|n| n as u16),
+                    feature_set,
+                    shred_version,
                     gossip_port: row.get::<_, Option<i32>>("gossip_port").map(|n| n as u16),
-                    rpc_public: row.get("rpc_public"),
+                    rpc_public,
                     pubsub_public: row.get("pubsub_public"),
                     activated_stake: row.get::<_, Decimal>("activated_stake"),
                     marinade_stake: row.get::<_, Decimal>("marinade_stake"),
@@ -1201,9 +1204,28 @@ pub async fn load_validators(
                     rugged_commission_occurrences: 0,
                 });
 
-            // Gossip can miss a node for a whole epoch, leaving that epoch's row versionless; rows arrive epoch-DESC, so this lands the newest epoch that observed a version.
-            if record.version.is_none() {
-                record.version = row.get("version");
+            // Rows are newest-first, so project all node metadata from the first usable row.
+            let has_node_metadata = [
+                rpc_public.is_some(),
+                version.is_some(),
+                stored_client_id.is_some(),
+                client_id_raw.is_some(),
+                feature_set.is_some(),
+                shred_version.is_some(),
+            ]
+            .into_iter()
+            .any(|present| present);
+            if has_node_metadata && !projected_node_metadata.contains(&vote_account) {
+                record.version = version.clone();
+                record.client_id = client_id;
+                record.client_name = client_name(client_id);
+                record.client_label = client_label(client_id);
+                record.client_vendor = client_vendor(client_id);
+                record.client_lineage = client_lineage(client_id);
+                record.client_id_raw = client_id_raw.clone();
+                record.feature_set = feature_set;
+                record.shred_version = shred_version;
+                projected_node_metadata.insert(vote_account.clone());
             }
 
             let seeding_epoch = *seeding_epochs.entry(vote_account.clone()).or_insert(epoch);
@@ -1253,7 +1275,7 @@ pub async fn load_validators(
                 commission_effective: row
                     .get::<_, Option<i32>>("commission_effective")
                     .map(|n| n.try_into().unwrap()),
-                version: row.get("version"),
+                version,
                 mev_commission_bps: row.get::<_, Option<i32>>("mev_commission_bps"),
                 priority_commission_bps: row.get::<_, Option<i32>>("priority_commission_bps"),
                 dc_asn: row.get::<_, Option<i32>>("dc_asn"),
@@ -1266,10 +1288,10 @@ pub async fn load_validators(
                 client_vendor: client_vendor(client_id),
                 client_lineage: client_lineage(client_id),
                 client_id_raw,
-                feature_set: row.get::<_, Option<i64>>("feature_set").map(|n| n as u32),
-                shred_version: row.get::<_, Option<i32>>("shred_version").map(|n| n as u16),
+                feature_set,
+                shred_version,
                 gossip_port: row.get::<_, Option<i32>>("gossip_port").map(|n| n as u16),
-                rpc_public: row.get("rpc_public"),
+                rpc_public,
                 pubsub_public: row.get("pubsub_public"),
                 activated_stake: row.get::<_, Decimal>("activated_stake"),
                 marinade_stake: row.get::<_, Decimal>("marinade_stake"),

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1130,6 +1130,8 @@ pub async fn load_validators(
             let feature_set = row.get::<_, Option<i64>>("feature_set").map(|n| n as u32);
             let shred_version = row.get::<_, Option<i32>>("shred_version").map(|n| n as u16);
             let rpc_public: Option<bool> = row.get("rpc_public");
+            let pubsub_public: Option<bool> = row.get("pubsub_public");
+            let gossip_port = row.get::<_, Option<i32>>("gossip_port").map(|n| n as u16);
 
             let record = records
                 .entry(vote_account.clone())
@@ -1170,9 +1172,9 @@ pub async fn load_validators(
                     client_id_raw: client_id_raw.clone(),
                     feature_set,
                     shred_version,
-                    gossip_port: row.get::<_, Option<i32>>("gossip_port").map(|n| n as u16),
+                    gossip_port,
                     rpc_public,
-                    pubsub_public: row.get("pubsub_public"),
+                    pubsub_public,
                     activated_stake: row.get::<_, Decimal>("activated_stake"),
                     marinade_stake: row.get::<_, Decimal>("marinade_stake"),
                     foundation_stake: row.get::<_, Decimal>("foundation_stake"),
@@ -1225,6 +1227,9 @@ pub async fn load_validators(
                 record.client_id_raw = client_id_raw.clone();
                 record.feature_set = feature_set;
                 record.shred_version = shred_version;
+                record.gossip_port = gossip_port;
+                record.rpc_public = rpc_public;
+                record.pubsub_public = pubsub_public;
                 projected_node_metadata.insert(vote_account.clone());
             }
 

--- a/store/tests/validator_version_projection_sql.rs
+++ b/store/tests/validator_version_projection_sql.rs
@@ -1,0 +1,143 @@
+mod common;
+
+use common::{migrated_client, skip_without_database};
+use rust_decimal::Decimal;
+use store::utils::{load_validators, ValidatorOverlays};
+
+const EPOCH_OBSERVED: u64 = 996;
+const EPOCH_BLANK: u64 = 997;
+const EPOCH_OPEN: u64 = 998;
+
+#[tokio::test]
+async fn load_validators_projects_the_newest_observed_version() {
+    let schema = "ds_test_load_validators_version_projection";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    client
+        .execute(
+            "INSERT INTO cluster_info (epoch_slot, epoch, transaction_count, created_at)
+             VALUES (1, $1, 0, NOW()), (1, $2, 0, NOW()), (1, $3, 0, NOW())",
+            &[
+                &Decimal::from(EPOCH_OBSERVED),
+                &Decimal::from(EPOCH_BLANK),
+                &Decimal::from(EPOCH_OPEN),
+            ],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "INSERT INTO validators (
+                identity, vote_account, epoch, activated_stake, marinade_stake,
+                marinade_native_stake, superminority, stake_to_become_superminority, credits,
+                leader_slots, blocks_produced, skip_rate, updated_at, version, client_id,
+                client_id_raw, feature_set, shred_version, rpc_public, pubsub_public
+            ) VALUES
+                ('identityGossipGap', 'voteGossipGap', $1, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.1.0-rc.1', 3, 'Agave', 123, 456, false, false),
+                ('identityGossipGap', 'voteGossipGap', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+                ('identityGossipGap', 'voteGossipGap', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+                ('identitySeen', 'voteSeen', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.0.3', 3, 'Agave', 111, 222, false, false),
+                ('identitySeen', 'voteSeen', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.1.0', 1, 'Jito', 333, 444, true, false),
+                ('identityPartial', 'votePartial', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.0.3', 3, 'Agave', 111, 222, false, false),
+                ('identityPartial', 'votePartial', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, 1, 'Jito', 333, 444, false, false),
+                ('identityRetained', 'voteRetained', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.0.3', 3, 'Agave', 111, 222, false, false),
+                ('identityRetained', 'voteRetained', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.1.0', 1, 'Jito', NULL, NULL, NULL, NULL),
+                ('identityNeverSeen', 'voteNeverSeen', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, NULL, NULL, NULL, NULL, NULL, NULL)",
+            &[
+                &Decimal::from(EPOCH_OBSERVED),
+                &Decimal::from(EPOCH_BLANK),
+                &Decimal::from(EPOCH_OPEN),
+            ],
+        )
+        .await
+        .unwrap();
+
+    let validators = load_validators(
+        &client,
+        "http://127.0.0.1:1".to_string(),
+        3,
+        1,
+        &ValidatorOverlays::default(),
+    )
+    .await
+    .unwrap();
+
+    let gap = validators
+        .get("voteGossipGap")
+        .expect("voteGossipGap must load");
+    assert_eq!(
+        gap.version,
+        Some("4.1.0-rc.1".to_string()),
+        "two versionless epochs must not read as a versionless validator"
+    );
+    assert_eq!(gap.client_id, Some(3));
+    assert_eq!(gap.client_name, "Agave");
+    assert_eq!(gap.client_label, "Agave");
+    assert_eq!(gap.client_vendor, Some("agave".to_string()));
+    assert_eq!(gap.client_lineage, Some("agave".to_string()));
+    assert_eq!(gap.client_id_raw, Some("Agave".to_string()));
+    assert_eq!(gap.feature_set, Some(123));
+    assert_eq!(gap.shred_version, Some(456));
+    assert_eq!(
+        gap.epoch_stats
+            .iter()
+            .map(|s| (s.epoch, s.version.clone()))
+            .collect::<Vec<_>>(),
+        vec![
+            (EPOCH_OPEN, None),
+            (EPOCH_BLANK, None),
+            (EPOCH_OBSERVED, Some("4.1.0-rc.1".to_string())),
+        ],
+        "the epochs that observed nothing must stay empty"
+    );
+    assert_eq!(gap.epoch_stats[0].client_id, None);
+    assert_eq!(gap.epoch_stats[0].client_name, "Unknown");
+    assert_eq!(gap.epoch_stats[0].feature_set, None);
+    assert_eq!(gap.epoch_stats[0].shred_version, None);
+    assert_eq!(gap.epoch_stats[2].client_id, Some(3));
+    assert_eq!(gap.epoch_stats[2].client_name, "Agave");
+    assert_eq!(gap.epoch_stats[2].feature_set, Some(123));
+    assert_eq!(gap.epoch_stats[2].shred_version, Some(456));
+
+    let seen = validators.get("voteSeen").unwrap();
+    assert_eq!(
+        seen.version,
+        Some("4.1.0".to_string()),
+        "an upgrade in the newest epoch must not be shadowed by the epoch below it"
+    );
+    assert_eq!(seen.client_id, Some(1));
+    assert_eq!(seen.client_name, "Jito Labs");
+    assert_eq!(seen.client_label, "Agave + Jito");
+    assert_eq!(seen.client_vendor, Some("jito".to_string()));
+    assert_eq!(seen.client_lineage, Some("agave".to_string()));
+    assert_eq!(seen.client_id_raw, Some("Jito".to_string()));
+    assert_eq!(seen.feature_set, Some(333));
+    assert_eq!(seen.shred_version, Some(444));
+
+    let partial = validators.get("votePartial").unwrap();
+    assert_eq!(partial.version, None);
+    assert_eq!(partial.client_id, Some(1));
+    assert_eq!(partial.client_name, "Jito Labs");
+    assert_eq!(partial.feature_set, Some(333));
+    assert_eq!(partial.shred_version, Some(444));
+
+    let retained = validators.get("voteRetained").unwrap();
+    assert_eq!(retained.version, Some("4.1.0".to_string()));
+    assert_eq!(retained.client_id, Some(1));
+    assert_eq!(retained.client_name, "Jito Labs");
+    assert_eq!(retained.feature_set, None);
+    assert_eq!(retained.shred_version, None);
+    assert_eq!(
+        validators.get("voteNeverSeen").unwrap().version,
+        None,
+        "a validator never observed has nothing to project"
+    );
+
+    client
+        .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .unwrap();
+}

--- a/store/tests/validator_version_projection_sql.rs
+++ b/store/tests/validator_version_projection_sql.rs
@@ -34,18 +34,18 @@ async fn load_validators_projects_the_newest_observed_version() {
                 identity, vote_account, epoch, activated_stake, marinade_stake,
                 marinade_native_stake, superminority, stake_to_become_superminority, credits,
                 leader_slots, blocks_produced, skip_rate, updated_at, version, client_id,
-                client_id_raw, feature_set, shred_version, rpc_public, pubsub_public
+                client_id_raw, feature_set, shred_version, rpc_public, pubsub_public, gossip_port
             ) VALUES
-                ('identityGossipGap', 'voteGossipGap', $1, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.1.0-rc.1', 3, 'Agave', 123, 456, false, false),
-                ('identityGossipGap', 'voteGossipGap', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-                ('identityGossipGap', 'voteGossipGap', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-                ('identitySeen', 'voteSeen', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.0.3', 3, 'Agave', 111, 222, false, false),
-                ('identitySeen', 'voteSeen', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.1.0', 1, 'Jito', 333, 444, true, false),
-                ('identityPartial', 'votePartial', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.0.3', 3, 'Agave', 111, 222, false, false),
-                ('identityPartial', 'votePartial', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, 1, 'Jito', 333, 444, false, false),
-                ('identityRetained', 'voteRetained', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.0.3', 3, 'Agave', 111, 222, false, false),
-                ('identityRetained', 'voteRetained', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.1.0', 1, 'Jito', NULL, NULL, NULL, NULL),
-                ('identityNeverSeen', 'voteNeverSeen', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, NULL, NULL, NULL, NULL, NULL, NULL)",
+                ('identityGossipGap', 'voteGossipGap', $1, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.1.0-rc.1', 3, 'Agave', 123, 456, false, false, 8000),
+                ('identityGossipGap', 'voteGossipGap', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+                ('identityGossipGap', 'voteGossipGap', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+                ('identitySeen', 'voteSeen', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.0.3', 3, 'Agave', 111, 222, false, false, 8000),
+                ('identitySeen', 'voteSeen', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.1.0', 1, 'Jito', 333, 444, true, false, 8001),
+                ('identityPartial', 'votePartial', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.0.3', 3, 'Agave', 111, 222, false, false, 8000),
+                ('identityPartial', 'votePartial', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, 1, 'Jito', 333, 444, false, false, 8001),
+                ('identityRetained', 'voteRetained', $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.0.3', 3, 'Agave', 111, 222, false, false, 8000),
+                ('identityRetained', 'voteRetained', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), '4.1.0', 1, 'Jito', NULL, NULL, NULL, NULL, NULL),
+                ('identityNeverSeen', 'voteNeverSeen', $3, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)",
             &[
                 &Decimal::from(EPOCH_OBSERVED),
                 &Decimal::from(EPOCH_BLANK),
@@ -81,6 +81,9 @@ async fn load_validators_projects_the_newest_observed_version() {
     assert_eq!(gap.client_id_raw, Some("Agave".to_string()));
     assert_eq!(gap.feature_set, Some(123));
     assert_eq!(gap.shred_version, Some(456));
+    assert_eq!(gap.rpc_public, Some(false));
+    assert_eq!(gap.pubsub_public, Some(false));
+    assert_eq!(gap.gossip_port, Some(8000));
     assert_eq!(
         gap.epoch_stats
             .iter()
@@ -116,6 +119,9 @@ async fn load_validators_projects_the_newest_observed_version() {
     assert_eq!(seen.client_id_raw, Some("Jito".to_string()));
     assert_eq!(seen.feature_set, Some(333));
     assert_eq!(seen.shred_version, Some(444));
+    assert_eq!(seen.rpc_public, Some(true));
+    assert_eq!(seen.pubsub_public, Some(false));
+    assert_eq!(seen.gossip_port, Some(8001));
 
     let partial = validators.get("votePartial").unwrap();
     assert_eq!(partial.version, None);
@@ -123,6 +129,8 @@ async fn load_validators_projects_the_newest_observed_version() {
     assert_eq!(partial.client_name, "Jito Labs");
     assert_eq!(partial.feature_set, Some(333));
     assert_eq!(partial.shred_version, Some(444));
+    assert_eq!(partial.rpc_public, Some(false));
+    assert_eq!(partial.gossip_port, Some(8001));
 
     let retained = validators.get("voteRetained").unwrap();
     assert_eq!(retained.version, Some("4.1.0".to_string()));
@@ -130,6 +138,10 @@ async fn load_validators_projects_the_newest_observed_version() {
     assert_eq!(retained.client_name, "Jito Labs");
     assert_eq!(retained.feature_set, None);
     assert_eq!(retained.shred_version, None);
+    // The row that carries the group carries its gaps too: the older row's ports are not mixed in.
+    assert_eq!(retained.rpc_public, None);
+    assert_eq!(retained.pubsub_public, None);
+    assert_eq!(retained.gossip_port, None);
     assert_eq!(
         validators.get("voteNeverSeen").unwrap().version,
         None,


### PR DESCRIPTION
Top-level version was seeded from the newest epoch row alone, so a gossip gap in the most recent epochs made a validator read as versionless despite older epochs holding a version. Added a fill-down over the epoch-DESC rows so the record takes the newest observed version, leaving epoch_stats[].version null where nothing was observed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validator records now consistently display the latest available client and version metadata, including RPC, pubsub, and gossip details.
  * Metadata is only applied to the correct validator identity, improving accuracy when records overlap or contain gaps.
  * Per-epoch validator statistics retain metadata specific to each epoch, preventing older records from overwriting newer details.
  * Validator metadata remains correctly populated when information is missing or appears across different epochs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->