### PR TITLE
[GEN-8631] add expected take rates to the take-rates historical data

### DIFF
--- a/api.md
+++ b/api.md
@@ -145,6 +145,9 @@ Query parameters, mutually exclusive; without either one the whole stored histor
 
 `epoch_start_at` and `epoch_end_at` are `null` for epochs whose boundaries are not recorded.
 Such an epoch is still returned by both query modes, including the open one.
+
+`realized_take_rate` is what the validator kept that epoch; `expected_take_rate` is what its
+commissions that epoch implied it would, `null` where no commission was recorded.
 ```bash
 curl -sfLS localhost:8000/validators/XkCriyrNwS3G4rzAXtG5B1nnvb5Ka1JtCku93VqeKAr/take-rates | jq
 ```
@@ -155,7 +158,8 @@ curl -sfLS localhost:8000/validators/XkCriyrNwS3G4rzAXtG5B1nnvb5Ka1JtCku93VqeKAr
       "epoch": 378,
       "epoch_start_at": "2022-11-27T19:45:05.669098Z",
       "epoch_end_at": "2022-11-29T19:45:05.669098Z",
-      "take_rate": 0.0812,
+      "realized_take_rate": 0.0812,
+      "expected_take_rate": 0.1052,
       "created_at": "2022-11-30T15:58:04.038843Z"
     }
   ]

--- a/api.md
+++ b/api.md
@@ -147,7 +147,8 @@ Query parameters, mutually exclusive; without either one the whole stored histor
 Such an epoch is still returned by both query modes, including the open one.
 
 `realized_take_rate` is what the validator kept that epoch; `expected_take_rate` is what its
