### PR TITLE
[GEN-8802] [trivial] increase epoch stats window 80->90 to match incidents window

### DIFF
--- a/api/src/handlers/events.rs
+++ b/api/src/handlers/events.rs
@@ -16,7 +16,7 @@ pub struct ResponseEvents {
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
 pub struct QueryParams {
-    /// Lower-bound epoch (inclusive). Mutually exclusive with `query_from_date`. Defaults to the last 80 epochs.
+    /// Lower-bound epoch (inclusive). Mutually exclusive with `query_from_date`. Defaults to the last 90 epochs.
     query_from_epoch: Option<u64>,
     /// Lower-bound date (RFC3339), resolved to the first epoch ending on/after it. Mutually exclusive with `query_from_epoch`.
     query_from_date: Option<DateTime<Utc>>,

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1761,7 +1761,7 @@ pub async fn load_block_production_stats(
                     COALESCE(SUM(leader_slots), 0) leader_slots,
                     COALESCE(1 - COALESCE(SUM(blocks_produced), 0) / NULLIF(SUM(leader_slots), 0), 1)::DOUBLE PRECISION avg_skip_rate
                 FROM validators
-                WHERE epoch > $1
+                WHERE epoch >= $1
                 GROUP BY epoch ORDER BY epoch DESC",
                 &[&Decimal::from(first_epoch)],
             )

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -23,7 +23,7 @@ use tokio::sync::Semaphore;
 use tokio_postgres::{types::ToSql, Client, GenericClient};
 
 /// Default number of recent epochs the API loads/serves (validators, uptimes, events, ...).
-pub const DEFAULT_CACHE_EPOCHS: u64 = 80;
+pub const DEFAULT_CACHE_EPOCHS: u64 = 90;
 
 /// Agave's year: the same one every `slots_per_year` row annualises to, so nominal and measured stay comparable.
 const SECONDS_IN_YEAR: f64 = 31556925.9936;
@@ -226,6 +226,9 @@ async fn get_apy_calculators(
 /// Window (in epochs) over which per-validator downtime incidents are collected for the
 /// `incidents` field on `/validators`.
 const DEFAULT_INCIDENTS_WINDOW_EPOCHS: u64 = 90;
+
+// Keep default cached epochs at least the size of the incidents window.
+const _: () = assert!(DEFAULT_INCIDENTS_WINDOW_EPOCHS <= DEFAULT_CACHE_EPOCHS);
 
 /// How far back to accept a validator's latest Jito commissions. Wide enough to survive an epoch
 /// with no distribution account written, short enough that a long-departed validator reads as absent.

--- a/store/src/validators_events.rs
+++ b/store/src/validators_events.rs
@@ -133,6 +133,7 @@ pub async fn get_events_with_context(
             last_epoch
                 .and_then(|e| e.to_u64())
                 .unwrap_or(0)
+                .saturating_add(1)
                 .saturating_sub(DEFAULT_CACHE_EPOCHS)
         }
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validator event queries now use the last 90 epochs by default, providing a broader history window.
  * Increased the default cached epoch range to 90 epochs for improved consistency with incident data.
  * Block production statistics now include the first epoch in the requested range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->