-commissions that epoch implied it would, `null` where no commission was recorded.
+commissions that epoch implied it would. It is `null` where no commission was recorded, and for
+the in-progress epoch, which has paid no inflation rewards to weight them by.
 ```bash
 curl -sfLS localhost:8000/validators/XkCriyrNwS3G4rzAXtG5B1nnvb5Ka1JtCku93VqeKAr/take-rates | jq
 ```

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -15,7 +15,7 @@ use store::dto::{
 use store::groups::ValidatorGroupings;
 use tokio::time::{sleep, timeout, Duration, Instant};
 
-use store::utils::{TakeRates, ValidatorOverlays};
+use store::utils::{RewardMixShares, TakeRates, ValidatorOverlays};
 
 pub(crate) use store::utils::DEFAULT_CACHE_EPOCHS;
 pub(crate) const DEFAULT_COMPUTING_EPOCHS: u64 = 20;
@@ -23,7 +23,7 @@ const CACHE_WARMUP_TIME_S: u64 = 10 * 60;
 const CACHE_RETRY_TIME_S: u64 = 30;
 // A step still running two refresh windows in is wedged, not slow; no probe can see that on its own.
 const WARM_STEP_TIMEOUT_S: u64 = 2 * CACHE_WARMUP_TIME_S;
-const WARM_STEPS: usize = 6;
+const WARM_STEPS: usize = 7;
 
 type CachedValidators = HashMap<String, ValidatorRecord>;
 /// Client and provider aggregates, derived from the validators they are published with.
@@ -32,6 +32,7 @@ type CachedCommissions = HashMap<String, Vec<CommissionRecord>>;
 type CachedVersions = HashMap<String, Vec<VersionRecord>>;
 type CachedUptimes = HashMap<String, Vec<UptimeRecord>>;
 type CachedClusterStats = Option<ClusterStats>;
+type CachedEpochRewardMix = HashMap<u64, RewardMixShares>;
 
 #[derive(Default, Clone)]
 pub struct CachedSingleRunScores {
@@ -76,6 +77,7 @@ pub struct Cache {
     pub versions: CachedVersions,
     pub uptimes: CachedUptimes,
     pub cluster_stats: CachedClusterStats,
+    pub epoch_reward_mix: CachedEpochRewardMix,
     pub validators_single_run_scores: CachedSingleRunScores,
     pub validators_multi_run_scores: CachedMultiRunScores,
     pub per_epoch: Option<PerEpochCache>,
@@ -190,6 +192,10 @@ impl Cache {
 
     pub fn get_uptimes(&self, vote_account: &String) -> Option<Vec<UptimeRecord>> {
         self.uptimes.get(vote_account).cloned()
+    }
+
+    pub fn get_epoch_reward_mix(&self) -> &CachedEpochRewardMix {
+        &self.epoch_reward_mix
     }
 
     pub fn get_validators_multi_run_scores(&self) -> CachedMultiRunScores {
@@ -478,6 +484,21 @@ pub async fn warm_cluster_stats_cache(context: &WrappedContext) -> anyhow::Resul
 
     Ok(())
 }
+pub async fn warm_epoch_reward_mix_cache(context: &WrappedContext) -> anyhow::Result<()> {
+    info!("Loading epoch reward mix from DB");
+    let warmup_timer = Instant::now();
+    let epoch_reward_mix =
+        store::take_rates::load_epoch_reward_mix(&context.read().await.psql_client).await?;
+
+    let epochs_len = epoch_reward_mix.len();
+    context.write().await.cache.epoch_reward_mix = epoch_reward_mix;
+    info!(
+        "Loaded epoch reward mix for {epochs_len} epochs to cache in {} ms",
+        warmup_timer.elapsed().as_millis()
+    );
+
+    Ok(())
+}
 pub async fn warm_scores_cache(context: &WrappedContext) -> anyhow::Result<()> {
     info!("Loading scores from DB");
     let warmup_timer = Instant::now();
@@ -555,6 +576,9 @@ fn warm_steps() -> [WarmStep; WARM_STEPS] {
         ("commissions", |c| Box::pin(warm_commissions_cache(c))),
         ("uptimes", |c| Box::pin(warm_uptimes_cache(c))),
         ("cluster_stats", |c| Box::pin(warm_cluster_stats_cache(c))),
+        ("epoch_reward_mix", |c| {
+            Box::pin(warm_epoch_reward_mix_cache(c))
+        }),
         ("validators", |c| Box::pin(warm_validators_cache(c))),
     ]
 }

--- a/api/src/handlers/take_rates.rs
+++ b/api/src/handlers/take_rates.rs
@@ -75,8 +75,10 @@ pub async fn handler(
         Err((status, message)) => return Ok(response_error(status, message)),
     };
 
+    let reward_mix = context_guard.cache.get_epoch_reward_mix();
+
     Ok(
-        match get_take_rate_series(psql_client, vote_key, from_epoch).await {
+        match get_take_rate_series(psql_client, vote_key, from_epoch, reward_mix).await {
             Ok(take_rates) => {
                 warp::reply::with_status(json(&ResponseTakeRates { take_rates }), StatusCode::OK)
             }

--- a/migrations/0026-jito-commission-indexes.sql
+++ b/migrations/0026-jito-commission-indexes.sql
@@ -1,0 +1,3 @@
+-- One row per collect snapshot in both tables, so a per-epoch read picks the newest per (vote_account, epoch).
+CREATE INDEX idx_mev_vote_account_epoch ON mev(vote_account, epoch, created_at DESC);
+CREATE INDEX idx_jito_priority_fee_vote_account_epoch ON jito_priority_fee(vote_account, epoch, created_at DESC);

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -483,7 +483,9 @@ pub struct TakeRateRecord {
     pub epoch: u64,
     pub epoch_start_at: Option<DateTime<Utc>>,
     pub epoch_end_at: Option<DateTime<Utc>>,
-    pub take_rate: f64,
+    pub realized_take_rate: f64,
+    /// This epoch's commissions weighted by this epoch's reward mix, against `realized_take_rate`'s measured figure. Inflation side is the worse of the epoch's `commission_max_observed` and `commission_advertised`, so any mid-epoch move reads high. Not the same window as `/validators`'s `expected_take_rate`, which pairs the current rate with a trailing 30-day mix. Null when the epoch has no commission recorded.
+    pub expected_take_rate: Option<f64>,
     pub created_at: DateTime<Utc>,
 }
 

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -484,7 +484,7 @@ pub struct TakeRateRecord {
     pub epoch_start_at: Option<DateTime<Utc>>,
     pub epoch_end_at: Option<DateTime<Utc>>,
     pub realized_take_rate: f64,
-    /// This epoch's commissions weighted by this epoch's reward mix, against `realized_take_rate`'s measured figure. Inflation side is the worse of the epoch's `commission_max_observed` and `commission_advertised`, so any mid-epoch move reads high. Not the same window as `/validators`'s `expected_take_rate`, which pairs the current rate with a trailing 30-day mix. Null when the epoch has no commission recorded.
+    /// Take rate implied by the epoch's commissions, weighted by the epoch's reward mix.
     pub expected_take_rate: Option<f64>,
     pub created_at: DateTime<Utc>,
 }

--- a/store/src/take_rates.rs
+++ b/store/src/take_rates.rs
@@ -201,15 +201,14 @@ pub async fn load_epoch_reward_mix(
         if total.is_zero() {
             continue;
         }
+        let total = total.to_f64().unwrap_or_default();
 
-        // Divided in Decimal: cluster-wide lamport sums reach f64's exact-integer ceiling.
-        let share = |component: Decimal| (component / total).to_f64().unwrap_or_default();
         mix.insert(
             epoch,
             RewardMixShares {
-                inflation: share(inflation),
-                mev: share(mev),
-                block: share(block),
+                inflation: inflation.to_f64().unwrap_or_default() / total,
+                mev: mev.to_f64().unwrap_or_default() / total,
+                block: block.to_f64().unwrap_or_default() / total,
             },
         );
     }

--- a/store/src/take_rates.rs
+++ b/store/src/take_rates.rs
@@ -1,4 +1,5 @@
 use crate::dto::TakeRateRecord;
+use crate::utils::{expected_take_rate, worst_known_commission, RewardMixShares};
 use chrono::{DateTime, Utc};
 use collect::take_rates::ValidatorRewardsSnapshot;
 use log::info;
@@ -168,20 +169,84 @@ pub async fn store_take_rates(
     Ok(())
 }
 
+/// Cluster reward mix per epoch. Epochs that paid nothing are absent, not zero-weighted.
+pub async fn load_epoch_reward_mix(
+    psql_client: &Client,
+) -> anyhow::Result<HashMap<u64, RewardMixShares>> {
+    let rows = psql_client
+        .query(
+            &format!(
+                "
+        SELECT
+            epoch,
+            SUM(inflation_rewards) AS inflation,
+            SUM(mev_rewards) AS mev,
+            SUM(block_rewards) AS block
+        FROM {VALIDATORS_REWARDS_TABLE}
+        GROUP BY epoch
+        "
+            ),
+            &[],
+        )
+        .await?;
+
+    let mut mix = HashMap::with_capacity(rows.len());
+    for row in rows {
+        let epoch: u64 = row.get::<_, Decimal>("epoch").try_into()?;
+        let inflation: Decimal = row.get("inflation");
+        let mev: Decimal = row.get("mev");
+        let block: Decimal = row.get("block");
+
+        let total = inflation + mev + block;
+        if total.is_zero() {
+            continue;
+        }
+
+        // Divided in Decimal: cluster-wide lamport sums reach f64's exact-integer ceiling.
+        let share = |component: Decimal| (component / total).to_f64().unwrap_or_default();
+        mix.insert(
+            epoch,
+            RewardMixShares {
+                inflation: share(inflation),
+                mev: share(mev),
+                block: share(block),
+            },
+        );
+    }
+
+    Ok(mix)
+}
+
 pub async fn get_take_rate_series(
     psql_client: &Client,
     vote_account: &str,
     from_epoch: Option<u64>,
+    reward_mix: &HashMap<u64, RewardMixShares>,
 ) -> anyhow::Result<Vec<TakeRateRecord>> {
     let from_epoch = from_epoch.map(Decimal::from);
     let query = format!(
         "
         SELECT
-            {VALIDATORS_REWARDS_TABLE}.epoch, take_rate, created_at,
-            epochs.start_at AS epoch_start, epochs.end_at AS epoch_end
+            {VALIDATORS_REWARDS_TABLE}.epoch, take_rate AS realized_take_rate, created_at,
+            epochs.start_at AS epoch_start, epochs.end_at AS epoch_end,
+            validators.commission_max_observed, validators.commission_advertised,
+            mev.mev_commission AS mev_commission_bps,
+            jpf.validator_commission AS priority_commission_bps
         FROM {VALIDATORS_REWARDS_TABLE}
         LEFT JOIN epochs ON {VALIDATORS_REWARDS_TABLE}.epoch = epochs.epoch
-        WHERE vote_account = $1
+        LEFT JOIN validators
+            ON validators.vote_account = {VALIDATORS_REWARDS_TABLE}.vote_account
+            AND validators.epoch = {VALIDATORS_REWARDS_TABLE}.epoch
+        -- Both filters stay inside the subqueries; moved to the join they scan every validator's snapshots.
+        LEFT JOIN (
+            SELECT DISTINCT ON (epoch) epoch, mev_commission
+            FROM mev WHERE vote_account = $1 ORDER BY epoch, created_at DESC
+        ) mev ON mev.epoch = {VALIDATORS_REWARDS_TABLE}.epoch
+        LEFT JOIN (
+            SELECT DISTINCT ON (epoch) epoch, validator_commission
+            FROM jito_priority_fee WHERE vote_account = $1 ORDER BY epoch, created_at DESC
+        ) jpf ON jpf.epoch = {VALIDATORS_REWARDS_TABLE}.epoch
+        WHERE {VALIDATORS_REWARDS_TABLE}.vote_account = $1
           AND ($2::NUMERIC IS NULL OR {VALIDATORS_REWARDS_TABLE}.epoch >= $2::NUMERIC)
         ORDER BY {VALIDATORS_REWARDS_TABLE}.epoch ASC
         "
@@ -192,13 +257,25 @@ pub async fn get_take_rate_series(
 
     let mut records = Vec::with_capacity(rows.len());
     for row in rows {
+        let epoch: u64 = row.get::<_, Decimal>("epoch").try_into()?;
         // Null where `epochs` has no row: `store close-epoch` has not run for it yet, or a
         // `--from-epoch` backfill reached past the stored epoch history.
         records.push(TakeRateRecord {
-            epoch: row.get::<_, Decimal>("epoch").try_into()?,
+            epoch,
             epoch_start_at: row.get::<_, Option<DateTime<Utc>>>("epoch_start"),
             epoch_end_at: row.get::<_, Option<DateTime<Utc>>>("epoch_end"),
-            take_rate: row.get("take_rate"),
+            realized_take_rate: row.get("realized_take_rate"),
+            expected_take_rate: reward_mix.get(&epoch).and_then(|shares| {
+                expected_take_rate(
+                    *shares,
+                    worst_known_commission(
+                        row.get::<_, Option<i32>>("commission_max_observed"),
+                        row.get::<_, Option<i32>>("commission_advertised"),
+                    ),
+                    row.get::<_, Option<i32>>("mev_commission_bps"),
+                    row.get::<_, Option<i32>>("priority_commission_bps"),
+                )
+            }),
             created_at: row.get("created_at"),
         })
     }

--- a/store/src/take_rates.rs
+++ b/store/src/take_rates.rs
@@ -169,7 +169,8 @@ pub async fn store_take_rates(
     Ok(())
 }
 
-/// Cluster reward mix per epoch. Epochs that paid nothing are absent, not zero-weighted.
+/// Cluster reward mix per epoch. Epochs that paid no inflation are absent: the in-progress one has
+/// only accruing block rewards, and nothing else pays out before the epoch closes.
 pub async fn load_epoch_reward_mix(
     psql_client: &Client,
 ) -> anyhow::Result<HashMap<u64, RewardMixShares>> {
@@ -184,6 +185,7 @@ pub async fn load_epoch_reward_mix(
             SUM(block_rewards) AS block
         FROM {VALIDATORS_REWARDS_TABLE}
         GROUP BY epoch
+        HAVING SUM(inflation_rewards) > 0
         "
             ),
             &[],
@@ -197,11 +199,7 @@ pub async fn load_epoch_reward_mix(
         let mev: Decimal = row.get("mev");
         let block: Decimal = row.get("block");
 
-        let total = inflation + mev + block;
-        if total.is_zero() {
-            continue;
-        }
-        let total = total.to_f64().unwrap_or_default();
+        let total = (inflation + mev + block).to_f64().unwrap_or_default();
 
         mix.insert(
             epoch,

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -785,13 +785,19 @@ pub async fn load_take_rates() -> anyhow::Result<TakeRates> {
 /// What the validator's own fee settings imply it keeps, weighted by the cluster reward mix.
 /// Renormalized over the components it actually earns: a validator not running Jito receives no MEV
 /// at all, so crediting it a 0% MEV commission would dilute the rate it takes on what it does earn.
-/// None when the inflation commission is unknown, which is the one component no validator can opt out of.
+/// None when the inflation commission is unknown, or when the mix carries no inflation to weight it by.
+/// Inflation is the one component no validator can opt out of.
 pub fn expected_take_rate(
     shares: RewardMixShares,
     inflation_commission_pct: Option<i32>,
     mev_commission_bps: Option<i32>,
     priority_commission_bps: Option<i32>,
 ) -> Option<f64> {
+    // An in-progress epoch has paid no inflation or MEV yet, leaving a mix of pure block rewards.
+    if shares.inflation <= 0.0 {
+        return None;
+    }
+
     let mut weighted = (f64::from(inflation_commission_pct?) / 100.0) * shares.inflation;
     let mut weight = shares.inflation;
 
@@ -804,7 +810,7 @@ pub fn expected_take_rate(
     weighted += priority_commission_bps.map_or(1.0, |bps| f64::from(bps) / 10_000.0) * shares.block;
     weight += shares.block;
 
-    (weight > 0.0).then_some(weighted / weight)
+    Some(weighted / weight)
 }
 
 /// The higher of the last closed epoch's observed ceiling and what is advertised now: a validator moving its commission inside an epoch advertises the low end, so a rise counts at once while a cut waits for the epoch to close.
@@ -2370,6 +2376,21 @@ mod tests {
             block: 0.0,
         };
         assert_eq!(expected_take_rate(empty, Some(5), Some(1_000), None), None);
+    }
+
+    #[test]
+    fn expected_take_rate_is_unknown_for_a_mix_that_has_paid_only_block_rewards() {
+        // The in-progress epoch's shape: inflation and MEV pay at the boundary, block rewards accrue.
+        let accruing = RewardMixShares {
+            inflation: 0.0,
+            mev: 0.0,
+            block: 1.0,
+        };
+        assert_eq!(
+            expected_take_rate(accruing, Some(5), None, None),
+            None,
+            "weighting a 5% validator by a pure block mix would read it at 100%"
+        );
     }
 
     #[test]

--- a/store/tests/take_rate_series_sql.rs
+++ b/store/tests/take_rate_series_sql.rs
@@ -307,6 +307,7 @@ async fn epoch_reward_mix_splits_each_epoch_across_its_components() {
     insert_reward_components(&client, "voteOther", 2001, 40, 0, 0).await;
     insert_reward_components(&client, VOTE, 2002, 50, 25, 25).await;
     insert_reward_components(&client, VOTE, 2003, 0, 0, 0).await;
+    insert_reward_components(&client, VOTE, 2004, 0, 0, 50).await;
 
     let mix = load_epoch_reward_mix(&client).await.unwrap();
 
@@ -327,6 +328,11 @@ async fn epoch_reward_mix_splits_each_epoch_across_its_components() {
     assert!(
         !mix.contains_key(&2003),
         "an epoch that paid nothing has no mix to weight by"
+    );
+
+    assert!(
+        !mix.contains_key(&2004),
+        "an in-progress epoch has only accruing block rewards, which would weight out every commission"
     );
 
     client

--- a/store/tests/take_rate_series_sql.rs
+++ b/store/tests/take_rate_series_sql.rs
@@ -3,12 +3,28 @@ mod common;
 use chrono::{DateTime, Duration, Utc};
 use common::{migrated_client, skip_without_database};
 use rust_decimal::Decimal;
-use store::take_rates::get_take_rate_series;
+use std::collections::HashMap;
+use store::take_rates::{get_take_rate_series, load_epoch_reward_mix};
+use store::utils::RewardMixShares;
 use tokio_postgres::Client;
 
 const LAST_EPOCH: u64 = 1000;
 const EPOCHS: u64 = 120;
 const VOTE: &str = "voteTakeRates";
+
+const MIX: RewardMixShares = RewardMixShares {
+    inflation: 0.90,
+    mev: 0.04,
+    block: 0.06,
+};
+
+fn approx(actual: Option<f64>, expected: f64, context: &str) {
+    let actual = actual.unwrap_or_else(|| panic!("{context} must not be null"));
+    assert!(
+        (actual - expected).abs() < 1e-12,
+        "{context}: {actual} != {expected}"
+    );
+}
 
 fn epoch_start(epoch: u64) -> DateTime<Utc> {
     "2024-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap() + Duration::days(2 * epoch as i64)
@@ -22,6 +38,91 @@ async fn insert_reward(client: &Client, vote_account: &str, epoch: u64, take_rat
                 mev_rewards, block_rewards, take_rate, created_at, updated_at
             ) VALUES ($1, $2, 10, 100, 100, 0, 0, $3, NOW(), NOW())",
             &[&vote_account, &Decimal::from(epoch), &take_rate],
+        )
+        .await
+        .unwrap();
+}
+
+async fn insert_reward_components(
+    client: &Client,
+    vote_account: &str,
+    epoch: u64,
+    inflation: i64,
+    mev: i64,
+    block: i64,
+) {
+    client
+        .execute(
+            "INSERT INTO validators_rewards (
+                vote_account, epoch, validator_rewards, total_rewards, inflation_rewards,
+                mev_rewards, block_rewards, take_rate, created_at, updated_at
+            ) VALUES ($1, $2, 0, $3 + $4 + $5, $3, $4, $5, 0, NOW(), NOW())",
+            &[
+                &vote_account,
+                &Decimal::from(epoch),
+                &Decimal::from(inflation),
+                &Decimal::from(mev),
+                &Decimal::from(block),
+            ],
+        )
+        .await
+        .unwrap();
+}
+
+async fn insert_validator(
+    client: &Client,
+    epoch: u64,
+    commission_advertised: Option<i32>,
+    commission_max_observed: Option<i32>,
+) {
+    client
+        .execute(
+            "INSERT INTO validators (
+                identity, vote_account, epoch, activated_stake, marinade_stake,
+                marinade_native_stake, superminority, stake_to_become_superminority, credits,
+                leader_slots, blocks_produced, skip_rate, updated_at,
+                commission_advertised, commission_max_observed
+            ) VALUES ('identityTakeRates', $1, $2, 100, 0, 0, false, 0, 0, 0, 0, 0, NOW(), $3, $4)",
+            &[
+                &VOTE,
+                &Decimal::from(epoch),
+                &commission_advertised,
+                &commission_max_observed,
+            ],
+        )
+        .await
+        .unwrap();
+}
+
+async fn insert_mev(
+    client: &Client,
+    epoch: u64,
+    mev_commission_bps: i32,
+    created_at: DateTime<Utc>,
+) {
+    client
+        .execute(
+            "INSERT INTO mev (vote_account, mev_commission, epoch_slot, epoch, created_at)
+             VALUES ($1, $2, 1, $3, $4)",
+            &[
+                &VOTE,
+                &mev_commission_bps,
+                &Decimal::from(epoch),
+                &created_at,
+            ],
+        )
+        .await
+        .unwrap();
+}
+
+async fn insert_priority_fee(client: &Client, epoch: u64, priority_commission_bps: i32) {
+    client
+        .execute(
+            "INSERT INTO jito_priority_fee (
+                vote_account, validator_commission, total_lamports_transferred, epoch_slot, epoch,
+                created_at
+            ) VALUES ($1, $2, 0, 1, $3, NOW())",
+            &[&VOTE, &priority_commission_bps, &Decimal::from(epoch)],
         )
         .await
         .unwrap();
@@ -62,9 +163,18 @@ async fn take_rate_series_spans_the_whole_stored_history() {
     }
     insert_reward(&client, "voteOther", LAST_EPOCH, 0.1).await;
 
-    let series = get_take_rate_series(&client, VOTE, None).await.unwrap();
+    let no_mix = HashMap::new();
+    let series = get_take_rate_series(&client, VOTE, None, &no_mix)
+        .await
+        .unwrap();
     let epochs: Vec<u64> = series.iter().map(|record| record.epoch).collect();
     assert_eq!(epochs, (first_epoch..=LAST_EPOCH).collect::<Vec<_>>());
+    assert!(
+        series
+            .iter()
+            .all(|record| record.expected_take_rate.is_none()),
+        "an unloaded reward mix must null the whole series instead of weighting by zero"
+    );
 
     let epoch_without_boundaries = series.last().unwrap();
     assert_eq!(epoch_without_boundaries.epoch, LAST_EPOCH);
@@ -74,21 +184,145 @@ async fn take_rate_series_spans_the_whole_stored_history() {
     let closed_epoch = &series[0];
     assert_eq!(closed_epoch.epoch_start_at, Some(epoch_start(first_epoch)));
 
-    let bounded = get_take_rate_series(&client, VOTE, Some(LAST_EPOCH - 2))
+    let bounded = get_take_rate_series(&client, VOTE, Some(LAST_EPOCH - 2), &no_mix)
         .await
         .unwrap();
     let epochs: Vec<u64> = bounded.iter().map(|record| record.epoch).collect();
     assert_eq!(epochs, vec![LAST_EPOCH - 2, LAST_EPOCH - 1, LAST_EPOCH]);
 
-    let other = get_take_rate_series(&client, "voteOther", None)
+    let other = get_take_rate_series(&client, "voteOther", None, &no_mix)
         .await
         .unwrap();
     assert_eq!(other.len(), 1);
 
-    let unknown = get_take_rate_series(&client, "voteUnknown", None)
+    let unknown = get_take_rate_series(&client, "voteUnknown", None, &no_mix)
         .await
         .unwrap();
     assert!(unknown.is_empty());
+
+    client
+        .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn expected_take_rate_weights_each_epoch_by_its_own_commissions() {
+    let schema = "ds_test_take_rate_series_expected";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    // One epoch per case. Every epoch gets a rewards row, so a null can only come from the joins.
+    let epochs = 1001..=1006;
+    let mut mix = HashMap::new();
+    for epoch in epochs.clone() {
+        insert_reward(&client, VOTE, epoch, 0.05).await;
+        mix.insert(epoch, MIX);
+    }
+
+    // 1001: all three commissions known.
+    insert_validator(&client, 1001, Some(10), Some(10)).await;
+    insert_mev(&client, 1001, 800, Utc::now()).await;
+    insert_priority_fee(&client, 1001, 2000).await;
+
+    // 1002: no `mev` row, so the MEV share leaves the denominator.
+    insert_validator(&client, 1002, Some(10), Some(10)).await;
+    insert_priority_fee(&client, 1002, 2000).await;
+
+    // 1003: no `jito_priority_fee` row, so every block reward counts as kept.
+    insert_validator(&client, 1003, Some(10), Some(10)).await;
+    insert_mev(&client, 1003, 800, Utc::now()).await;
+
+    // 1004: no `validators` row at all.
+    insert_mev(&client, 1004, 800, Utc::now()).await;
+    insert_priority_fee(&client, 1004, 2000).await;
+
+    // 1005: advertised 0 but the epoch was caught at 100.
+    insert_validator(&client, 1005, Some(0), Some(100)).await;
+    insert_mev(&client, 1005, 0, Utc::now()).await;
+
+    // 1006: two snapshots for the same epoch.
+    insert_validator(&client, 1006, Some(10), Some(10)).await;
+    insert_mev(&client, 1006, 800, Utc::now() - Duration::hours(1)).await;
+    insert_mev(&client, 1006, 300, Utc::now()).await;
+    insert_priority_fee(&client, 1006, 2000).await;
+
+    let series = get_take_rate_series(&client, VOTE, None, &mix)
+        .await
+        .unwrap();
+    let rates: HashMap<u64, Option<f64>> = series
+        .iter()
+        .map(|record| (record.epoch, record.expected_take_rate))
+        .collect();
+    assert_eq!(series.len(), epochs.count());
+
+    approx(rates[&1001], 0.1052, "all three commissions known");
+    approx(
+        rates[&1002],
+        0.102 / 0.96,
+        "a validator with no MEV account must not be credited a zero MEV commission",
+    );
+    approx(
+        rates[&1003],
+        0.1532,
+        "block rewards are wholly kept without a PriorityFeeDistribution account",
+    );
+    assert_eq!(
+        rates[&1004], None,
+        "an epoch with no commission recorded must read null, not zero"
+    );
+    approx(
+        rates[&1005],
+        0.96,
+        "the epoch's ceiling must win over what it advertised",
+    );
+    approx(
+        rates[&1006],
+        0.1032,
+        "the newest snapshot of the epoch wins",
+    );
+
+    client
+        .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn epoch_reward_mix_splits_each_epoch_across_its_components() {
+    let schema = "ds_test_epoch_reward_mix";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    insert_reward_components(&client, VOTE, 2001, 60, 20, 20).await;
+    insert_reward_components(&client, "voteOther", 2001, 40, 0, 0).await;
+    insert_reward_components(&client, VOTE, 2002, 50, 25, 25).await;
+    insert_reward_components(&client, VOTE, 2003, 0, 0, 0).await;
+
+    let mix = load_epoch_reward_mix(&client).await.unwrap();
+
+    let shared = mix[&2001];
+    approx(
+        Some(shared.inflation),
+        100.0 / 140.0,
+        "2001 inflation share",
+    );
+    approx(Some(shared.mev), 20.0 / 140.0, "2001 mev share");
+    approx(Some(shared.block), 20.0 / 140.0, "2001 block share");
+
+    let single = mix[&2002];
+    approx(Some(single.inflation), 0.5, "2002 inflation share");
+    approx(Some(single.mev), 0.25, "2002 mev share");
+    approx(Some(single.block), 0.25, "2002 block share");
+
+    assert!(
+        !mix.contains_key(&2003),
+        "an epoch that paid nothing has no mix to weight by"
+    );
 
     client
         .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))

--- a/store/tests/take_rate_series_sql.rs
+++ b/store/tests/take_rate_series_sql.rs
@@ -56,7 +56,12 @@ async fn insert_reward_components(
             "INSERT INTO validators_rewards (
                 vote_account, epoch, validator_rewards, total_rewards, inflation_rewards,
                 mev_rewards, block_rewards, take_rate, created_at, updated_at
-            ) VALUES ($1, $2, 0, $3 + $4 + $5, $3, $4, $5, 0, NOW(), NOW())",
+            ) VALUES (
+                $1, $2, 0,
+                $3::NUMERIC + $4::NUMERIC + $5::NUMERIC,
+                $3::NUMERIC, $4::NUMERIC, $5::NUMERIC,
+                0, NOW(), NOW()
+            )",
             &[
                 &vote_account,
                 &Decimal::from(epoch),


### PR DESCRIPTION
Introducing the expected take rate into the take rate history endpoint in addition to the realized one.

Renamed field `take_rate` to `realized_take_rate` on purpose. No need for bw compat, api not yet used by anyone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expected take-rate calculations based on each epoch’s reward composition.
  * Take-rate results now distinguish realized and expected rates.
  * Added support for inflation, MEV, priority-fee, and block-reward shares.
* **Performance**
  * Improved take-rate data retrieval with caching and database indexing.
* **Bug Fixes**
  * Improved handling of missing reward data, unknown accounts, commission limits, and block-only rewards.
* **Documentation**
  * Clarified expected take-rate descriptions and API response fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->