### PR TITLE
[GEN-8776] block production incidents

### DIFF
--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -50,6 +50,8 @@ use utoipa::OpenApi;
         schemas(store::dto::UnstakeHint),
         schemas(store::dto::UptimeRecord),
         schemas(store::dto::IncidentRecord),
+        schemas(store::dto::IncidentDetail),
+        schemas(store::dto::BlockProductionDetail),
         schemas(store::dto::GroupIncidentRecord),
         schemas(store::dto::GroupIncidents),
         schemas(store::dto::EventEpochRecord),

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -13,6 +13,7 @@ use store::dto::{
     ValidatorGroups, ValidatorRecord, ValidatorScoreRecord, VersionRecord,
 };
 use store::groups::ValidatorGroupings;
+use store::incidents::{IncidentFilters, ValidatorIncidents};
 use tokio::time::{sleep, timeout, Duration, Instant};
 
 use store::utils::{RewardMixShares, TakeRates, ValidatorOverlays};
@@ -26,6 +27,8 @@ const WARM_STEP_TIMEOUT_S: u64 = 2 * CACHE_WARMUP_TIME_S;
 const WARM_STEPS: usize = 7;
 
 type CachedValidators = HashMap<String, ValidatorRecord>;
+/// Raw incident material the served `incidents` arrays are projected from, per vote account.
+type CachedValidatorIncidents = ValidatorIncidents;
 /// Client and provider aggregates, derived from the validators they are published with.
 type CachedValidatorGroups = ValidatorGroupings;
 type CachedCommissions = HashMap<String, Vec<CommissionRecord>>;
@@ -72,6 +75,7 @@ pub struct Cache {
     pub bond_flags: CachedBondFlags,
     pub net_apy: CachedNetApy,
     pub validators: CachedValidators,
+    pub validator_incidents: CachedValidatorIncidents,
     pub validator_groups: CachedValidatorGroups,
     pub commissions: CachedCommissions,
     pub versions: CachedVersions,
@@ -155,6 +159,10 @@ impl Cache {
 
     pub fn get_validators(&self) -> CachedValidators {
         self.validators.clone()
+    }
+
+    pub fn get_validator_incidents(&self) -> CachedValidatorIncidents {
+        self.validator_incidents.clone()
     }
 
     pub fn get_client_groups(&self) -> ValidatorGroupTree {
@@ -371,7 +379,7 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
         protected: bond_flags.protected.vote_accounts.clone(),
     };
 
-    let validators = store::utils::load_validators(
+    let mut validators = store::utils::load_validators(
         &context.read().await.psql_client,
         scoring_url,
         DEFAULT_CACHE_EPOCHS,
@@ -390,13 +398,30 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
         warn!("No validators in DB, caching an empty set");
     }
 
-    // Off the executor thread: three walks of every cached epoch of every validator per grouping,
-    // over the three groupings the endpoints serve, each key resolved through the client registry.
-    let (validators, validator_groups) = tokio::task::spawn_blocking(move || {
-        let validator_groups = store::groups::aggregate_all(&validators);
-        (validators, validator_groups)
-    })
+    // The window ends at the newest epoch the validator records report, which is the same epoch the
+    // API measures its incident window back from. `cluster_info` can be an epoch ahead or behind it.
+    let last_epoch = store::utils::last_reported_epoch(validators.values()).unwrap_or(0);
+    let validator_incidents = store::utils::load_validator_incidents(
+        &context.read().await.psql_client,
+        (last_epoch + 1).saturating_sub(DEFAULT_CACHE_EPOCHS),
+        last_epoch,
+        &validators,
+    )
     .await?;
+
+    // Off the executor thread: walks every cached epoch of every validator.
+    let (validators, validator_incidents, validator_groups) =
+        tokio::task::spawn_blocking(move || {
+            // Initialize incidents with default filters that query params in `/validators` can override
+            let filters = IncidentFilters::default();
+            for (vote_account, record) in validators.iter_mut() {
+                record.incidents =
+                    validator_incidents.into_response_incidents(vote_account, &filters);
+            }
+            let validator_groups = store::groups::aggregate_all(&validators);
+            (validators, validator_incidents, validator_groups)
+        })
+        .await?;
 
     let validators_len = validators.len();
     {
@@ -410,6 +435,7 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
         ctx.cache.bond_flags = bond_flags;
         ctx.cache.net_apy = net_apy;
         ctx.cache.validators = validators;
+        ctx.cache.validator_incidents = validator_incidents;
         ctx.cache.validator_groups = validator_groups;
     }
 

--- a/api/src/cache.rs
+++ b/api/src/cache.rs
@@ -13,7 +13,7 @@ use store::dto::{
     ValidatorGroups, ValidatorRecord, ValidatorScoreRecord, VersionRecord,
 };
 use store::groups::ValidatorGroupings;
-use store::incidents::{IncidentFilters, ValidatorIncidents};
+use store::incidents::{IncidentFilters, ValidatorIncidents, DEFAULT_INCIDENT_TYPES};
 use tokio::time::{sleep, timeout, Duration, Instant};
 
 use store::utils::{RewardMixShares, TakeRates, ValidatorOverlays};
@@ -413,7 +413,10 @@ pub async fn warm_validators_cache(context: &WrappedContext) -> anyhow::Result<(
     let (validators, validator_incidents, validator_groups) =
         tokio::task::spawn_blocking(move || {
             // Initialize incidents with default filters that query params in `/validators` can override
-            let filters = IncidentFilters::default();
+            let filters = IncidentFilters {
+                types: Some(DEFAULT_INCIDENT_TYPES.to_vec()),
+                ..IncidentFilters::default()
+            };
             for (vote_account, record) in validators.iter_mut() {
                 record.incidents =
                     validator_incidents.into_response_incidents(vote_account, &filters);

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -457,7 +457,6 @@ pub fn filter_validators(
                 return false;
             }
             match &incident.detail {
-                // Restart noise is under the floor, unless the epoch also breached block production.
                 IncidentDetail::Downtime {
                     downtime_seconds,
                     block_production,

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -476,7 +476,7 @@ pub fn filter_validators(
     let min_incident_downtime = config
         .min_incident_downtime_seconds
         .unwrap_or(DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS);
-    // `breached` owns both defaults, so the caller's floors travel as they arrived.
+    // `counts_as_incident` owns both defaults, so the caller's floors travel as they arrived.
     let (min_missed_slots, min_leader_slots) = (
         config.min_incident_missed_slots,
         config.min_incident_leader_slots,
@@ -498,26 +498,29 @@ pub fn filter_validators(
             .unwrap_or(DEFAULT_INCIDENTS_WINDOW_EPOCHS),
     );
     for validator in validators.values_mut() {
-        validator.incidents.retain(|incident| {
+        validator.incidents.retain_mut(|incident| {
             if incident.epoch < from_epoch {
                 return false;
             }
-            // Served when any symptom is asked for and over its own floor.
-            let (downtime_seconds, block_production) = match &incident.detail {
+            let (downtime_seconds, block_production) = match &mut incident.detail {
                 IncidentDetail::Downtime {
                     downtime_seconds,
                     block_production,
                     ..
-                } => (Some(*downtime_seconds), block_production.as_ref()),
+                } => (Some(*downtime_seconds), block_production.as_mut()),
                 IncidentDetail::BlockProduction {
                     block_production, ..
                 } => (None, Some(block_production)),
             };
+            // Re-answered against the caller's floors, so what is served agrees with what is said.
+            let counts_as_incident = block_production.is_some_and(|detail| {
+                detail.counts_as_incident = detail.counts_as_incident(min_missed_slots, min_leader_slots);
+                detail.counts_as_incident
+            });
+            // Served when any symptom is asked for and over its own floor.
             (wants_downtime
                 && downtime_seconds.is_some_and(|seconds| seconds >= min_incident_downtime))
-                || (wants_block_production
-                    && block_production
-                        .is_some_and(|detail| detail.breached(min_missed_slots, min_leader_slots)))
+                || (wants_block_production && counts_as_incident)
         });
     }
 
@@ -995,14 +998,17 @@ mod tests {
     const FIXTURE_MISSED_SLOTS: u64 = 548;
 
     fn skipped(missed_slots: u64) -> BlockProductionDetail {
-        BlockProductionDetail {
+        let mut detail = BlockProductionDetail {
             leader_slots: FIXTURE_LEADER_SLOTS,
             blocks_produced: FIXTURE_LEADER_SLOTS - missed_slots,
             missed_slots,
             skip_rate: missed_slots as f64 / FIXTURE_LEADER_SLOTS as f64,
             cluster_skip_rate: 0.001_57,
             threshold: 0.015_7,
-        }
+            counts_as_incident: false,
+        };
+        detail.counts_as_incident = detail.counts_as_incident(None, None);
+        detail
     }
 
     fn block_production_incident_of(epoch: u64, missed_slots: u64) -> IncidentRecord {
@@ -1295,7 +1301,7 @@ mod tests {
     }
 
     #[test]
-    fn a_downtime_carrying_numbers_that_did_not_breach_is_no_block_production_incident() {
+    fn a_downtime_carrying_numbers_under_the_rule_is_no_block_production_incident() {
         // 5 of 6392 is 0.08%, under the bar: the numbers are information, not a verdict.
         let validators = map(vec![with_incidents("blip", vec![down_and_skipped(600, 5)])]);
         let config = GetValidatorsConfig {
@@ -1308,7 +1314,7 @@ mod tests {
     }
 
     #[test]
-    fn a_downtime_carrying_numbers_that_breached_is_a_block_production_incident() {
+    fn a_downtime_carrying_numbers_over_the_rule_is_a_block_production_incident() {
         let validators = map(vec![with_incidents(
             "skipper",
             vec![down_and_skipped(600, FIXTURE_MISSED_SLOTS)],
@@ -1318,6 +1324,29 @@ mod tests {
             ..config()
         };
         assert_eq!(filter_validators(validators, &config)[0].incidents.len(), 1);
+    }
+
+    // What is served has to agree with what it says about itself.
+    #[test]
+    fn a_caller_floor_rewrites_the_counts_as_incident_flag_it_is_served_with() {
+        let validators = map(vec![with_incidents(
+            "skipper",
+            vec![down_and_skipped(600, FIXTURE_MISSED_SLOTS)],
+        )]);
+        let config = GetValidatorsConfig {
+            min_incident_missed_slots: Some(FIXTURE_MISSED_SLOTS + 1),
+            ..config()
+        };
+
+        let served = filter_validators(validators, &config);
+        let IncidentDetail::Downtime {
+            block_production, ..
+        } = &served[0].incidents[0].detail
+        else {
+            panic!("a downtime fixture is a downtime incident");
+        };
+        // Kept by its downtime, but no longer a block production incident under this floor.
+        assert!(!block_production.as_ref().unwrap().counts_as_incident);
     }
 
     #[test]

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -915,7 +915,6 @@ mod tests {
                     skip_rate: 0.0857,
                     cluster_skip_rate: 0.001_57,
                     threshold: 0.015_7,
-                    cluster_skip_rate_multiple: Some(54.6),
                 },
             },
         }

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -17,14 +17,13 @@ use store::{
         ValidatorsAggregated,
     },
     groups::{aggregate_operators, singleton_group},
-    incidents::MIN_MISSED_SLOTS,
+    incidents::{MIN_LEADER_SLOTS, MIN_MISSED_SLOTS},
     utils::{to_fixed_for_sort, worst_known_commission, DEFAULT_CACHE_EPOCHS},
 };
 use warp::{http::StatusCode, reply::json, Reply};
 
 const DEFAULT_EPOCHS: usize = 15;
 const DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS: u64 = 180;
-const DEFAULT_MIN_INCIDENT_MISSED_SLOTS: u64 = MIN_MISSED_SLOTS;
 const DEFAULT_INCIDENTS_WINDOW_EPOCHS: u64 = 90;
 const DEFAULT_LIMIT: usize = 100;
 
@@ -103,6 +102,8 @@ pub struct QueryParams {
     min_incident_downtime_seconds: Option<u64>,
     /// Minimum missed leader slots for a skipped epoch to read as an incident. Defaults to 4, minimum 4.
     min_incident_missed_slots: Option<u64>,
+    /// Minimum leader slots an epoch needs before its block production is judged. Defaults to 64, minimum 64.
+    min_incident_leader_slots: Option<u64>,
     /// Epochs back the `incidents` array reaches, counting the newest reported epoch itself. Defaults to 90; above 90 — the whole window the cache holds — answers 400. Unrelated to `epochs`, which sizes `epoch_stats`.
     incident_window_epochs: Option<u64>,
     query_verified: Option<bool>,
@@ -135,6 +136,7 @@ pub struct GetValidatorsConfig {
     pub query_incident_types: Option<Vec<IncidentType>>,
     pub min_incident_downtime_seconds: Option<u64>,
     pub min_incident_missed_slots: Option<u64>,
+    pub min_incident_leader_slots: Option<u64>,
     pub incident_window_epochs: Option<u64>,
     pub query_verified: Option<bool>,
     pub query_protected: Option<bool>,
@@ -474,9 +476,11 @@ pub fn filter_validators(
     let min_incident_downtime = config
         .min_incident_downtime_seconds
         .unwrap_or(DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS);
-    let min_missed_slots = config
-        .min_incident_missed_slots
-        .unwrap_or(DEFAULT_MIN_INCIDENT_MISSED_SLOTS);
+    // `breached` owns both defaults, so the caller's floors travel as they arrived.
+    let (min_missed_slots, min_leader_slots) = (
+        config.min_incident_missed_slots,
+        config.min_incident_leader_slots,
+    );
     let wants = |incident_type| {
         config
             .query_incident_types
@@ -513,7 +517,7 @@ pub fn filter_validators(
                 && downtime_seconds.is_some_and(|seconds| seconds >= min_incident_downtime))
                 || (wants_block_production
                     && block_production
-                        .is_some_and(|detail| detail.breached(Some(min_missed_slots))))
+                        .is_some_and(|detail| detail.breached(min_missed_slots, min_leader_slots)))
         });
     }
 
@@ -612,6 +616,14 @@ pub async fn handler(
             ));
         }
     }
+    if let Some(leader_slots) = query_params.min_incident_leader_slots {
+        if leader_slots < MIN_LEADER_SLOTS {
+            return Ok(response_error(
+                StatusCode::BAD_REQUEST,
+                format!("min_incident_leader_slots must be at least {MIN_LEADER_SLOTS}"),
+            ));
+        }
+    }
     let query_incident_types = match query_params.query_incident_types.as_deref() {
         Some(types) => match IncidentType::parse_list(types) {
             Ok(types) => Some(types),
@@ -651,6 +663,7 @@ pub async fn handler(
         query_incident_types,
         min_incident_downtime_seconds: query_params.min_incident_downtime_seconds,
         min_incident_missed_slots: query_params.min_incident_missed_slots,
+        min_incident_leader_slots: query_params.min_incident_leader_slots,
         incident_window_epochs: query_params.incident_window_epochs,
         query_verified: query_params.query_verified,
         query_protected: query_params.query_protected,
@@ -851,6 +864,7 @@ mod tests {
             query_incident_types: None,
             min_incident_downtime_seconds: None,
             min_incident_missed_slots: None,
+            min_incident_leader_slots: None,
             incident_window_epochs: None,
             query_verified: None,
             query_protected: None,
@@ -1304,6 +1318,20 @@ mod tests {
             ..config()
         };
         assert_eq!(filter_validators(validators, &config)[0].incidents.len(), 1);
+    }
+
+    #[test]
+    fn a_leader_slot_floor_above_the_default_drops_what_the_rule_admitted() {
+        let validators = map(vec![with_incidents(
+            "skipper",
+            vec![down_and_skipped(600, FIXTURE_MISSED_SLOTS)],
+        )]);
+        let config = GetValidatorsConfig {
+            query_incident_types: Some(vec![IncidentType::BlockProduction]),
+            min_incident_leader_slots: Some(FIXTURE_LEADER_SLOTS + 1),
+            ..config()
+        };
+        assert!(filter_validators(validators, &config)[0].incidents.is_empty());
     }
 
     #[test]

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -1148,7 +1148,12 @@ mod tests {
             filtered[0]
                 .incidents
                 .iter()
-                .map(downtime_seconds)
+                .map(|incident| match incident.detail {
+                    IncidentDetail::Downtime {
+                        downtime_seconds, ..
+                    } => downtime_seconds,
+                    _ => panic!("a downtime fixture is a downtime incident"),
+                })
                 .collect::<Vec<_>>(),
             vec![180]
         );

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -71,7 +71,7 @@ pub struct QueryParams {
     query_sfdp: Option<bool>,
     /// `true` keeps the validators whose `incidents` array comes back empty, `false` the rest. It reads that array, so `min_incident_downtime_seconds` and `incident_window_epochs` shape it too, where `epochs` and `query_from_date` do not.
     query_incident_free: Option<bool>,
-    /// Minimum downtime in seconds for a `DOWN` interval to read as an incident. Shorter intervals are restart noise, and reach neither the `incidents` array nor `order_field=incidents` nor `query_incident_free`.
+    /// Minimum downtime in seconds for a `DOWN` interval to read as an incident. Shorter intervals are restart noise, and reach neither the `incidents` array nor `order_field=incidents` nor `query_incident_free`. Block production incidents have no downtime to measure and are kept whatever this is set to.
     min_incident_downtime_seconds: Option<u64>,
     /// Epochs back the `incidents` array reaches, counting the newest reported epoch itself. Defaults to 90; above 90 — the whole window the cache holds — answers 400. Unrelated to `epochs`, which sizes `epoch_stats`.
     incident_window_epochs: Option<u64>,
@@ -450,7 +450,10 @@ pub fn filter_validators(
     );
     for validator in validators.values_mut() {
         validator.incidents.retain(|incident| {
-            incident.epoch >= from_epoch && incident.downtime_seconds >= min_incident_downtime
+            incident.epoch >= from_epoch
+                && incident
+                    .detail
+                    .is_over_downtime_floor(min_incident_downtime)
         });
     }
 
@@ -614,7 +617,10 @@ pub async fn handler(
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use store::dto::{IncidentRecord, ValidatorEpochStats, ValidatorWarning, UNKNOWN_CLIENT_NAME};
+    use store::dto::{
+        BlockProductionDetail, IncidentDetail, IncidentRecord, ValidatorEpochStats,
+        ValidatorWarning, UNKNOWN_CLIENT_NAME,
+    };
 
     fn epoch_stat(epoch: u64, stake: i64) -> ValidatorEpochStats {
         ValidatorEpochStats {
@@ -876,9 +882,41 @@ mod tests {
         let end_at = Utc::now();
         IncidentRecord {
             epoch,
-            start_at: end_at - chrono::Duration::seconds(downtime_seconds as i64),
-            end_at,
-            downtime_seconds,
+            detail: IncidentDetail::Downtime {
+                start_at: end_at - chrono::Duration::seconds(downtime_seconds as i64),
+                end_at,
+                downtime_seconds,
+                block_production: None,
+            },
+        }
+    }
+
+    fn block_production_incident(epoch: u64) -> IncidentRecord {
+        let epoch_end_at = Utc::now();
+        IncidentRecord {
+            epoch,
+            detail: IncidentDetail::BlockProduction {
+                epoch_start_at: Some(epoch_end_at - chrono::Duration::days(2)),
+                epoch_end_at: Some(epoch_end_at),
+                block_production: BlockProductionDetail {
+                    leader_slots: 6392,
+                    blocks_produced: 5844,
+                    missed_slots: 548,
+                    skip_rate: 0.0857,
+                    cluster_skip_rate: 0.001_57,
+                    threshold: 0.015_7,
+                    cluster_skip_rate_multiple: Some(54.6),
+                },
+            },
+        }
+    }
+
+    fn downtime_seconds(incident: &IncidentRecord) -> u64 {
+        match incident.detail {
+            IncidentDetail::Downtime {
+                downtime_seconds, ..
+            } => downtime_seconds,
+            IncidentDetail::BlockProduction { .. } => 0,
         }
     }
 
@@ -1032,6 +1070,56 @@ mod tests {
     }
 
     #[test]
+    fn a_block_production_incident_is_not_incident_free() {
+        let validators = map(vec![
+            ValidatorRecord {
+                incidents: vec![block_production_incident(100)],
+                ..validator("skipper", 100, vec![])
+            },
+            validator("clean", 100, vec![]),
+        ]);
+        let config = GetValidatorsConfig {
+            query_incident_free: Some(true),
+            ..config()
+        };
+        assert_eq!(
+            vote_accounts(filter_validators(validators, &config)),
+            vec!["clean".to_string()]
+        );
+    }
+
+    #[test]
+    fn the_downtime_floor_does_not_reach_block_production_incidents() {
+        let validators = map(vec![ValidatorRecord {
+            incidents: vec![block_production_incident(100)],
+            ..validator("skipper", 100, vec![])
+        }]);
+        let config = GetValidatorsConfig {
+            query_incident_free: Some(true),
+            min_incident_downtime_seconds: Some(u64::MAX),
+            ..config()
+        };
+        assert!(filter_validators(validators, &config).is_empty());
+    }
+
+    #[test]
+    fn a_block_production_incident_outside_the_window_is_dropped_like_any_other() {
+        // The fixtures report up to epoch 100, so the default window opens at epoch 11.
+        let validators = map(vec![ValidatorRecord {
+            incidents: vec![block_production_incident(10)],
+            ..validator("skipper", 100, vec![])
+        }]);
+        let config = GetValidatorsConfig {
+            query_incident_free: Some(true),
+            ..config()
+        };
+        assert_eq!(
+            vote_accounts(filter_validators(validators, &config)),
+            vec!["skipper".to_string()]
+        );
+    }
+
+    #[test]
     fn min_incident_downtime_alone_keeps_every_validator_but_trims_their_arrays() {
         let validators = map(vec![
             validator_with_incidents("blip", &[179]),
@@ -1060,7 +1148,7 @@ mod tests {
             filtered[0]
                 .incidents
                 .iter()
-                .map(|incident| incident.downtime_seconds)
+                .map(downtime_seconds)
                 .collect::<Vec<_>>(),
             vec![180]
         );

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -896,7 +896,7 @@ mod tests {
         IncidentRecord {
             epoch,
             detail: IncidentDetail::BlockProduction {
-                epoch_start_at: Some(epoch_end_at - chrono::Duration::days(2)),
+                epoch_start_at: epoch_end_at - chrono::Duration::days(2),
                 epoch_end_at: Some(epoch_end_at),
                 block_production: BlockProductionDetail {
                     leader_slots: 6392,

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -514,7 +514,8 @@ pub fn filter_validators(
             };
             // Re-answered against the caller's floors, so what is served agrees with what is said.
             let counts_as_incident = block_production.is_some_and(|detail| {
-                detail.counts_as_incident = detail.counts_as_incident(min_missed_slots, min_leader_slots);
+                detail.counts_as_incident =
+                    detail.counts_as_incident(min_missed_slots, min_leader_slots);
                 detail.counts_as_incident
             });
             // Served when any symptom is asked for and over its own floor.
@@ -1360,7 +1361,9 @@ mod tests {
             min_incident_leader_slots: Some(FIXTURE_LEADER_SLOTS + 1),
             ..config()
         };
-        assert!(filter_validators(validators, &config)[0].incidents.is_empty());
+        assert!(filter_validators(validators, &config)[0]
+            .incidents
+            .is_empty());
     }
 
     #[test]

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -12,7 +12,10 @@ use log::error;
 use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
 use store::{
-    dto::{ValidatorGroupRecord, ValidatorGroups, ValidatorRecord, ValidatorsAggregated},
+    dto::{
+        IncidentDetail, ValidatorGroupRecord, ValidatorGroups, ValidatorRecord,
+        ValidatorsAggregated,
+    },
     groups::{aggregate_operators, singleton_group},
     utils::{to_fixed_for_sort, worst_known_commission, DEFAULT_CACHE_EPOCHS},
 };
@@ -450,10 +453,18 @@ pub fn filter_validators(
     );
     for validator in validators.values_mut() {
         validator.incidents.retain(|incident| {
-            incident.epoch >= from_epoch
-                && incident
-                    .detail
-                    .is_over_downtime_floor(min_incident_downtime)
+            if incident.epoch < from_epoch {
+                return false;
+            }
+            match &incident.detail {
+                // Restart noise is under the floor, unless the epoch also breached block production.
+                IncidentDetail::Downtime {
+                    downtime_seconds,
+                    block_production,
+                    ..
+                } => *downtime_seconds >= min_incident_downtime || block_production.is_some(),
+                _ => true,
+            }
         });
     }
 
@@ -908,15 +919,6 @@ mod tests {
                     cluster_skip_rate_multiple: Some(54.6),
                 },
             },
-        }
-    }
-
-    fn downtime_seconds(incident: &IncidentRecord) -> u64 {
-        match incident.detail {
-            IncidentDetail::Downtime {
-                downtime_seconds, ..
-            } => downtime_seconds,
-            IncidentDetail::BlockProduction { .. } => 0,
         }
     }
 

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -17,14 +17,37 @@ use store::{
         ValidatorsAggregated,
     },
     groups::{aggregate_operators, singleton_group},
+    incidents::MIN_MISSED_SLOTS,
     utils::{to_fixed_for_sort, worst_known_commission, DEFAULT_CACHE_EPOCHS},
 };
 use warp::{http::StatusCode, reply::json, Reply};
 
 const DEFAULT_EPOCHS: usize = 15;
 const DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS: u64 = 180;
+const DEFAULT_MIN_INCIDENT_MISSED_SLOTS: u64 = MIN_MISSED_SLOTS;
 const DEFAULT_INCIDENTS_WINDOW_EPOCHS: u64 = 90;
 const DEFAULT_LIMIT: usize = 100;
+
+/// Which kind of incident a caller wants served.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncidentType {
+    Downtime,
+    BlockProduction,
+}
+
+impl IncidentType {
+    /// Reads the names the response emits under `incident_type`, and their snake_case spellings.
+    fn parse_list(types: &str) -> Result<Vec<Self>, String> {
+        types
+            .split(',')
+            .map(|name| match name.trim().to_lowercase().as_str() {
+                "downtime" => Ok(Self::Downtime),
+                "block_production" | "blockproduction" => Ok(Self::BlockProduction),
+                other => Err(other.to_string()),
+            })
+            .collect()
+    }
+}
 
 // Incidents older than the cache reaches were never loaded, so a wider window would serve less than it says.
 const _: () = assert!(DEFAULT_INCIDENTS_WINDOW_EPOCHS <= DEFAULT_CACHE_EPOCHS);
@@ -72,10 +95,14 @@ pub struct QueryParams {
     query_marinade_stake: Option<bool>,
     query_with_names: Option<bool>,
     query_sfdp: Option<bool>,
-    /// `true` keeps the validators whose `incidents` array comes back empty, `false` the rest. It reads that array, so `min_incident_downtime_seconds` and `incident_window_epochs` shape it too, where `epochs` and `query_from_date` do not.
+    /// `true` keeps the validators whose `incidents` array comes back empty, `false` the rest. It reads that array, so `query_incident_types`, `min_incident_downtime_seconds`, `min_incident_missed_slots` and `incident_window_epochs` shape it too, where `epochs` and `query_from_date` do not.
     query_incident_free: Option<bool>,
+    /// Comma-separated incident types to serve: `downtime`, `block_production`. Defaults to all of them. An epoch with more than one symptom is served under any of them.
+    query_incident_types: Option<String>,
     /// Minimum downtime in seconds for a `DOWN` interval to read as an incident. Shorter intervals are restart noise, and reach neither the `incidents` array nor `order_field=incidents` nor `query_incident_free`. Only applies to the downtime incident type.
     min_incident_downtime_seconds: Option<u64>,
+    /// Minimum missed leader slots for a skipped epoch to read as an incident. Defaults to 4, minimum 4.
+    min_incident_missed_slots: Option<u64>,
     /// Epochs back the `incidents` array reaches, counting the newest reported epoch itself. Defaults to 90; above 90 — the whole window the cache holds — answers 400. Unrelated to `epochs`, which sizes `epoch_stats`.
     incident_window_epochs: Option<u64>,
     query_verified: Option<bool>,
@@ -105,7 +132,9 @@ pub struct GetValidatorsConfig {
     pub query_with_names: Option<bool>,
     pub query_sfdp: Option<bool>,
     pub query_incident_free: Option<bool>,
+    pub query_incident_types: Option<Vec<IncidentType>>,
     pub min_incident_downtime_seconds: Option<u64>,
+    pub min_incident_missed_slots: Option<u64>,
     pub incident_window_epochs: Option<u64>,
     pub query_verified: Option<bool>,
     pub query_protected: Option<bool>,
@@ -445,6 +474,19 @@ pub fn filter_validators(
     let min_incident_downtime = config
         .min_incident_downtime_seconds
         .unwrap_or(DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS);
+    let min_missed_slots = config
+        .min_incident_missed_slots
+        .unwrap_or(DEFAULT_MIN_INCIDENT_MISSED_SLOTS);
+    let wants = |incident_type| {
+        config
+            .query_incident_types
+            .as_ref()
+            .is_none_or(|types| types.contains(&incident_type))
+    };
+    let (wants_downtime, wants_block_production) = (
+        wants(IncidentType::Downtime),
+        wants(IncidentType::BlockProduction),
+    );
     // The window counts `last_epoch` itself.
     let from_epoch = (last_epoch + 1).saturating_sub(
         config
@@ -456,14 +498,22 @@ pub fn filter_validators(
             if incident.epoch < from_epoch {
                 return false;
             }
-            match &incident.detail {
+            // Served when any symptom is asked for and over its own floor.
+            let (downtime_seconds, block_production) = match &incident.detail {
                 IncidentDetail::Downtime {
                     downtime_seconds,
                     block_production,
                     ..
-                } => *downtime_seconds >= min_incident_downtime || block_production.is_some(),
-                _ => true,
-            }
+                } => (Some(*downtime_seconds), block_production.as_ref()),
+                IncidentDetail::BlockProduction {
+                    block_production, ..
+                } => (None, Some(block_production)),
+            };
+            (wants_downtime
+                && downtime_seconds.is_some_and(|seconds| seconds >= min_incident_downtime))
+                || (wants_block_production
+                    && block_production
+                        .is_some_and(|detail| detail.breached(Some(min_missed_slots))))
         });
     }
 
@@ -554,6 +604,28 @@ pub async fn handler(
             ));
         }
     }
+    if let Some(missed_slots) = query_params.min_incident_missed_slots {
+        if missed_slots < MIN_MISSED_SLOTS {
+            return Ok(response_error(
+                StatusCode::BAD_REQUEST,
+                format!("min_incident_missed_slots must be at least {MIN_MISSED_SLOTS}"),
+            ));
+        }
+    }
+    let query_incident_types = match query_params.query_incident_types.as_deref() {
+        Some(types) => match IncidentType::parse_list(types) {
+            Ok(types) => Some(types),
+            Err(unknown) => {
+                return Ok(response_error(
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "query_incident_types does not know {unknown:?}, expected downtime or block_production"
+                    ),
+                ))
+            }
+        },
+        None => None,
+    };
     let config = GetValidatorsConfig {
         order_direction: query_params
             .order_direction
@@ -576,7 +648,9 @@ pub async fn handler(
         query_with_names: query_params.query_with_names,
         query_sfdp: query_params.query_sfdp,
         query_incident_free: query_params.query_incident_free,
+        query_incident_types,
         min_incident_downtime_seconds: query_params.min_incident_downtime_seconds,
+        min_incident_missed_slots: query_params.min_incident_missed_slots,
         incident_window_epochs: query_params.incident_window_epochs,
         query_verified: query_params.query_verified,
         query_protected: query_params.query_protected,
@@ -774,7 +848,9 @@ mod tests {
             query_with_names: None,
             query_sfdp: None,
             query_incident_free: None,
+            query_incident_types: None,
             min_incident_downtime_seconds: None,
+            min_incident_missed_slots: None,
             incident_window_epochs: None,
             query_verified: None,
             query_protected: None,
@@ -901,22 +977,54 @@ mod tests {
         }
     }
 
-    fn block_production_incident(epoch: u64) -> IncidentRecord {
+    const FIXTURE_LEADER_SLOTS: u64 = 6392;
+    const FIXTURE_MISSED_SLOTS: u64 = 548;
+
+    fn skipped(missed_slots: u64) -> BlockProductionDetail {
+        BlockProductionDetail {
+            leader_slots: FIXTURE_LEADER_SLOTS,
+            blocks_produced: FIXTURE_LEADER_SLOTS - missed_slots,
+            missed_slots,
+            skip_rate: missed_slots as f64 / FIXTURE_LEADER_SLOTS as f64,
+            cluster_skip_rate: 0.001_57,
+            threshold: 0.015_7,
+        }
+    }
+
+    fn block_production_incident_of(epoch: u64, missed_slots: u64) -> IncidentRecord {
         let epoch_end_at = Utc::now();
         IncidentRecord {
             epoch,
             detail: IncidentDetail::BlockProduction {
                 epoch_start_at: epoch_end_at - chrono::Duration::days(2),
                 epoch_end_at: Some(epoch_end_at),
-                block_production: BlockProductionDetail {
-                    leader_slots: 6392,
-                    blocks_produced: 5844,
-                    missed_slots: 548,
-                    skip_rate: 0.0857,
-                    cluster_skip_rate: 0.001_57,
-                    threshold: 0.015_7,
-                },
+                block_production: skipped(missed_slots),
             },
+        }
+    }
+
+    fn block_production_incident(epoch: u64) -> IncidentRecord {
+        block_production_incident_of(epoch, FIXTURE_MISSED_SLOTS)
+    }
+
+    /// One epoch that went down and also skipped: a downtime row carrying a symptom of each kind.
+    fn down_and_skipped(downtime_seconds: u64, missed_slots: u64) -> IncidentRecord {
+        let end_at = Utc::now();
+        IncidentRecord {
+            epoch: 100,
+            detail: IncidentDetail::Downtime {
+                start_at: end_at - chrono::Duration::seconds(downtime_seconds as i64),
+                end_at,
+                downtime_seconds,
+                block_production: Some(skipped(missed_slots)),
+            },
+        }
+    }
+
+    fn with_incidents(vote_account: &str, incidents: Vec<IncidentRecord>) -> ValidatorRecord {
+        ValidatorRecord {
+            incidents,
+            ..validator(vote_account, 100, vec![])
         }
     }
 
@@ -1100,6 +1208,135 @@ mod tests {
             ..config()
         };
         assert!(filter_validators(validators, &config).is_empty());
+    }
+
+    #[test]
+    fn the_missed_slot_floor_trims_block_production_incidents() {
+        let validators = map(vec![with_incidents(
+            "skipper",
+            vec![block_production_incident_of(100, 548)],
+        )]);
+        let config = GetValidatorsConfig {
+            query_incident_free: Some(true),
+            min_incident_missed_slots: Some(549),
+            ..config()
+        };
+        assert_eq!(
+            vote_accounts(filter_validators(validators, &config)),
+            vec!["skipper".to_string()]
+        );
+    }
+
+    #[test]
+    fn the_missed_slot_floor_does_not_reach_downtime_incidents() {
+        let validators = map(vec![validator_with_incidents("outage", &[600])]);
+        let config = GetValidatorsConfig {
+            query_incident_free: Some(true),
+            min_incident_missed_slots: Some(u64::MAX),
+            ..config()
+        };
+        assert!(filter_validators(validators, &config).is_empty());
+    }
+
+    #[test]
+    fn each_incident_type_serves_only_its_own_kind() {
+        for (incident_type, served) in [
+            (IncidentType::Downtime, "outage"),
+            (IncidentType::BlockProduction, "skipper"),
+        ] {
+            let validators = map(vec![
+                validator_with_incidents("outage", &[600]),
+                with_incidents("skipper", vec![block_production_incident(100)]),
+            ]);
+            let config = GetValidatorsConfig {
+                query_incident_free: Some(false),
+                query_incident_types: Some(vec![incident_type]),
+                ..config()
+            };
+            assert_eq!(
+                vote_accounts(filter_validators(validators, &config)),
+                vec![served.to_string()],
+                "{incident_type:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_epoch_with_both_symptoms_is_served_under_either_type() {
+        for incident_type in [IncidentType::Downtime, IncidentType::BlockProduction] {
+            let validators = map(vec![with_incidents(
+                "both",
+                vec![down_and_skipped(600, 548)],
+            )]);
+            let config = GetValidatorsConfig {
+                query_incident_types: Some(vec![incident_type]),
+                ..config()
+            };
+            assert_eq!(
+                filter_validators(validators, &config)[0].incidents.len(),
+                1,
+                "{incident_type:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_downtime_carrying_numbers_that_did_not_breach_is_no_block_production_incident() {
+        // 5 of 6392 is 0.08%, under the bar: the numbers are information, not a verdict.
+        let validators = map(vec![with_incidents("blip", vec![down_and_skipped(600, 5)])]);
+        let config = GetValidatorsConfig {
+            query_incident_types: Some(vec![IncidentType::BlockProduction]),
+            ..config()
+        };
+        assert!(filter_validators(validators, &config)[0]
+            .incidents
+            .is_empty());
+    }
+
+    #[test]
+    fn a_downtime_carrying_numbers_that_breached_is_a_block_production_incident() {
+        let validators = map(vec![with_incidents(
+            "skipper",
+            vec![down_and_skipped(600, FIXTURE_MISSED_SLOTS)],
+        )]);
+        let config = GetValidatorsConfig {
+            query_incident_types: Some(vec![IncidentType::BlockProduction]),
+            ..config()
+        };
+        assert_eq!(filter_validators(validators, &config)[0].incidents.len(), 1);
+    }
+
+    #[test]
+    fn an_epoch_with_both_symptoms_under_both_floors_is_dropped() {
+        // Under the 180s floor and under one leader turn: no symptom carries it on its own.
+        let validators = map(vec![with_incidents("both", vec![down_and_skipped(30, 2)])]);
+        assert!(filter_validators(validators, &config())[0]
+            .incidents
+            .is_empty());
+    }
+
+    #[test]
+    fn an_epoch_that_only_skipped_enough_survives_the_downtime_floor() {
+        let validators = map(vec![with_incidents(
+            "both",
+            vec![down_and_skipped(30, 548)],
+        )]);
+        assert_eq!(
+            filter_validators(validators, &config())[0].incidents.len(),
+            1
+        );
+    }
+
+    #[test]
+    fn incident_types_read_the_names_the_response_emits() {
+        assert_eq!(
+            IncidentType::parse_list("Downtime,block_production").unwrap(),
+            vec![IncidentType::Downtime, IncidentType::BlockProduction]
+        );
+        assert_eq!(
+            IncidentType::parse_list("uptime"),
+            Err("uptime".to_string())
+        );
     }
 
     #[test]

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -71,7 +71,7 @@ pub struct QueryParams {
     query_sfdp: Option<bool>,
     /// `true` keeps the validators whose `incidents` array comes back empty, `false` the rest. It reads that array, so `min_incident_downtime_seconds` and `incident_window_epochs` shape it too, where `epochs` and `query_from_date` do not.
     query_incident_free: Option<bool>,
-    /// Minimum downtime in seconds for a `DOWN` interval to read as an incident. Shorter intervals are restart noise, and reach neither the `incidents` array nor `order_field=incidents` nor `query_incident_free`. Block production incidents have no downtime to measure and are kept whatever this is set to.
+    /// Minimum downtime in seconds for a `DOWN` interval to read as an incident. Shorter intervals are restart noise, and reach neither the `incidents` array nor `order_field=incidents` nor `query_incident_free`. Only applies to the downtime incident type.
     min_incident_downtime_seconds: Option<u64>,
     /// Epochs back the `incidents` array reaches, counting the newest reported epoch itself. Defaults to 90; above 90 — the whole window the cache holds — answers 400. Unrelated to `epochs`, which sizes `epoch_stats`.
     incident_window_epochs: Option<u64>,

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -28,7 +28,7 @@ const DEFAULT_INCIDENTS_WINDOW_EPOCHS: u64 = 90;
 const DEFAULT_LIMIT: usize = 100;
 
 /// Which kind of incident a caller wants served.
-#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum IncidentType {
     Downtime,
     BlockProduction,
@@ -95,7 +95,7 @@ pub struct QueryParams {
     query_marinade_stake: Option<bool>,
     query_with_names: Option<bool>,
     query_sfdp: Option<bool>,
-    /// `true` keeps the validators whose `incidents` array comes back empty, `false` the rest. It reads that array, so `query_incident_types`, `min_incident_downtime_seconds`, `min_incident_missed_slots` and `incident_window_epochs` shape it too, where `epochs` and `query_from_date` do not.
+    /// `true` keeps the validators whose `incidents` array comes back empty, `false` the rest. Shaped by incident related query options.
     query_incident_free: Option<bool>,
     /// Comma-separated incident types to serve: `Downtime`, `BlockProduction`, as `incident_type` spells them in the response. Defaults to all of them. An epoch with more than one symptom is served under any of them.
     query_incident_types: Option<String>,

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -1018,7 +1018,7 @@ mod tests {
             epoch,
             detail: IncidentDetail::BlockProduction {
                 epoch_start_at: epoch_end_at - chrono::Duration::days(2),
-                epoch_end_at: Some(epoch_end_at),
+                epoch_end_at,
                 block_production: skipped(missed_slots),
             },
         }

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -35,13 +35,14 @@ pub enum IncidentType {
 }
 
 impl IncidentType {
-    /// Reads the names the response emits under `incident_type`, and their snake_case spellings.
+    /// Reads the names the response emits under `incident_type`, spelled as `order_field` and every
+    /// other enum of this API spells its values.
     fn parse_list(types: &str) -> Result<Vec<Self>, String> {
         types
             .split(',')
-            .map(|name| match name.trim().to_lowercase().as_str() {
-                "downtime" => Ok(Self::Downtime),
-                "block_production" | "blockproduction" => Ok(Self::BlockProduction),
+            .map(|name| match name.trim() {
+                "Downtime" => Ok(Self::Downtime),
+                "BlockProduction" => Ok(Self::BlockProduction),
                 other => Err(other.to_string()),
             })
             .collect()
@@ -96,7 +97,7 @@ pub struct QueryParams {
     query_sfdp: Option<bool>,
     /// `true` keeps the validators whose `incidents` array comes back empty, `false` the rest. It reads that array, so `query_incident_types`, `min_incident_downtime_seconds`, `min_incident_missed_slots` and `incident_window_epochs` shape it too, where `epochs` and `query_from_date` do not.
     query_incident_free: Option<bool>,
-    /// Comma-separated incident types to serve: `downtime`, `block_production`. Defaults to all of them. An epoch with more than one symptom is served under any of them.
+    /// Comma-separated incident types to serve: `Downtime`, `BlockProduction`, as `incident_type` spells them in the response. Defaults to all of them. An epoch with more than one symptom is served under any of them.
     query_incident_types: Option<String>,
     /// Minimum downtime in seconds for a `DOWN` interval to read as an incident. Shorter intervals are restart noise, and reach neither the `incidents` array nor `order_field=incidents` nor `query_incident_free`. Only applies to the downtime incident type.
     min_incident_downtime_seconds: Option<u64>,
@@ -635,7 +636,7 @@ pub async fn handler(
                 return Ok(response_error(
                     StatusCode::BAD_REQUEST,
                     format!(
-                        "query_incident_types does not know {unknown:?}, expected downtime or block_production"
+                        "query_incident_types does not know {unknown:?}, expected Downtime or BlockProduction"
                     ),
                 ))
             }
@@ -1384,18 +1385,6 @@ mod tests {
         assert_eq!(
             filter_validators(validators, &config())[0].incidents.len(),
             1
-        );
-    }
-
-    #[test]
-    fn incident_types_read_the_names_the_response_emits() {
-        assert_eq!(
-            IncidentType::parse_list("Downtime,block_production").unwrap(),
-            vec![IncidentType::Downtime, IncidentType::BlockProduction]
-        );
-        assert_eq!(
-            IncidentType::parse_list("uptime"),
-            Err("uptime".to_string())
         );
     }
 

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -12,42 +12,19 @@ use log::error;
 use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
 use store::{
-    dto::{
-        IncidentDetail, ValidatorGroupRecord, ValidatorGroups, ValidatorRecord,
-        ValidatorsAggregated,
-    },
+    dto::{ValidatorGroupRecord, ValidatorGroups, ValidatorRecord, ValidatorsAggregated},
     groups::{aggregate_operators, singleton_group},
-    incidents::{MIN_LEADER_SLOTS, MIN_MISSED_SLOTS},
+    incidents::{
+        IncidentFilters, IncidentType, ValidatorIncidents, DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS,
+        MIN_LEADER_SLOTS, MIN_MISSED_SLOTS,
+    },
     utils::{to_fixed_for_sort, worst_known_commission, DEFAULT_CACHE_EPOCHS},
 };
 use warp::{http::StatusCode, reply::json, Reply};
 
 const DEFAULT_EPOCHS: usize = 15;
-const DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS: u64 = 180;
 const DEFAULT_INCIDENTS_WINDOW_EPOCHS: u64 = 90;
 const DEFAULT_LIMIT: usize = 100;
-
-/// Which kind of incident a caller wants served.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum IncidentType {
-    Downtime,
-    BlockProduction,
-}
-
-impl IncidentType {
-    /// Reads the names the response emits under `incident_type`, spelled as `order_field` and every
-    /// other enum of this API spells its values.
-    fn parse_list(types: &str) -> Result<Vec<Self>, String> {
-        types
-            .split(',')
-            .map(|name| match name.trim() {
-                "Downtime" => Ok(Self::Downtime),
-                "BlockProduction" => Ok(Self::BlockProduction),
-                other => Err(other.to_string()),
-            })
-            .collect()
-    }
-}
 
 // Incidents older than the cache reaches were never loaded, so a wider window would serve less than it says.
 const _: () = assert!(DEFAULT_INCIDENTS_WINDOW_EPOCHS <= DEFAULT_CACHE_EPOCHS);
@@ -163,16 +140,17 @@ pub async fn get_validators(
     context: WrappedContext,
     config: GetValidatorsConfig,
 ) -> anyhow::Result<ValidatorsPage> {
-    let (validators, bond_flags_updated_at, net_apy_updated_at) = {
+    let (validators, incidents, bond_flags_updated_at, net_apy_updated_at) = {
         let cache = &context.read().await.cache;
         (
             cache.get_validators(),
+            cache.get_validator_incidents(),
             cache.bond_flags_updated_at().map(DateTime::<Utc>::from),
             cache.net_apy_updated_at().map(DateTime::<Utc>::from),
         )
     };
 
-    let validators = filter_validators(validators, &config);
+    let validators = filter_validators(validators, &incidents, &config);
     // Measured over the whole match rather than the page, so every page reads the same window.
     let newest_epoch = validators
         .iter()
@@ -466,64 +444,32 @@ fn get_field_extractor(order_field: OrderField) -> FieldExtractor {
 
 pub fn filter_validators(
     mut validators: HashMap<String, ValidatorRecord>,
+    incidents: &ValidatorIncidents,
     config: &GetValidatorsConfig,
 ) -> Vec<ValidatorRecord> {
     // Shared with the client and provider aggregates, so both describe the same population.
     let last_epoch = store::utils::last_reported_epoch(validators.values()).unwrap_or(0);
     validators.retain(|_, validator| store::utils::is_eligible_validator(validator, last_epoch));
 
-    // Everything downstream reads whatever survives here: the array served, the ordering,
+    // Everything downstream reads whatever this projection serves: the array itself, the ordering,
     // `query_incident_free`, and the operator rows aggregated off these records.
-    let min_incident_downtime = config
-        .min_incident_downtime_seconds
-        .unwrap_or(DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS);
-    // `counts_as_incident` owns both defaults, so the caller's floors travel as they arrived.
-    let (min_missed_slots, min_leader_slots) = (
-        config.min_incident_missed_slots,
-        config.min_incident_leader_slots,
-    );
-    let wants = |incident_type| {
-        config
-            .query_incident_types
-            .as_ref()
-            .is_none_or(|types| types.contains(&incident_type))
+    let filters = IncidentFilters {
+        // The window counts `last_epoch` itself.
+        from_epoch: (last_epoch + 1).saturating_sub(
+            config
+                .incident_window_epochs
+                .unwrap_or(DEFAULT_INCIDENTS_WINDOW_EPOCHS),
+        ),
+        min_downtime_seconds: config
+            .min_incident_downtime_seconds
+            .unwrap_or(DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS),
+        // `counts_as_incident` owns both defaults, so the caller's floors travel as they arrived.
+        min_missed_slots: config.min_incident_missed_slots,
+        min_leader_slots: config.min_incident_leader_slots,
+        types: config.query_incident_types.clone(),
     };
-    let (wants_downtime, wants_block_production) = (
-        wants(IncidentType::Downtime),
-        wants(IncidentType::BlockProduction),
-    );
-    // The window counts `last_epoch` itself.
-    let from_epoch = (last_epoch + 1).saturating_sub(
-        config
-            .incident_window_epochs
-            .unwrap_or(DEFAULT_INCIDENTS_WINDOW_EPOCHS),
-    );
-    for validator in validators.values_mut() {
-        validator.incidents.retain_mut(|incident| {
-            if incident.epoch < from_epoch {
-                return false;
-            }
-            let (downtime_seconds, block_production) = match &mut incident.detail {
-                IncidentDetail::Downtime {
-                    downtime_seconds,
-                    block_production,
-                    ..
-                } => (Some(*downtime_seconds), block_production.as_mut()),
-                IncidentDetail::BlockProduction {
-                    block_production, ..
-                } => (None, Some(block_production)),
-            };
-            // Re-answered against the caller's floors, so what is served agrees with what is said.
-            let counts_as_incident = block_production.is_some_and(|detail| {
-                detail.counts_as_incident =
-                    detail.counts_as_incident(min_missed_slots, min_leader_slots);
-                detail.counts_as_incident
-            });
-            // Served when any symptom is asked for and over its own floor.
-            (wants_downtime
-                && downtime_seconds.is_some_and(|seconds| seconds >= min_incident_downtime))
-                || (wants_block_production && counts_as_incident)
-        });
+    for (vote_account, validator) in validators.iter_mut() {
+        validator.incidents = incidents.into_response_incidents(vote_account, &filters);
     }
 
     if config.query_sfdp.is_some() {
@@ -719,10 +665,8 @@ pub async fn handler(
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use store::dto::{
-        BlockProductionDetail, IncidentDetail, IncidentRecord, ValidatorEpochStats,
-        ValidatorWarning, UNKNOWN_CLIENT_NAME,
-    };
+    use store::dto::{IncidentDetail, ValidatorEpochStats, ValidatorWarning, UNKNOWN_CLIENT_NAME};
+    use store::incidents::{DowntimeInterval, EpochBlockProduction};
 
     fn epoch_stat(epoch: u64, stake: i64) -> ValidatorEpochStats {
         ValidatorEpochStats {
@@ -904,7 +848,7 @@ mod tests {
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &no_incidents(), &config)),
             vec!["flagged".to_string()]
         );
     }
@@ -920,7 +864,7 @@ mod tests {
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &no_incidents(), &config)),
             vec!["clean".to_string()]
         );
     }
@@ -931,7 +875,10 @@ mod tests {
             validator("flagged", 100, vec![ValidatorWarning::Superminority]),
             validator("clean", 100, vec![]),
         ]);
-        assert_eq!(filter_validators(validators, &config()).len(), 2);
+        assert_eq!(
+            filter_validators(validators, &no_incidents(), &config()).len(),
+            2
+        );
     }
 
     fn protected_validator(vote_account: &str) -> ValidatorRecord {
@@ -952,7 +899,7 @@ mod tests {
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &no_incidents(), &config)),
             vec!["bonded".to_string()]
         );
     }
@@ -968,7 +915,7 @@ mod tests {
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &no_incidents(), &config)),
             vec!["unbonded".to_string()]
         );
     }
@@ -979,102 +926,94 @@ mod tests {
             protected_validator("bonded"),
             validator("unbonded", 100, vec![]),
         ]);
-        assert_eq!(filter_validators(validators, &config()).len(), 2);
-    }
-
-    // load_incidents derives downtime_seconds as EXTRACT(epoch FROM end_at - start_at).
-    fn incident_in_epoch(epoch: u64, downtime_seconds: u64) -> IncidentRecord {
-        let end_at = Utc::now();
-        IncidentRecord {
-            epoch,
-            detail: IncidentDetail::Downtime {
-                start_at: end_at - chrono::Duration::seconds(downtime_seconds as i64),
-                end_at,
-                downtime_seconds,
-                block_production: None,
-            },
-        }
+        assert_eq!(
+            filter_validators(validators, &no_incidents(), &config()).len(),
+            2
+        );
     }
 
     const FIXTURE_LEADER_SLOTS: u64 = 6392;
     const FIXTURE_MISSED_SLOTS: u64 = 548;
+    /// Puts the bar at 1.57%, which `FIXTURE_MISSED_SLOTS` breaks at 8.6% and a few slots do not.
+    const FIXTURE_CLUSTER_SKIP_RATE: f64 = 0.001_57;
 
-    fn skipped(missed_slots: u64) -> BlockProductionDetail {
-        let mut detail = BlockProductionDetail {
-            leader_slots: FIXTURE_LEADER_SLOTS,
-            blocks_produced: FIXTURE_LEADER_SLOTS - missed_slots,
-            missed_slots,
-            skip_rate: missed_slots as f64 / FIXTURE_LEADER_SLOTS as f64,
-            cluster_skip_rate: 0.001_57,
-            threshold: 0.015_7,
-            counts_as_incident: false,
-        };
-        detail.counts_as_incident = detail.counts_as_incident(None, None);
-        detail
-    }
+    /// Raw incident material, as the store hands it to the projection. The fixture validators report
+    /// epoch stats up to epoch 100.
+    #[derive(Default)]
+    struct Material(ValidatorIncidents);
 
-    fn block_production_incident_of(epoch: u64, missed_slots: u64) -> IncidentRecord {
-        let epoch_end_at = Utc::now();
-        IncidentRecord {
-            epoch,
-            detail: IncidentDetail::BlockProduction {
-                epoch_start_at: epoch_end_at - chrono::Duration::days(2),
-                epoch_end_at,
-                block_production: skipped(missed_slots),
-            },
+    impl Material {
+        fn down(mut self, vote_account: &str, epoch: u64, downtime_seconds: u64) -> Self {
+            let end_at = Utc::now();
+            self.0
+                .records(vote_account)
+                .downtimes
+                .push(DowntimeInterval {
+                    epoch,
+                    start_at: end_at - chrono::Duration::seconds(downtime_seconds as i64),
+                    end_at,
+                    downtime_seconds,
+                });
+            self
+        }
+
+        fn produced(mut self, vote_account: &str, epoch: u64, missed_slots: u64) -> Self {
+            let epoch_end_at = Utc::now();
+            self.0
+                .records(vote_account)
+                .block_production
+                .push(EpochBlockProduction {
+                    epoch,
+                    epoch_start_at: epoch_end_at - chrono::Duration::days(2),
+                    epoch_end_at,
+                    leader_slots: FIXTURE_LEADER_SLOTS,
+                    blocks_produced: FIXTURE_LEADER_SLOTS - missed_slots,
+                    cluster_skip_rate: FIXTURE_CLUSTER_SKIP_RATE,
+                });
+            self
+        }
+
+        /// An epoch that broke the block production rule: 548 of 6392 missed is 8.6%.
+        fn skipped(self, vote_account: &str, epoch: u64) -> Self {
+            self.produced(vote_account, epoch, FIXTURE_MISSED_SLOTS)
+        }
+
+        fn build(self) -> ValidatorIncidents {
+            self.0
         }
     }
 
-    fn block_production_incident(epoch: u64) -> IncidentRecord {
-        block_production_incident_of(epoch, FIXTURE_MISSED_SLOTS)
+    /// `DOWN` intervals of one validator in the epoch the fixtures report.
+    fn downtimes(vote_account: &str, seconds: &[u64]) -> ValidatorIncidents {
+        seconds
+            .iter()
+            .fold(Material::default(), |material, seconds| {
+                material.down(vote_account, 100, *seconds)
+            })
+            .build()
     }
 
-    /// One epoch that went down and also skipped: a downtime row carrying a symptom of each kind.
-    fn down_and_skipped(downtime_seconds: u64, missed_slots: u64) -> IncidentRecord {
-        let end_at = Utc::now();
-        IncidentRecord {
-            epoch: 100,
-            detail: IncidentDetail::Downtime {
-                start_at: end_at - chrono::Duration::seconds(downtime_seconds as i64),
-                end_at,
-                downtime_seconds,
-                block_production: Some(skipped(missed_slots)),
-            },
-        }
-    }
-
-    fn with_incidents(vote_account: &str, incidents: Vec<IncidentRecord>) -> ValidatorRecord {
-        ValidatorRecord {
-            incidents,
-            ..validator(vote_account, 100, vec![])
-        }
-    }
-
-    // The fixture validators report epoch_stats up to epoch 100.
-    fn incident(downtime_seconds: u64) -> IncidentRecord {
-        incident_in_epoch(100, downtime_seconds)
-    }
-
-    fn validator_with_incidents(vote_account: &str, downtimes: &[u64]) -> ValidatorRecord {
-        ValidatorRecord {
-            incidents: downtimes.iter().copied().map(incident).collect(),
-            ..validator(vote_account, 100, vec![])
-        }
+    fn no_incidents() -> ValidatorIncidents {
+        ValidatorIncidents::default()
     }
 
     #[test]
     fn incident_free_without_a_floor_reads_the_default_one() {
         let validators = map(vec![
-            validator_with_incidents("blip", &[1]),
-            validator_with_incidents("outage", &[180]),
-            validator_with_incidents("clean", &[]),
+            validator("blip", 100, vec![]),
+            validator("outage", 100, vec![]),
+            validator("clean", 100, vec![]),
         ]);
+        let incidents = Material::default()
+            .down("blip", 100, 1)
+            .down("outage", 100, 180)
+            .build();
         let config = GetValidatorsConfig {
             query_incident_free: Some(true),
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &incidents, &config)),
             vec!["blip".to_string(), "clean".to_string()],
             "a one-second blip is restart noise, not an incident"
         );
@@ -1083,38 +1022,34 @@ mod tests {
     #[test]
     fn the_default_window_reaches_ninety_epochs_back() {
         // The fixtures report up to epoch 100, so the window opens at epoch 11.
-        let stale = ValidatorRecord {
-            incidents: vec![incident_in_epoch(10, 600)],
-            ..validator("stale", 100, vec![])
-        };
-        let recent = ValidatorRecord {
-            incidents: vec![incident_in_epoch(11, 600)],
-            ..validator("recent", 100, vec![])
-        };
+        let validators = map(vec![
+            validator("stale", 100, vec![]),
+            validator("recent", 100, vec![]),
+        ]);
+        let incidents = Material::default()
+            .down("stale", 10, 600)
+            .down("recent", 11, 600)
+            .build();
         let config = GetValidatorsConfig {
             query_incident_free: Some(true),
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(map(vec![stale, recent]), &config)),
+            vote_accounts(filter_validators(validators, &incidents, &config)),
             vec!["stale".to_string()]
         );
     }
 
     #[test]
     fn incident_window_epochs_trims_the_array_and_the_filter_together() {
-        let validators = || {
-            map(vec![ValidatorRecord {
-                incidents: vec![incident_in_epoch(98, 600)],
-                ..validator("outage", 100, vec![])
-            }])
-        };
+        let validators = || map(vec![validator("outage", 100, vec![])]);
+        let incidents = Material::default().down("outage", 98, 600).build();
         let narrowed = GetValidatorsConfig {
             query_incident_free: Some(true),
             incident_window_epochs: Some(2),
             ..config()
         };
-        let filtered = filter_validators(validators(), &narrowed);
+        let filtered = filter_validators(validators(), &incidents, &narrowed);
         assert_eq!(
             vote_accounts(filtered.clone()),
             vec!["outage".to_string()],
@@ -1129,20 +1064,21 @@ mod tests {
             incident_window_epochs: Some(3),
             ..narrowed
         };
-        assert!(filter_validators(validators(), &widened).is_empty());
+        assert!(filter_validators(validators(), &incidents, &widened).is_empty());
     }
 
     #[test]
     fn the_window_trims_the_array_without_query_incident_free() {
-        let validators = map(vec![ValidatorRecord {
-            incidents: vec![incident_in_epoch(98, 600), incident_in_epoch(100, 600)],
-            ..validator("outage", 100, vec![])
-        }]);
+        let validators = map(vec![validator("outage", 100, vec![])]);
+        let incidents = Material::default()
+            .down("outage", 98, 600)
+            .down("outage", 100, 600)
+            .build();
         let config = GetValidatorsConfig {
             incident_window_epochs: Some(2),
             ..config()
         };
-        let filtered = filter_validators(validators, &config);
+        let filtered = filter_validators(validators, &incidents, &config);
         assert_eq!(
             filtered[0]
                 .incidents
@@ -1156,45 +1092,54 @@ mod tests {
     #[test]
     fn incident_free_ignores_downtime_below_the_floor() {
         let validators = map(vec![
-            validator_with_incidents("blip", &[179]),
-            validator_with_incidents("outage", &[180]),
+            validator("blip", 100, vec![]),
+            validator("outage", 100, vec![]),
         ]);
+        let incidents = Material::default()
+            .down("blip", 100, 179)
+            .down("outage", 100, 180)
+            .build();
         let config = GetValidatorsConfig {
             query_incident_free: Some(true),
             min_incident_downtime_seconds: Some(180),
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &incidents, &config)),
             vec!["blip".to_string()]
         );
     }
 
     #[test]
     fn incident_free_looks_at_every_incident_not_just_the_first() {
-        let validators = map(vec![validator_with_incidents("mixed", &[10, 600])]);
+        let validators = map(vec![validator("mixed", 100, vec![])]);
+        let incidents = downtimes("mixed", &[10, 600]);
         let config = GetValidatorsConfig {
             query_incident_free: Some(true),
             min_incident_downtime_seconds: Some(180),
             ..config()
         };
-        assert!(filter_validators(validators, &config).is_empty());
+        assert!(filter_validators(validators, &incidents, &config).is_empty());
     }
 
     #[test]
     fn incident_free_false_keeps_only_validators_over_the_floor() {
         let validators = map(vec![
-            validator_with_incidents("blip", &[179]),
-            validator_with_incidents("outage", &[180]),
-            validator_with_incidents("clean", &[]),
+            validator("blip", 100, vec![]),
+            validator("outage", 100, vec![]),
+            validator("clean", 100, vec![]),
         ]);
+        let incidents = Material::default()
+            .down("blip", 100, 179)
+            .down("outage", 100, 180)
+            .build();
         let config = GetValidatorsConfig {
             query_incident_free: Some(false),
             min_incident_downtime_seconds: Some(180),
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &incidents, &config)),
             vec!["outage".to_string()]
         );
     }
@@ -1202,73 +1147,72 @@ mod tests {
     #[test]
     fn a_block_production_incident_is_not_incident_free() {
         let validators = map(vec![
-            ValidatorRecord {
-                incidents: vec![block_production_incident(100)],
-                ..validator("skipper", 100, vec![])
-            },
+            validator("skipper", 100, vec![]),
             validator("clean", 100, vec![]),
         ]);
+        let incidents = Material::default().skipped("skipper", 100).build();
         let config = GetValidatorsConfig {
             query_incident_free: Some(true),
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &incidents, &config)),
             vec!["clean".to_string()]
         );
     }
 
     #[test]
     fn the_downtime_floor_does_not_reach_block_production_incidents() {
-        let validators = map(vec![ValidatorRecord {
-            incidents: vec![block_production_incident(100)],
-            ..validator("skipper", 100, vec![])
-        }]);
+        let validators = map(vec![validator("skipper", 100, vec![])]);
+        let incidents = Material::default().skipped("skipper", 100).build();
         let config = GetValidatorsConfig {
             query_incident_free: Some(true),
             min_incident_downtime_seconds: Some(u64::MAX),
             ..config()
         };
-        assert!(filter_validators(validators, &config).is_empty());
+        assert!(filter_validators(validators, &incidents, &config).is_empty());
     }
 
     #[test]
     fn the_missed_slot_floor_trims_block_production_incidents() {
-        let validators = map(vec![with_incidents(
-            "skipper",
-            vec![block_production_incident_of(100, 548)],
-        )]);
+        let validators = map(vec![validator("skipper", 100, vec![])]);
+        let incidents = Material::default().skipped("skipper", 100).build();
         let config = GetValidatorsConfig {
             query_incident_free: Some(true),
-            min_incident_missed_slots: Some(549),
+            min_incident_missed_slots: Some(FIXTURE_MISSED_SLOTS + 1),
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &incidents, &config)),
             vec!["skipper".to_string()]
         );
     }
 
     #[test]
     fn the_missed_slot_floor_does_not_reach_downtime_incidents() {
-        let validators = map(vec![validator_with_incidents("outage", &[600])]);
+        let validators = map(vec![validator("outage", 100, vec![])]);
+        let incidents = downtimes("outage", &[600]);
         let config = GetValidatorsConfig {
             query_incident_free: Some(true),
             min_incident_missed_slots: Some(u64::MAX),
             ..config()
         };
-        assert!(filter_validators(validators, &config).is_empty());
+        assert!(filter_validators(validators, &incidents, &config).is_empty());
     }
 
     #[test]
     fn each_incident_type_serves_only_its_own_kind() {
+        let incidents = Material::default()
+            .down("outage", 100, 600)
+            .skipped("skipper", 100)
+            .build();
         for (incident_type, served) in [
             (IncidentType::Downtime, "outage"),
             (IncidentType::BlockProduction, "skipper"),
         ] {
             let validators = map(vec![
-                validator_with_incidents("outage", &[600]),
-                with_incidents("skipper", vec![block_production_incident(100)]),
+                validator("outage", 100, vec![]),
+                validator("skipper", 100, vec![]),
             ]);
             let config = GetValidatorsConfig {
                 query_incident_free: Some(false),
@@ -1276,131 +1220,42 @@ mod tests {
                 ..config()
             };
             assert_eq!(
-                vote_accounts(filter_validators(validators, &config)),
+                vote_accounts(filter_validators(validators, &incidents, &config)),
                 vec![served.to_string()],
                 "{incident_type:?}"
             );
         }
     }
 
+    // A restart under the floor is not served, so the epoch it happened in is served for its block
+    // production instead, under the type that says so.
     #[test]
-    fn an_epoch_with_both_symptoms_is_served_under_either_type() {
-        for incident_type in [IncidentType::Downtime, IncidentType::BlockProduction] {
-            let validators = map(vec![with_incidents(
-                "both",
-                vec![down_and_skipped(600, 548)],
-            )]);
-            let config = GetValidatorsConfig {
-                query_incident_types: Some(vec![incident_type]),
-                ..config()
-            };
-            assert_eq!(
-                filter_validators(validators, &config)[0].incidents.len(),
-                1,
-                "{incident_type:?}"
-            );
-        }
-    }
+    fn a_restart_under_the_floor_does_not_carry_its_epoch_s_block_production() {
+        let validators = map(vec![validator("flappy", 100, vec![])]);
+        let incidents = Material::default()
+            .down("flappy", 100, 12)
+            .skipped("flappy", 100)
+            .build();
 
-    #[test]
-    fn a_downtime_carrying_numbers_under_the_rule_is_no_block_production_incident() {
-        // 5 of 6392 is 0.08%, under the bar: the numbers are information, not a verdict.
-        let validators = map(vec![with_incidents("blip", vec![down_and_skipped(600, 5)])]);
-        let config = GetValidatorsConfig {
-            query_incident_types: Some(vec![IncidentType::BlockProduction]),
-            ..config()
-        };
-        assert!(filter_validators(validators, &config)[0]
-            .incidents
-            .is_empty());
-    }
-
-    #[test]
-    fn a_downtime_carrying_numbers_over_the_rule_is_a_block_production_incident() {
-        let validators = map(vec![with_incidents(
-            "skipper",
-            vec![down_and_skipped(600, FIXTURE_MISSED_SLOTS)],
-        )]);
-        let config = GetValidatorsConfig {
-            query_incident_types: Some(vec![IncidentType::BlockProduction]),
-            ..config()
-        };
-        assert_eq!(filter_validators(validators, &config)[0].incidents.len(), 1);
-    }
-
-    // What is served has to agree with what it says about itself.
-    #[test]
-    fn a_caller_floor_rewrites_the_counts_as_incident_flag_it_is_served_with() {
-        let validators = map(vec![with_incidents(
-            "skipper",
-            vec![down_and_skipped(600, FIXTURE_MISSED_SLOTS)],
-        )]);
-        let config = GetValidatorsConfig {
-            min_incident_missed_slots: Some(FIXTURE_MISSED_SLOTS + 1),
-            ..config()
-        };
-
-        let served = filter_validators(validators, &config);
-        let IncidentDetail::Downtime {
-            block_production, ..
-        } = &served[0].incidents[0].detail
-        else {
-            panic!("a downtime fixture is a downtime incident");
-        };
-        // Kept by its downtime, but no longer a block production incident under this floor.
-        assert!(!block_production.as_ref().unwrap().counts_as_incident);
-    }
-
-    #[test]
-    fn a_leader_slot_floor_above_the_default_drops_what_the_rule_admitted() {
-        let validators = map(vec![with_incidents(
-            "skipper",
-            vec![down_and_skipped(600, FIXTURE_MISSED_SLOTS)],
-        )]);
-        let config = GetValidatorsConfig {
-            query_incident_types: Some(vec![IncidentType::BlockProduction]),
-            min_incident_leader_slots: Some(FIXTURE_LEADER_SLOTS + 1),
-            ..config()
-        };
-        assert!(filter_validators(validators, &config)[0]
-            .incidents
-            .is_empty());
-    }
-
-    #[test]
-    fn an_epoch_with_both_symptoms_under_both_floors_is_dropped() {
-        // Under the 180s floor and under one leader turn: no symptom carries it on its own.
-        let validators = map(vec![with_incidents("both", vec![down_and_skipped(30, 2)])]);
-        assert!(filter_validators(validators, &config())[0]
-            .incidents
-            .is_empty());
-    }
-
-    #[test]
-    fn an_epoch_that_only_skipped_enough_survives_the_downtime_floor() {
-        let validators = map(vec![with_incidents(
-            "both",
-            vec![down_and_skipped(30, 548)],
-        )]);
-        assert_eq!(
-            filter_validators(validators, &config())[0].incidents.len(),
-            1
-        );
+        let served = filter_validators(validators, &incidents, &config());
+        assert_eq!(served[0].incidents.len(), 1);
+        assert!(matches!(
+            served[0].incidents[0].detail,
+            IncidentDetail::BlockProduction { .. }
+        ));
     }
 
     #[test]
     fn a_block_production_incident_outside_the_window_is_dropped_like_any_other() {
         // The fixtures report up to epoch 100, so the default window opens at epoch 11.
-        let validators = map(vec![ValidatorRecord {
-            incidents: vec![block_production_incident(10)],
-            ..validator("skipper", 100, vec![])
-        }]);
+        let validators = map(vec![validator("skipper", 100, vec![])]);
+        let incidents = Material::default().skipped("skipper", 10).build();
         let config = GetValidatorsConfig {
             query_incident_free: Some(true),
             ..config()
         };
         assert_eq!(
-            vote_accounts(filter_validators(validators, &config)),
+            vote_accounts(filter_validators(validators, &incidents, &config)),
             vec!["skipper".to_string()]
         );
     }
@@ -1408,14 +1263,18 @@ mod tests {
     #[test]
     fn min_incident_downtime_alone_keeps_every_validator_but_trims_their_arrays() {
         let validators = map(vec![
-            validator_with_incidents("blip", &[179]),
-            validator_with_incidents("outage", &[180]),
+            validator("blip", 100, vec![]),
+            validator("outage", 100, vec![]),
         ]);
+        let incidents = Material::default()
+            .down("blip", 100, 179)
+            .down("outage", 100, 180)
+            .build();
         let config = GetValidatorsConfig {
             min_incident_downtime_seconds: Some(180),
             ..config()
         };
-        let filtered = filter_validators(validators, &config);
+        let filtered = filter_validators(validators, &incidents, &config);
         assert_eq!(filtered.len(), 2);
         assert_eq!(
             filtered
@@ -1428,8 +1287,8 @@ mod tests {
 
     #[test]
     fn the_incidents_array_drops_restart_noise_by_default() {
-        let validators = map(vec![validator_with_incidents("mixed", &[1, 180])]);
-        let filtered = filter_validators(validators, &config());
+        let validators = map(vec![validator("mixed", 100, vec![])]);
+        let filtered = filter_validators(validators, &downtimes("mixed", &[1, 180]), &config());
         assert_eq!(
             filtered[0]
                 .incidents
@@ -1447,12 +1306,17 @@ mod tests {
 
     #[test]
     fn a_zero_floor_serves_every_interval() {
-        let validators = map(vec![validator_with_incidents("mixed", &[1, 600])]);
+        let validators = map(vec![validator("mixed", 100, vec![])]);
         let config = GetValidatorsConfig {
             min_incident_downtime_seconds: Some(0),
             ..config()
         };
-        assert_eq!(filter_validators(validators, &config)[0].incidents.len(), 2);
+        assert_eq!(
+            filter_validators(validators, &downtimes("mixed", &[1, 600]), &config)[0]
+                .incidents
+                .len(),
+            2
+        );
     }
 
     #[test]
@@ -1964,7 +1828,8 @@ mod tests {
     #[test]
     fn incidents_and_delegation_relationships_order_validators_too() {
         let with_incidents = |vote_account: &str, count: usize| ValidatorRecord {
-            incidents: vec![incident(600); count],
+            incidents: downtimes(vote_account, &vec![600; count])
+                .into_response_incidents(vote_account, &Default::default()),
             ..validator(vote_account, 100, vec![])
         };
         assert_eq!(

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -15,8 +15,8 @@ use store::{
     dto::{ValidatorGroupRecord, ValidatorGroups, ValidatorRecord, ValidatorsAggregated},
     groups::{aggregate_operators, singleton_group},
     incidents::{
-        IncidentFilters, IncidentType, ValidatorIncidents, DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS,
-        MIN_LEADER_SLOTS, MIN_MISSED_SLOTS,
+        IncidentFilters, IncidentType, ValidatorIncidents, DEFAULT_INCIDENT_TYPES,
+        DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS, MIN_LEADER_SLOTS, MIN_MISSED_SLOTS,
     },
     utils::{to_fixed_for_sort, worst_known_commission, DEFAULT_CACHE_EPOCHS},
 };
@@ -74,7 +74,7 @@ pub struct QueryParams {
     query_sfdp: Option<bool>,
     /// `true` keeps the validators whose `incidents` array comes back empty, `false` the rest. Shaped by incident related query options.
     query_incident_free: Option<bool>,
-    /// Comma-separated incident types to serve: `Downtime`, `BlockProduction`, as `incident_type` spells them in the response. Defaults to all of them. An epoch with more than one symptom is served under any of them.
+    /// Comma-separated incident types to serve: `Downtime`, `BlockProduction`, as `incident_type` spells them in the response. Defaults to `Downtime`, since `BlockProduction` records carry different fields. An epoch with more than one symptom is served under any of them.
     query_incident_types: Option<String>,
     /// Minimum downtime in seconds for a `DOWN` interval to read as an incident. Shorter intervals are restart noise, and reach neither the `incidents` array nor `order_field=incidents` nor `query_incident_free`. Only applies to the downtime incident type.
     min_incident_downtime_seconds: Option<u64>,
@@ -587,7 +587,7 @@ pub async fn handler(
                 ))
             }
         },
-        None => None,
+        None => Some(DEFAULT_INCIDENT_TYPES.to_vec()),
     };
     let config = GetValidatorsConfig {
         order_direction: query_params

--- a/api/src/utils/validator_groups.rs
+++ b/api/src/utils/validator_groups.rs
@@ -225,16 +225,19 @@ pub fn page_tree(tree: ValidatorGroupTree, config: &GetGroupsConfig) -> TreePage
 mod tests {
     use super::*;
     use chrono::Utc;
-    use store::dto::{GroupIncidentRecord, GroupIncidents};
+    use store::dto::{GroupIncidentRecord, GroupIncidents, IncidentDetail};
     use store::groups::UNKNOWN_GROUP;
 
     fn long_incident() -> GroupIncidentRecord {
         GroupIncidentRecord {
             validator: "vote".to_string(),
             epoch: 100,
-            start_at: Utc::now(),
-            end_at: Utc::now(),
-            downtime_seconds: 600,
+            detail: IncidentDetail::Downtime {
+                start_at: Utc::now(),
+                end_at: Utc::now(),
+                downtime_seconds: 600,
+                block_production: None,
+            },
         }
     }
 

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -401,8 +401,8 @@ pub enum IncidentDetail {
         start_at: DateTime<Utc>,
         end_at: DateTime<Utc>,
         downtime_seconds: u64,
-        /// Set when the same epoch also breached the block production rule: the two are one event
-        /// with two symptoms, so they are not served as two incidents.
+        /// The epoch's block production, whenever there was any to measure. Breach or not: this
+        /// record exists because the validator went down, and these are the numbers alongside it.
         #[serde(default)]
         block_production: Option<BlockProductionDetail>,
     },
@@ -415,7 +415,7 @@ pub enum IncidentDetail {
     },
 }
 
-/// Why one epoch breached the block production rule, with the numbers behind it.
+/// What a validator produced of its leader slots in one epoch, and the bar it was held to.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, utoipa::ToSchema)]
 pub struct BlockProductionDetail {
     pub leader_slots: u64,

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -442,20 +442,6 @@ impl IncidentDetail {
             Self::BlockProduction { epoch_end_at, .. } => *epoch_end_at,
         }
     }
-
-    /// Whether the incident is one worth serving: over the downtime floor where it has downtime to
-    /// measure. Restart noise is under the floor; a block production incident has no downtime side
-    /// and is never noise.
-    pub fn is_over_downtime_floor(&self, min_downtime_seconds: u64) -> bool {
-        match self {
-            Self::Downtime {
-                downtime_seconds,
-                block_production,
-                ..
-            } => *downtime_seconds >= min_downtime_seconds || block_production.is_some(),
-            Self::BlockProduction { .. } => true,
-        }
-    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema)]

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -230,8 +230,7 @@ impl Validator {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema)]
-#[cfg_attr(test, derive(Default))]
+#[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema, Default)]
 pub struct ValidatorEpochStats {
     pub epoch: u64,
     pub epoch_start_at: Option<DateTime<Utc>>,
@@ -287,8 +286,7 @@ pub struct ValidatorEpochStats {
     pub rank_apy: Option<usize>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema)]
-#[cfg_attr(test, derive(Default))]
+#[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema, Default)]
 pub struct ValidatorRecord {
     pub identity: String,
     pub vote_account: String,
@@ -386,13 +384,77 @@ pub struct UptimeRecord {
     pub end_at: DateTime<Utc>,
 }
 
-/// A single downtime incident (one DOWN interval from the uptimes table).
+/// One incident on a validator in one epoch. `incident_type` says which kind, and which of the
+/// remaining fields are present.
 #[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema)]
 pub struct IncidentRecord {
     pub epoch: u64,
-    pub start_at: DateTime<Utc>,
-    pub end_at: DateTime<Utc>,
-    pub downtime_seconds: u64,
+    #[serde(flatten)]
+    pub detail: IncidentDetail,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, utoipa::ToSchema)]
+#[serde(tag = "incident_type")]
+pub enum IncidentDetail {
+    /// One DOWN interval from the uptimes table.
+    Downtime {
+        start_at: DateTime<Utc>,
+        end_at: DateTime<Utc>,
+        downtime_seconds: u64,
+        /// Set when the same epoch also breached the block production rule: the two are one event
+        /// with two symptoms, so they are not served as two incidents.
+        #[serde(default)]
+        block_production: Option<BlockProductionDetail>,
+    },
+    /// An epoch the validator was up for but produced too few of its leader slots in.
+    BlockProduction {
+        epoch_start_at: Option<DateTime<Utc>>,
+        epoch_end_at: Option<DateTime<Utc>>,
+        block_production: BlockProductionDetail,
+    },
+}
+
+/// Why one epoch breached the block production rule, with the numbers behind it.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, utoipa::ToSchema)]
+pub struct BlockProductionDetail {
+    pub leader_slots: u64,
+    pub blocks_produced: u64,
+    pub missed_slots: u64,
+    /// `missed_slots / leader_slots`, as a fraction.
+    pub skip_rate: f64,
+    /// The epoch's cluster-wide skip rate, over the validators that were evaluable that epoch.
+    pub cluster_skip_rate: f64,
+    /// The bar `skip_rate` had to clear that epoch, as a fraction.
+    pub threshold: f64,
+    /// How many times the cluster's own skip rate this validator skipped. Null in an epoch the
+    /// cluster skipped nothing.
+    pub cluster_skip_rate_multiple: Option<f64>,
+}
+
+impl IncidentDetail {
+    /// When the incident started, for ordering: a downtime interval when it went down, a block
+    /// production epoch when that epoch ended. `None` for an epoch with no end on record, which is
+    /// the running one.
+    pub fn started_at(&self) -> Option<DateTime<Utc>> {
+        match self {
+            Self::Downtime { start_at, .. } => Some(*start_at),
+            Self::BlockProduction { epoch_end_at, .. } => *epoch_end_at,
+        }
+    }
+
+    /// Whether the incident is one worth serving: over the downtime floor where it has downtime to
+    /// measure. Restart noise is under the floor; a block production incident has no downtime side
+    /// and is never noise.
+    pub fn is_over_downtime_floor(&self, min_downtime_seconds: u64) -> bool {
+        match self {
+            Self::Downtime {
+                downtime_seconds,
+                block_production,
+                ..
+            } => *downtime_seconds >= min_downtime_seconds || block_production.is_some(),
+            Self::BlockProduction { .. } => true,
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, utoipa::ToSchema)]
@@ -631,8 +693,9 @@ impl GroupIncidents {
     pub fn sort(&mut self) {
         if let Self::Records(records) = self {
             records.sort_by(|a, b| {
-                a.start_at
-                    .cmp(&b.start_at)
+                a.detail
+                    .started_at()
+                    .cmp(&b.detail.started_at())
                     .then_with(|| a.validator.cmp(&b.validator))
             });
         }
@@ -645,15 +708,14 @@ impl Default for GroupIncidents {
     }
 }
 
-/// A member's downtime incident as its group carries it.
+/// A member's incident as its group carries it, `incident_type` and all.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, utoipa::ToSchema)]
 pub struct GroupIncidentRecord {
-    /// Vote account of the member that was down.
+    /// Vote account of the member the incident is on.
     pub validator: String,
     pub epoch: u64,
-    pub start_at: DateTime<Utc>,
-    pub end_at: DateTime<Utc>,
-    pub downtime_seconds: u64,
+    #[serde(flatten)]
+    pub detail: IncidentDetail,
 }
 
 impl GroupIncidentRecord {
@@ -661,9 +723,7 @@ impl GroupIncidentRecord {
         Self {
             validator: validator.to_string(),
             epoch: incident.epoch,
-            start_at: incident.start_at,
-            end_at: incident.end_at,
-            downtime_seconds: incident.downtime_seconds,
+            detail: incident.detail.clone(),
         }
     }
 }
@@ -850,9 +910,12 @@ mod tests {
         GroupIncidentRecord {
             validator: "vote".to_string(),
             epoch: 100,
-            start_at: "2026-01-01T00:00:00Z".parse().unwrap(),
-            end_at: "2026-01-01T00:05:00Z".parse().unwrap(),
-            downtime_seconds: 300,
+            detail: IncidentDetail::Downtime {
+                start_at: "2026-01-01T00:00:00Z".parse().unwrap(),
+                end_at: "2026-01-01T00:05:00Z".parse().unwrap(),
+                downtime_seconds: 300,
+                block_production: None,
+            },
         }
     }
 

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -408,7 +408,8 @@ pub enum IncidentDetail {
     },
     /// An epoch the validator was up for but produced too few of its leader slots in.
     BlockProduction {
-        epoch_start_at: Option<DateTime<Utc>>,
+        epoch_start_at: DateTime<Utc>,
+        /// None until the epoch closes: the `epochs` row carrying the boundaries is written then.
         epoch_end_at: Option<DateTime<Utc>>,
         block_production: BlockProductionDetail,
     },

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -427,6 +427,9 @@ pub struct BlockProductionDetail {
     pub cluster_skip_rate: f64,
     /// The bar `skip_rate` had to clear that epoch, as a fraction.
     pub threshold: f64,
+    /// Whether these numbers count as an incident.
+    /// Affected by query params `min_incident_missed_slots` and `min_incident_leader_slots`.
+    pub counts_as_incident: bool,
 }
 
 impl IncidentDetail {

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -427,9 +427,6 @@ pub struct BlockProductionDetail {
     pub cluster_skip_rate: f64,
     /// The bar `skip_rate` had to clear that epoch, as a fraction.
     pub threshold: f64,
-    /// How many times the cluster's own skip rate this validator skipped. Null in an epoch the
-    /// cluster skipped nothing.
-    pub cluster_skip_rate_multiple: Option<f64>,
 }
 
 impl IncidentDetail {

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -433,11 +433,11 @@ pub struct BlockProductionDetail {
 
 impl IncidentDetail {
     /// When the incident started, for ordering: a downtime interval when it went down, a block
-    /// production epoch when that epoch ended.
+    /// production epoch when the epoch began.
     pub fn started_at(&self) -> DateTime<Utc> {
         match self {
             Self::Downtime { start_at, .. } => *start_at,
-            Self::BlockProduction { epoch_end_at, .. } => *epoch_end_at,
+            Self::BlockProduction { epoch_start_at, .. } => *epoch_start_at,
         }
     }
 }

--- a/store/src/dto.rs
+++ b/store/src/dto.rs
@@ -406,11 +406,10 @@ pub enum IncidentDetail {
         #[serde(default)]
         block_production: Option<BlockProductionDetail>,
     },
-    /// An epoch the validator was up for but produced too few of its leader slots in.
+    /// A closed epoch the validator was up for but produced too few of its leader slots in.
     BlockProduction {
         epoch_start_at: DateTime<Utc>,
-        /// None until the epoch closes: the `epochs` row carrying the boundaries is written then.
-        epoch_end_at: Option<DateTime<Utc>>,
+        epoch_end_at: DateTime<Utc>,
         block_production: BlockProductionDetail,
     },
 }
@@ -434,11 +433,10 @@ pub struct BlockProductionDetail {
 
 impl IncidentDetail {
     /// When the incident started, for ordering: a downtime interval when it went down, a block
-    /// production epoch when that epoch ended. `None` for an epoch with no end on record, which is
-    /// the running one.
-    pub fn started_at(&self) -> Option<DateTime<Utc>> {
+    /// production epoch when that epoch ended.
+    pub fn started_at(&self) -> DateTime<Utc> {
         match self {
-            Self::Downtime { start_at, .. } => Some(*start_at),
+            Self::Downtime { start_at, .. } => *start_at,
             Self::BlockProduction { epoch_end_at, .. } => *epoch_end_at,
         }
     }

--- a/store/src/groups.rs
+++ b/store/src/groups.rs
@@ -641,9 +641,12 @@ mod tests {
                     .iter()
                     .map(|days_ago| crate::dto::IncidentRecord {
                         epoch: CURRENT_EPOCH,
-                        start_at: Utc::now() - Duration::days(*days_ago),
-                        end_at: Utc::now() - Duration::days(*days_ago),
-                        downtime_seconds: 600,
+                        detail: crate::dto::IncidentDetail::Downtime {
+                            start_at: Utc::now() - Duration::days(*days_ago),
+                            end_at: Utc::now() - Duration::days(*days_ago),
+                            downtime_seconds: 600,
+                            block_production: None,
+                        },
                     })
                     .collect();
 
@@ -1499,7 +1502,7 @@ mod tests {
         assert_eq!(incidents.len(), 4);
         assert!(incidents
             .windows(2)
-            .all(|pair| pair[0].start_at <= pair[1].start_at));
+            .all(|pair| pair[0].detail.started_at() <= pair[1].detail.started_at()));
         assert_eq!(
             incidents
                 .iter()

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -54,39 +54,39 @@ pub fn cluster_skip_rates<'a>(
         .collect()
 }
 
-/// How one epoch breached the block production rule. `None` where it passed, where the validator
-/// held too few leader slots to be judged, or where the epoch has no cluster figure to judge it
-/// against.
-pub fn breach(
-    stats: &ValidatorEpochStats,
-    cluster_skip_rates: &HashMap<u64, f64>,
-) -> Option<BlockProductionDetail> {
-    let cluster_skip_rate = cluster_skip_rates.get(&stats.epoch).copied()?;
-    if stats.leader_slots < MIN_LEADER_SLOTS {
-        return None;
-    }
+impl BlockProductionDetail {
+    /// How one epoch breached the block production rule, given the cluster's own skip rate that
+    /// epoch. `None` where it passed, or where the validator held too few leader slots to be judged.
+    pub fn qualifies_as_breach(
+        stats: &ValidatorEpochStats,
+        cluster_skip_rate: f64,
+    ) -> Option<Self> {
+        if stats.leader_slots < MIN_LEADER_SLOTS {
+            return None;
+        }
 
-    let missed_slots = stats.leader_slots.saturating_sub(stats.blocks_produced);
-    if missed_slots < MIN_MISSED_SLOTS {
-        return None;
-    }
+        let missed_slots = stats.leader_slots.saturating_sub(stats.blocks_produced);
+        if missed_slots < MIN_MISSED_SLOTS {
+            return None;
+        }
 
-    let skip_rate = missed_slots as f64 / stats.leader_slots as f64;
-    let threshold = threshold(cluster_skip_rate);
-    if skip_rate < threshold {
-        return None;
-    }
+        let skip_rate = missed_slots as f64 / stats.leader_slots as f64;
+        let threshold = threshold(cluster_skip_rate);
+        if skip_rate < threshold {
+            return None;
+        }
 
-    Some(BlockProductionDetail {
-        leader_slots: stats.leader_slots,
-        blocks_produced: stats.blocks_produced,
-        missed_slots,
-        skip_rate,
-        cluster_skip_rate,
-        threshold,
-        cluster_skip_rate_multiple: (cluster_skip_rate > 0.0)
-            .then(|| skip_rate / cluster_skip_rate),
-    })
+        Some(Self {
+            leader_slots: stats.leader_slots,
+            blocks_produced: stats.blocks_produced,
+            missed_slots,
+            skip_rate,
+            cluster_skip_rate,
+            threshold,
+            cluster_skip_rate_multiple: (cluster_skip_rate > 0.0)
+                .then(|| skip_rate / cluster_skip_rate),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -114,9 +114,9 @@ mod tests {
         blocks_produced: u64,
         cluster_skip_rate: f64,
     ) -> Option<BlockProductionDetail> {
-        breach(
+        BlockProductionDetail::qualifies_as_breach(
             &stats(100, leader_slots, blocks_produced),
-            &HashMap::from([(100, cluster_skip_rate)]),
+            cluster_skip_rate,
         )
     }
 
@@ -136,11 +136,6 @@ mod tests {
     #[test]
     fn an_epoch_under_the_leader_slot_gate_is_not_evaluated() {
         assert!(breached(63, 0, 0.0).is_none());
-    }
-
-    #[test]
-    fn an_epoch_with_no_cluster_figure_is_not_evaluated() {
-        assert!(breach(&stats(100, 64, 0), &HashMap::new()).is_none());
     }
 
     #[test]

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -74,9 +74,10 @@ impl BlockProductionDetail {
     }
 
     /// Whether the validator broke the block production rule that epoch.
-    /// `min_missed_slots` defaults to `MIN_MISSED_SLOTS` (4)
-    pub fn breached(&self, min_missed_slots: Option<u64>) -> bool {
-        self.leader_slots >= MIN_LEADER_SLOTS
+    /// `min_missed_slots` defaults to `MIN_MISSED_SLOTS` (4) and cannot go under it.
+    /// `min_leader_slots` defaults to `MIN_LEADER_SLOTS` (64) and cannot go under it.
+    pub fn breached(&self, min_missed_slots: Option<u64>, min_leader_slots: Option<u64>) -> bool {
+        self.leader_slots >= min_leader_slots.unwrap_or(0).max(MIN_LEADER_SLOTS)
             && self.missed_slots >= min_missed_slots.unwrap_or(0).max(MIN_MISSED_SLOTS)
             && self.skip_rate >= self.threshold
     }
@@ -120,7 +121,7 @@ mod tests {
         cluster_skip_rate: f64,
     ) -> Option<BlockProductionDetail> {
         detail(leader_slots, blocks_produced, cluster_skip_rate)
-            .filter(|detail| detail.breached(None))
+            .filter(|detail| detail.breached(None, None))
     }
 
     #[test]
@@ -134,17 +135,27 @@ mod tests {
         let detail = detail(8, 5, 0.0).unwrap();
 
         assert_eq!(detail.missed_slots, 3);
-        assert!(!detail.breached(None));
+        assert!(!detail.breached(None, None));
     }
 
     #[test]
-    fn a_caller_floor_tightens_the_rule_but_cannot_loosen_it() {
+    fn a_caller_missed_slot_floor_tightens_the_rule_but_cannot_loosen_it() {
         let detail = detail(64, 60, 0.0).unwrap();
 
-        assert!(detail.breached(None));
-        assert!(!detail.breached(Some(5)));
+        assert!(detail.breached(None, None));
+        assert!(!detail.breached(Some(5), None));
         // 4 missed is the rule's own floor, and no caller gets under it.
-        assert!(detail.breached(Some(0)));
+        assert!(detail.breached(Some(0), None));
+    }
+
+    #[test]
+    fn a_caller_leader_slot_floor_tightens_the_rule_but_cannot_loosen_it() {
+        let detail = detail(64, 60, 0.0).unwrap();
+
+        assert!(detail.breached(None, None));
+        assert!(!detail.breached(None, Some(65)));
+        // 64 slots is the rule's own floor, and no caller gets under it.
+        assert!(detail.breached(None, Some(8)));
     }
 
     #[test]

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -49,36 +49,36 @@ pub fn cluster_skip_rates<'a>(
 }
 
 impl BlockProductionDetail {
-    /// How one epoch breached the block production rule, given the cluster's own skip rate that
-    /// epoch. `None` where it passed, or where the validator held too few leader slots to be judged.
-    pub fn qualifies_as_breach(
-        stats: &ValidatorEpochStats,
-        cluster_skip_rate: f64,
-    ) -> Option<Self> {
-        if stats.leader_slots < MIN_LEADER_SLOTS {
+    /// One epoch's block production, given the cluster's own skip rate that epoch. `None` where the
+    /// validator held no leader slots, which leaves nothing to divide by. Says nothing about whether
+    /// the validator fell short: that is `breached`.
+    pub fn for_epoch(stats: &ValidatorEpochStats, cluster_skip_rate: f64) -> Option<Self> {
+        if stats.leader_slots == 0 {
             return None;
         }
 
-        let missed_slots = stats.leader_slots.saturating_sub(stats.blocks_produced);
-        if missed_slots < MIN_MISSED_SLOTS {
-            return None;
-        }
-
-        let skip_rate = missed_slots as f64 / stats.leader_slots as f64;
-        let threshold = (CLUSTER_SKIP_RATE_MULTIPLIER * cluster_skip_rate)
-            .clamp(MIN_SKIP_RATE_THRESHOLD, MAX_SKIP_RATE_THRESHOLD);
-        if skip_rate < threshold {
-            return None;
-        }
+        // Matches the clamp in `cluster_skip_rates`: a node reporting more blocks than slots is
+        // upstream noise, and must not read as negative misses here either.
+        let blocks_produced = stats.blocks_produced.min(stats.leader_slots);
+        let missed_slots = stats.leader_slots - blocks_produced;
 
         Some(Self {
             leader_slots: stats.leader_slots,
-            blocks_produced: stats.blocks_produced,
+            blocks_produced,
             missed_slots,
-            skip_rate,
+            skip_rate: missed_slots as f64 / stats.leader_slots as f64,
             cluster_skip_rate,
-            threshold,
+            threshold: (CLUSTER_SKIP_RATE_MULTIPLIER * cluster_skip_rate)
+                .clamp(MIN_SKIP_RATE_THRESHOLD, MAX_SKIP_RATE_THRESHOLD),
         })
+    }
+
+    /// Whether the validator broke the block production rule that epoch.
+    /// `min_missed_slots` defaults to `MIN_MISSED_SLOTS` (4)
+    pub fn breached(&self, min_missed_slots: Option<u64>) -> bool {
+        self.leader_slots >= MIN_LEADER_SLOTS
+            && self.missed_slots >= min_missed_slots.unwrap_or(0).max(MIN_MISSED_SLOTS)
+            && self.skip_rate >= self.threshold
     }
 }
 
@@ -102,20 +102,62 @@ mod tests {
         }
     }
 
-    fn breached(
+    fn detail(
         leader_slots: u64,
         blocks_produced: u64,
         cluster_skip_rate: f64,
     ) -> Option<BlockProductionDetail> {
-        BlockProductionDetail::qualifies_as_breach(
+        BlockProductionDetail::for_epoch(
             &stats(100, leader_slots, blocks_produced),
             cluster_skip_rate,
         )
     }
 
+    /// The numbers, but only where they broke the rule: what the incidents themselves are built on.
+    fn breached(
+        leader_slots: u64,
+        blocks_produced: u64,
+        cluster_skip_rate: f64,
+    ) -> Option<BlockProductionDetail> {
+        detail(leader_slots, blocks_produced, cluster_skip_rate)
+            .filter(|detail| detail.breached(None))
+    }
+
     #[test]
     fn an_epoch_under_the_leader_slot_gate_is_not_evaluated() {
         assert!(breached(63, 0, 0.0).is_none());
+    }
+
+    #[test]
+    fn an_epoch_under_the_leader_slot_gate_still_reports_its_numbers() {
+        // The numbers ride along on a downtime incident; only the verdict needs the gate.
+        let detail = detail(8, 5, 0.0).unwrap();
+
+        assert_eq!(detail.missed_slots, 3);
+        assert!(!detail.breached(None));
+    }
+
+    #[test]
+    fn a_caller_floor_tightens_the_rule_but_cannot_loosen_it() {
+        let detail = detail(64, 60, 0.0).unwrap();
+
+        assert!(detail.breached(None));
+        assert!(!detail.breached(Some(5)));
+        // 4 missed is the rule's own floor, and no caller gets under it.
+        assert!(detail.breached(Some(0)));
+    }
+
+    #[test]
+    fn an_epoch_with_no_leader_slots_has_no_block_production() {
+        assert!(detail(0, 0, 0.0).is_none());
+    }
+
+    #[test]
+    fn more_blocks_than_slots_is_clamped_rather_than_wrapping() {
+        let detail = detail(64, 70, 0.0).unwrap();
+
+        assert_eq!(detail.blocks_produced, 64);
+        assert_eq!(detail.missed_slots, 0);
     }
 
     #[test]

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -1,0 +1,197 @@
+use crate::dto::{BlockProductionDetail, ValidatorEpochStats, ValidatorRecord};
+use std::collections::HashMap;
+
+/// Leader slots an epoch needs before its block production is judged at all. Below this there is
+/// not enough signal; covers 99.2% of stake.
+pub const MIN_LEADER_SLOTS: u64 = 64;
+
+/// Missed slots an epoch needs before it counts as an incident. Solana assigns leader slots in
+/// batches of 4, so a sub-turn miss is usually the cluster following a different fork.
+pub const MIN_MISSED_SLOTS: u64 = 4;
+
+/// The bar in a healthy epoch: produce 99% of assigned leader slots.
+pub const MIN_SKIP_RATE_THRESHOLD: f64 = 0.01;
+
+/// How far above the cluster's own skip rate the bar sits while the network is degraded.
+pub const CLUSTER_SKIP_RATE_MULTIPLIER: f64 = 10.0;
+
+/// Ceiling on the bar, so a degraded network can never push it somewhere non-physical. Uncapped,
+/// the 500-699 era would have moved it past 100%.
+pub const MAX_SKIP_RATE_THRESHOLD: f64 = 0.05;
+
+/// The skip rate an epoch's validators had to stay under to pass.
+pub fn threshold(cluster_skip_rate: f64) -> f64 {
+    (CLUSTER_SKIP_RATE_MULTIPLIER * cluster_skip_rate)
+        .clamp(MIN_SKIP_RATE_THRESHOLD, MAX_SKIP_RATE_THRESHOLD)
+}
+
+/// Total missed slots over total leader slots per epoch, across the validators that were evaluable
+/// that epoch. Epochs where nobody reached `MIN_LEADER_SLOTS` are left out.
+pub fn cluster_skip_rates<'a>(
+    records: impl IntoIterator<Item = &'a ValidatorRecord>,
+) -> HashMap<u64, f64> {
+    let mut totals: HashMap<u64, (u64, u64)> = Default::default();
+
+    for stats in records.into_iter().flat_map(|record| &record.epoch_stats) {
+        if stats.leader_slots < MIN_LEADER_SLOTS {
+            continue;
+        }
+        let (leader_slots, blocks_produced) = totals.entry(stats.epoch).or_default();
+        *leader_slots += stats.leader_slots;
+        // A node reporting more blocks than slots is upstream noise; it must not mint slots here.
+        *blocks_produced += stats.blocks_produced.min(stats.leader_slots);
+    }
+
+    totals
+        .into_iter()
+        .filter(|(_, (leader_slots, _))| *leader_slots > 0)
+        .map(|(epoch, (leader_slots, blocks_produced))| {
+            (
+                epoch,
+                (leader_slots - blocks_produced) as f64 / leader_slots as f64,
+            )
+        })
+        .collect()
+}
+
+/// How one epoch breached the block production rule. `None` where it passed, where the validator
+/// held too few leader slots to be judged, or where the epoch has no cluster figure to judge it
+/// against.
+pub fn breach(
+    stats: &ValidatorEpochStats,
+    cluster_skip_rates: &HashMap<u64, f64>,
+) -> Option<BlockProductionDetail> {
+    let cluster_skip_rate = cluster_skip_rates.get(&stats.epoch).copied()?;
+    if stats.leader_slots < MIN_LEADER_SLOTS {
+        return None;
+    }
+
+    let missed_slots = stats.leader_slots.saturating_sub(stats.blocks_produced);
+    if missed_slots < MIN_MISSED_SLOTS {
+        return None;
+    }
+
+    let skip_rate = missed_slots as f64 / stats.leader_slots as f64;
+    let threshold = threshold(cluster_skip_rate);
+    if skip_rate < threshold {
+        return None;
+    }
+
+    Some(BlockProductionDetail {
+        leader_slots: stats.leader_slots,
+        blocks_produced: stats.blocks_produced,
+        missed_slots,
+        skip_rate,
+        cluster_skip_rate,
+        threshold,
+        cluster_skip_rate_multiple: (cluster_skip_rate > 0.0)
+            .then(|| skip_rate / cluster_skip_rate),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats(epoch: u64, leader_slots: u64, blocks_produced: u64) -> ValidatorEpochStats {
+        ValidatorEpochStats {
+            epoch,
+            leader_slots,
+            blocks_produced,
+            ..Default::default()
+        }
+    }
+
+    fn validator(epoch_stats: Vec<ValidatorEpochStats>) -> ValidatorRecord {
+        ValidatorRecord {
+            epoch_stats,
+            ..Default::default()
+        }
+    }
+
+    fn breached(
+        leader_slots: u64,
+        blocks_produced: u64,
+        cluster_skip_rate: f64,
+    ) -> Option<BlockProductionDetail> {
+        breach(
+            &stats(100, leader_slots, blocks_produced),
+            &HashMap::from([(100, cluster_skip_rate)]),
+        )
+    }
+
+    #[test]
+    fn threshold_sits_at_one_percent_in_a_healthy_epoch() {
+        assert_eq!(threshold(0.0), 0.01);
+        assert_eq!(threshold(0.000_5), 0.01);
+    }
+
+    #[test]
+    fn threshold_scales_with_a_degraded_cluster_up_to_the_cap() {
+        // Epoch 1015: a 0.413% cluster skip rate lifted the bar to 4.13%.
+        assert!((threshold(0.004_13) - 0.041_3).abs() < 1e-12);
+        assert_eq!(threshold(0.5), MAX_SKIP_RATE_THRESHOLD);
+    }
+
+    #[test]
+    fn an_epoch_under_the_leader_slot_gate_is_not_evaluated() {
+        assert!(breached(63, 0, 0.0).is_none());
+    }
+
+    #[test]
+    fn an_epoch_with_no_cluster_figure_is_not_evaluated() {
+        assert!(breach(&stats(100, 64, 0), &HashMap::new()).is_none());
+    }
+
+    #[test]
+    fn a_sub_leader_turn_miss_is_not_an_incident() {
+        // 3 of 64 is 4.7%, well over the bar, but under one full leader turn.
+        assert!(breached(64, 61, 0.0).is_none());
+    }
+
+    #[test]
+    fn a_full_leader_turn_missed_over_the_bar_is_an_incident() {
+        let detail = breached(64, 60, 0.0).unwrap();
+
+        assert_eq!(detail.missed_slots, 4);
+        assert_eq!(detail.leader_slots, 64);
+        assert_eq!(detail.threshold, 0.01);
+        assert_eq!(detail.cluster_skip_rate_multiple, None);
+    }
+
+    #[test]
+    fn an_epoch_under_the_bar_is_no_incident_even_with_a_full_turn_missed() {
+        // 4 of 800 is 0.5%, under the 1% bar.
+        assert!(breached(800, 796, 0.0).is_none());
+    }
+
+    #[test]
+    fn a_degraded_cluster_lifts_the_bar_out_from_under_a_validator() {
+        // 2% skipped: an incident in a healthy epoch, not in one the cluster skipped 0.413% of.
+        assert!(breached(1000, 980, 0.0).is_some());
+        assert!(breached(1000, 980, 0.004_13).is_none());
+    }
+
+    #[test]
+    fn the_cap_keeps_the_bar_physical_when_the_cluster_is_badly_degraded() {
+        // Uncapped, 10 x 3.5% would be a 35% bar and this epoch would read as all clear.
+        let detail = breached(1000, 940, 0.035).unwrap();
+        assert_eq!(detail.threshold, MAX_SKIP_RATE_THRESHOLD);
+    }
+
+    #[test]
+    fn cluster_skip_rate_reads_only_the_evaluable_validators() {
+        let validators = [
+            validator(vec![stats(100, 1000, 990)]),
+            validator(vec![stats(100, 1000, 990)]),
+            // Under the gate: its 100% skip rate must not move the cluster figure.
+            validator(vec![stats(100, 32, 0)]),
+        ];
+        assert_eq!(cluster_skip_rates(&validators).get(&100), Some(&0.01));
+    }
+
+    #[test]
+    fn an_epoch_nobody_was_evaluable_in_has_no_cluster_skip_rate() {
+        assert!(cluster_skip_rates(&[validator(vec![stats(100, 32, 0)])]).is_empty());
+    }
+}

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -129,7 +129,6 @@ mod tests {
         let detail = breached(64, 60, 0.0).unwrap();
 
         assert_eq!(detail.missed_slots, 4);
-        assert_eq!(detail.leader_slots, 64);
         assert_eq!(detail.threshold, 0.01);
     }
 
@@ -162,10 +161,5 @@ mod tests {
             validator(vec![stats(100, 32, 0)]),
         ];
         assert_eq!(cluster_skip_rates(&validators).get(&100), Some(&0.01));
-    }
-
-    #[test]
-    fn an_epoch_nobody_was_evaluable_in_has_no_cluster_skip_rate() {
-        assert!(cluster_skip_rates(&[validator(vec![stats(100, 32, 0)])]).is_empty());
     }
 }

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -19,12 +19,6 @@ pub const CLUSTER_SKIP_RATE_MULTIPLIER: f64 = 10.0;
 /// the 500-699 era would have moved it past 100%.
 pub const MAX_SKIP_RATE_THRESHOLD: f64 = 0.05;
 
-/// The skip rate an epoch's validators had to stay under to pass.
-pub fn threshold(cluster_skip_rate: f64) -> f64 {
-    (CLUSTER_SKIP_RATE_MULTIPLIER * cluster_skip_rate)
-        .clamp(MIN_SKIP_RATE_THRESHOLD, MAX_SKIP_RATE_THRESHOLD)
-}
-
 /// Total missed slots over total leader slots per epoch, across the validators that were evaluable
 /// that epoch. Epochs where nobody reached `MIN_LEADER_SLOTS` are left out.
 pub fn cluster_skip_rates<'a>(
@@ -71,7 +65,8 @@ impl BlockProductionDetail {
         }
 
         let skip_rate = missed_slots as f64 / stats.leader_slots as f64;
-        let threshold = threshold(cluster_skip_rate);
+        let threshold = (CLUSTER_SKIP_RATE_MULTIPLIER * cluster_skip_rate)
+            .clamp(MIN_SKIP_RATE_THRESHOLD, MAX_SKIP_RATE_THRESHOLD);
         if skip_rate < threshold {
             return None;
         }
@@ -83,8 +78,6 @@ impl BlockProductionDetail {
             skip_rate,
             cluster_skip_rate,
             threshold,
-            cluster_skip_rate_multiple: (cluster_skip_rate > 0.0)
-                .then(|| skip_rate / cluster_skip_rate),
         })
     }
 }
@@ -121,19 +114,6 @@ mod tests {
     }
 
     #[test]
-    fn threshold_sits_at_one_percent_in_a_healthy_epoch() {
-        assert_eq!(threshold(0.0), 0.01);
-        assert_eq!(threshold(0.000_5), 0.01);
-    }
-
-    #[test]
-    fn threshold_scales_with_a_degraded_cluster_up_to_the_cap() {
-        // Epoch 1015: a 0.413% cluster skip rate lifted the bar to 4.13%.
-        assert!((threshold(0.004_13) - 0.041_3).abs() < 1e-12);
-        assert_eq!(threshold(0.5), MAX_SKIP_RATE_THRESHOLD);
-    }
-
-    #[test]
     fn an_epoch_under_the_leader_slot_gate_is_not_evaluated() {
         assert!(breached(63, 0, 0.0).is_none());
     }
@@ -151,7 +131,6 @@ mod tests {
         assert_eq!(detail.missed_slots, 4);
         assert_eq!(detail.leader_slots, 64);
         assert_eq!(detail.threshold, 0.01);
-        assert_eq!(detail.cluster_skip_rate_multiple, None);
     }
 
     #[test]

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -51,7 +51,7 @@ pub fn cluster_skip_rates<'a>(
 impl BlockProductionDetail {
     /// One epoch's block production, given the cluster's own skip rate that epoch. `None` where the
     /// validator held no leader slots, which leaves nothing to divide by. Says nothing about whether
-    /// the validator fell short: that is `breached`.
+    /// the validator fell short: that is `counts_as_incident`.
     pub fn for_epoch(stats: &ValidatorEpochStats, cluster_skip_rate: f64) -> Option<Self> {
         if stats.leader_slots == 0 {
             return None;
@@ -62,7 +62,7 @@ impl BlockProductionDetail {
         let blocks_produced = stats.blocks_produced.min(stats.leader_slots);
         let missed_slots = stats.leader_slots - blocks_produced;
 
-        Some(Self {
+        let mut detail = Self {
             leader_slots: stats.leader_slots,
             blocks_produced,
             missed_slots,
@@ -70,13 +70,16 @@ impl BlockProductionDetail {
             cluster_skip_rate,
             threshold: (CLUSTER_SKIP_RATE_MULTIPLIER * cluster_skip_rate)
                 .clamp(MIN_SKIP_RATE_THRESHOLD, MAX_SKIP_RATE_THRESHOLD),
-        })
+            counts_as_incident: false,
+        };
+        detail.counts_as_incident = detail.counts_as_incident(None, None);
+        Some(detail)
     }
 
     /// Whether the validator broke the block production rule that epoch.
     /// `min_missed_slots` defaults to `MIN_MISSED_SLOTS` (4) and cannot go under it.
     /// `min_leader_slots` defaults to `MIN_LEADER_SLOTS` (64) and cannot go under it.
-    pub fn breached(&self, min_missed_slots: Option<u64>, min_leader_slots: Option<u64>) -> bool {
+    pub fn counts_as_incident(&self, min_missed_slots: Option<u64>, min_leader_slots: Option<u64>) -> bool {
         self.leader_slots >= min_leader_slots.unwrap_or(0).max(MIN_LEADER_SLOTS)
             && self.missed_slots >= min_missed_slots.unwrap_or(0).max(MIN_MISSED_SLOTS)
             && self.skip_rate >= self.threshold
@@ -115,18 +118,18 @@ mod tests {
     }
 
     /// The numbers, but only where they broke the rule: what the incidents themselves are built on.
-    fn breached(
+    fn counts_as_incident(
         leader_slots: u64,
         blocks_produced: u64,
         cluster_skip_rate: f64,
     ) -> Option<BlockProductionDetail> {
         detail(leader_slots, blocks_produced, cluster_skip_rate)
-            .filter(|detail| detail.breached(None, None))
+            .filter(|detail| detail.counts_as_incident)
     }
 
     #[test]
     fn an_epoch_under_the_leader_slot_gate_is_not_evaluated() {
-        assert!(breached(63, 0, 0.0).is_none());
+        assert!(counts_as_incident(63, 0, 0.0).is_none());
     }
 
     #[test]
@@ -135,27 +138,27 @@ mod tests {
         let detail = detail(8, 5, 0.0).unwrap();
 
         assert_eq!(detail.missed_slots, 3);
-        assert!(!detail.breached(None, None));
+        assert!(!detail.counts_as_incident);
     }
 
     #[test]
     fn a_caller_missed_slot_floor_tightens_the_rule_but_cannot_loosen_it() {
         let detail = detail(64, 60, 0.0).unwrap();
 
-        assert!(detail.breached(None, None));
-        assert!(!detail.breached(Some(5), None));
+        assert!(detail.counts_as_incident);
+        assert!(!detail.counts_as_incident(Some(5), None));
         // 4 missed is the rule's own floor, and no caller gets under it.
-        assert!(detail.breached(Some(0), None));
+        assert!(detail.counts_as_incident(Some(0), None));
     }
 
     #[test]
     fn a_caller_leader_slot_floor_tightens_the_rule_but_cannot_loosen_it() {
         let detail = detail(64, 60, 0.0).unwrap();
 
-        assert!(detail.breached(None, None));
-        assert!(!detail.breached(None, Some(65)));
+        assert!(detail.counts_as_incident);
+        assert!(!detail.counts_as_incident(None, Some(65)));
         // 64 slots is the rule's own floor, and no caller gets under it.
-        assert!(detail.breached(None, Some(8)));
+        assert!(detail.counts_as_incident(None, Some(8)));
     }
 
     #[test]
@@ -174,12 +177,12 @@ mod tests {
     #[test]
     fn a_sub_leader_turn_miss_is_not_an_incident() {
         // 3 of 64 is 4.7%, well over the bar, but under one full leader turn.
-        assert!(breached(64, 61, 0.0).is_none());
+        assert!(counts_as_incident(64, 61, 0.0).is_none());
     }
 
     #[test]
     fn a_full_leader_turn_missed_over_the_bar_is_an_incident() {
-        let detail = breached(64, 60, 0.0).unwrap();
+        let detail = counts_as_incident(64, 60, 0.0).unwrap();
 
         assert_eq!(detail.missed_slots, 4);
         assert_eq!(detail.threshold, 0.01);
@@ -188,20 +191,20 @@ mod tests {
     #[test]
     fn an_epoch_under_the_bar_is_no_incident_even_with_a_full_turn_missed() {
         // 4 of 800 is 0.5%, under the 1% bar.
-        assert!(breached(800, 796, 0.0).is_none());
+        assert!(counts_as_incident(800, 796, 0.0).is_none());
     }
 
     #[test]
     fn a_degraded_cluster_lifts_the_bar_out_from_under_a_validator() {
         // 2% skipped: an incident in a healthy epoch, not in one the cluster skipped 0.413% of.
-        assert!(breached(1000, 980, 0.0).is_some());
-        assert!(breached(1000, 980, 0.004_13).is_none());
+        assert!(counts_as_incident(1000, 980, 0.0).is_some());
+        assert!(counts_as_incident(1000, 980, 0.004_13).is_none());
     }
 
     #[test]
     fn the_cap_keeps_the_bar_physical_when_the_cluster_is_badly_degraded() {
         // Uncapped, 10 x 3.5% would be a 35% bar and this epoch would read as all clear.
-        let detail = breached(1000, 940, 0.035).unwrap();
+        let detail = counts_as_incident(1000, 940, 0.035).unwrap();
         assert_eq!(detail.threshold, MAX_SKIP_RATE_THRESHOLD);
     }
 

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -79,7 +79,11 @@ impl BlockProductionDetail {
     /// Whether the validator broke the block production rule that epoch.
     /// `min_missed_slots` defaults to `MIN_MISSED_SLOTS` (4) and cannot go under it.
     /// `min_leader_slots` defaults to `MIN_LEADER_SLOTS` (64) and cannot go under it.
-    pub fn counts_as_incident(&self, min_missed_slots: Option<u64>, min_leader_slots: Option<u64>) -> bool {
+    pub fn counts_as_incident(
+        &self,
+        min_missed_slots: Option<u64>,
+        min_leader_slots: Option<u64>,
+    ) -> bool {
         self.leader_slots >= min_leader_slots.unwrap_or(0).max(MIN_LEADER_SLOTS)
             && self.missed_slots >= min_missed_slots.unwrap_or(0).max(MIN_MISSED_SLOTS)
             && self.skip_rate >= self.threshold

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -23,6 +23,8 @@ pub const MAX_SKIP_RATE_THRESHOLD: f64 = 0.05;
 /// Under this many seconds a `DOWN` interval is restart noise, not an incident.
 pub const DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS: u64 = 180;
 
+pub const DEFAULT_INCIDENT_TYPES: &[IncidentType] = &[IncidentType::Downtime];
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum IncidentType {
     Downtime,

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -36,9 +36,9 @@ pub fn cluster_skip_rates<'a>(
         *blocks_produced += stats.blocks_produced.min(stats.leader_slots);
     }
 
+    // Every epoch in here cleared MIN_LEADER_SLOTS above, so there is no zero to divide by.
     totals
         .into_iter()
-        .filter(|(_, (leader_slots, _))| *leader_slots > 0)
         .map(|(epoch, (leader_slots, blocks_produced))| {
             (
                 epoch,

--- a/store/src/incidents.rs
+++ b/store/src/incidents.rs
@@ -1,4 +1,5 @@
-use crate::dto::{BlockProductionDetail, ValidatorEpochStats, ValidatorRecord};
+use crate::dto;
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
 /// Leader slots an epoch needs before its block production is judged at all. Below this there is
@@ -19,10 +20,237 @@ pub const CLUSTER_SKIP_RATE_MULTIPLIER: f64 = 10.0;
 /// the 500-699 era would have moved it past 100%.
 pub const MAX_SKIP_RATE_THRESHOLD: f64 = 0.05;
 
+/// Under this many seconds a `DOWN` interval is restart noise, not an incident.
+pub const DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS: u64 = 180;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum IncidentType {
+    Downtime,
+    BlockProduction,
+}
+
+impl IncidentType {
+    /// Takes the names the response emits under `incident_type`.
+    pub fn parse_list(types: &str) -> Result<Vec<Self>, String> {
+        types
+            .split(',')
+            .map(|name| match name.trim() {
+                "Downtime" => Ok(Self::Downtime),
+                "BlockProduction" => Ok(Self::BlockProduction),
+                other => Err(other.to_string()),
+            })
+            .collect()
+    }
+}
+
+/// One `DOWN` interval as `uptimes` recorded it.
+#[derive(Debug, Clone)]
+pub struct DowntimeInterval {
+    pub epoch: u64,
+    pub start_at: DateTime<Utc>,
+    pub end_at: DateTime<Utc>,
+    pub downtime_seconds: u64,
+}
+
+/// One closed epoch's leader slot counters, and the cluster figure they are judged against.
+#[derive(Debug, Clone)]
+pub struct EpochBlockProduction {
+    pub epoch: u64,
+    pub epoch_start_at: DateTime<Utc>,
+    pub epoch_end_at: DateTime<Utc>,
+    pub leader_slots: u64,
+    /// Clamped to `leader_slots`: a node reporting more blocks than slots is upstream noise.
+    pub blocks_produced: u64,
+    pub cluster_skip_rate: f64,
+}
+
+impl EpochBlockProduction {
+    /// `None` with no leader slots to divide by, and with no `epochs` row yet: that is the epoch
+    /// still running, whose counters cover only the slots elapsed so far.
+    pub fn new(stats: &dto::ValidatorEpochStats, cluster_skip_rate: f64) -> Option<Self> {
+        let (Some(epoch_start_at), Some(epoch_end_at)) = (stats.epoch_start_at, stats.epoch_end_at)
+        else {
+            return None;
+        };
+        if stats.leader_slots == 0 {
+            return None;
+        }
+
+        Some(Self {
+            epoch: stats.epoch,
+            epoch_start_at,
+            epoch_end_at,
+            leader_slots: stats.leader_slots,
+            blocks_produced: stats.blocks_produced.min(stats.leader_slots),
+            cluster_skip_rate,
+        })
+    }
+
+    pub fn missed_slots(&self) -> u64 {
+        self.leader_slots - self.blocks_produced
+    }
+
+    pub fn skip_rate(&self) -> f64 {
+        self.missed_slots() as f64 / self.leader_slots as f64
+    }
+
+    /// The bar the epoch had to clear, as a fraction.
+    pub fn threshold(&self) -> f64 {
+        (CLUSTER_SKIP_RATE_MULTIPLIER * self.cluster_skip_rate)
+            .clamp(MIN_SKIP_RATE_THRESHOLD, MAX_SKIP_RATE_THRESHOLD)
+    }
+
+    /// Whether the validator broke the block production rule that epoch. The caller's floors can
+    /// only tighten the rule: they never reach under `MIN_LEADER_SLOTS` or `MIN_MISSED_SLOTS`.
+    pub fn counts_as_incident(&self, filters: &IncidentFilters) -> bool {
+        self.leader_slots >= filters.min_leader_slots.unwrap_or(0).max(MIN_LEADER_SLOTS)
+            && self.missed_slots() >= filters.min_missed_slots.unwrap_or(0).max(MIN_MISSED_SLOTS)
+            && self.skip_rate() >= self.threshold()
+    }
+
+    /// The numbers as the response carries them, judged under the caller's floors.
+    pub fn detail(&self, filters: &IncidentFilters) -> dto::BlockProductionDetail {
+        dto::BlockProductionDetail {
+            leader_slots: self.leader_slots,
+            blocks_produced: self.blocks_produced,
+            missed_slots: self.missed_slots(),
+            skip_rate: self.skip_rate(),
+            cluster_skip_rate: self.cluster_skip_rate,
+            threshold: self.threshold(),
+            counts_as_incident: self.counts_as_incident(filters),
+        }
+    }
+}
+
+/// Window and floors one response is judged under.
+#[derive(Debug, Clone)]
+pub struct IncidentFilters {
+    /// Oldest epoch to report, inclusive.
+    pub from_epoch: u64,
+    pub min_downtime_seconds: u64,
+    pub min_missed_slots: Option<u64>,
+    pub min_leader_slots: Option<u64>,
+    /// `None` serves every kind.
+    pub types: Option<Vec<IncidentType>>,
+}
+
+impl Default for IncidentFilters {
+    fn default() -> Self {
+        Self {
+            from_epoch: 0,
+            min_downtime_seconds: DEFAULT_MIN_INCIDENT_DOWNTIME_SECONDS,
+            min_missed_slots: None,
+            min_leader_slots: None,
+            types: None,
+        }
+    }
+}
+
+impl IncidentFilters {
+    fn wants(&self, incident_type: IncidentType) -> bool {
+        self.types
+            .as_ref()
+            .is_none_or(|types| types.contains(&incident_type))
+    }
+}
+
+/// One validator's raw material: nothing judged, nothing merged.
+#[derive(Debug, Clone, Default)]
+pub struct ValidatorIncidentRecords {
+    pub downtimes: Vec<DowntimeInterval>,
+    pub block_production: Vec<EpochBlockProduction>,
+}
+
+impl ValidatorIncidentRecords {
+    /// An epoch's block production is reported once: on that epoch's downtime records if any are
+    /// served, otherwise as a record of its own.
+    pub fn into_response_incidents(&self, filters: &IncidentFilters) -> Vec<dto::IncidentRecord> {
+        let mut incidents: Vec<dto::IncidentRecord> = Vec::new();
+
+        if filters.wants(IncidentType::Downtime) {
+            for downtime in self.downtimes.iter().filter(|downtime| {
+                downtime.epoch >= filters.from_epoch
+                    && downtime.downtime_seconds >= filters.min_downtime_seconds
+            }) {
+                incidents.push(dto::IncidentRecord {
+                    epoch: downtime.epoch,
+                    detail: dto::IncidentDetail::Downtime {
+                        start_at: downtime.start_at,
+                        end_at: downtime.end_at,
+                        downtime_seconds: downtime.downtime_seconds,
+                        block_production: self
+                            .epoch_block_production(downtime.epoch)
+                            .map(|production| production.detail(filters)),
+                    },
+                });
+            }
+        }
+
+        if filters.wants(IncidentType::BlockProduction) {
+            let carried: Vec<u64> = incidents.iter().map(|incident| incident.epoch).collect();
+            for production in self
+                .block_production
+                .iter()
+                .filter(|production| production.epoch >= filters.from_epoch)
+                .filter(|production| !carried.contains(&production.epoch))
+            {
+                if production.counts_as_incident(filters) {
+                    incidents.push(dto::IncidentRecord {
+                        epoch: production.epoch,
+                        detail: dto::IncidentDetail::BlockProduction {
+                            epoch_start_at: production.epoch_start_at,
+                            epoch_end_at: production.epoch_end_at,
+                            block_production: production.detail(filters),
+                        },
+                    });
+                }
+            }
+        }
+
+        incidents.sort_by_key(|incident| (incident.epoch, incident.detail.started_at()));
+        incidents
+    }
+
+    fn epoch_block_production(&self, epoch: u64) -> Option<&EpochBlockProduction> {
+        self.block_production
+            .iter()
+            .find(|production| production.epoch == epoch)
+    }
+}
+
+/// Keyed by vote account.
+#[derive(Debug, Clone, Default)]
+pub struct ValidatorIncidents(HashMap<String, ValidatorIncidentRecords>);
+
+impl ValidatorIncidents {
+    pub fn records(&mut self, vote_account: &str) -> &mut ValidatorIncidentRecords {
+        self.0.entry(vote_account.to_string()).or_default()
+    }
+
+    pub fn get(&self, vote_account: &str) -> Option<&ValidatorIncidentRecords> {
+        self.0.get(vote_account)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Empty for a validator with no incident material.
+    pub fn into_response_incidents(
+        &self,
+        vote_account: &str,
+        filters: &IncidentFilters,
+    ) -> Vec<dto::IncidentRecord> {
+        self.get(vote_account)
+            .map(|records| records.into_response_incidents(filters))
+            .unwrap_or_default()
+    }
+}
+
 /// Total missed slots over total leader slots per epoch, across the validators that were evaluable
 /// that epoch. Epochs where nobody reached `MIN_LEADER_SLOTS` are left out.
 pub fn cluster_skip_rates<'a>(
-    records: impl IntoIterator<Item = &'a ValidatorRecord>,
+    records: impl IntoIterator<Item = &'a dto::ValidatorRecord>,
 ) -> HashMap<u64, f64> {
     let mut totals: HashMap<u64, (u64, u64)> = Default::default();
 
@@ -48,77 +276,49 @@ pub fn cluster_skip_rates<'a>(
         .collect()
 }
 
-impl BlockProductionDetail {
-    /// One epoch's block production, given the cluster's own skip rate that epoch. `None` where the
-    /// validator held no leader slots, which leaves nothing to divide by. Says nothing about whether
-    /// the validator fell short: that is `counts_as_incident`.
-    pub fn for_epoch(stats: &ValidatorEpochStats, cluster_skip_rate: f64) -> Option<Self> {
-        if stats.leader_slots == 0 {
-            return None;
-        }
-
-        // Matches the clamp in `cluster_skip_rates`: a node reporting more blocks than slots is
-        // upstream noise, and must not read as negative misses here either.
-        let blocks_produced = stats.blocks_produced.min(stats.leader_slots);
-        let missed_slots = stats.leader_slots - blocks_produced;
-
-        let mut detail = Self {
-            leader_slots: stats.leader_slots,
-            blocks_produced,
-            missed_slots,
-            skip_rate: missed_slots as f64 / stats.leader_slots as f64,
-            cluster_skip_rate,
-            threshold: (CLUSTER_SKIP_RATE_MULTIPLIER * cluster_skip_rate)
-                .clamp(MIN_SKIP_RATE_THRESHOLD, MAX_SKIP_RATE_THRESHOLD),
-            counts_as_incident: false,
-        };
-        detail.counts_as_incident = detail.counts_as_incident(None, None);
-        Some(detail)
-    }
-
-    /// Whether the validator broke the block production rule that epoch.
-    /// `min_missed_slots` defaults to `MIN_MISSED_SLOTS` (4) and cannot go under it.
-    /// `min_leader_slots` defaults to `MIN_LEADER_SLOTS` (64) and cannot go under it.
-    pub fn counts_as_incident(
-        &self,
-        min_missed_slots: Option<u64>,
-        min_leader_slots: Option<u64>,
-    ) -> bool {
-        self.leader_slots >= min_leader_slots.unwrap_or(0).max(MIN_LEADER_SLOTS)
-            && self.missed_slots >= min_missed_slots.unwrap_or(0).max(MIN_MISSED_SLOTS)
-            && self.skip_rate >= self.threshold
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn stats(epoch: u64, leader_slots: u64, blocks_produced: u64) -> ValidatorEpochStats {
-        ValidatorEpochStats {
+    const EPOCH: u64 = 100;
+
+    fn stats(epoch: u64, leader_slots: u64, blocks_produced: u64) -> dto::ValidatorEpochStats {
+        let epoch_start_at: DateTime<Utc> = "2026-01-01T00:00:00Z".parse().unwrap();
+        dto::ValidatorEpochStats {
             epoch,
             leader_slots,
             blocks_produced,
+            epoch_start_at: Some(epoch_start_at),
+            epoch_end_at: Some(epoch_start_at + chrono::Duration::days(2)),
             ..Default::default()
         }
     }
 
-    fn validator(epoch_stats: Vec<ValidatorEpochStats>) -> ValidatorRecord {
-        ValidatorRecord {
+    fn validator(epoch_stats: Vec<dto::ValidatorEpochStats>) -> dto::ValidatorRecord {
+        dto::ValidatorRecord {
             epoch_stats,
             ..Default::default()
         }
+    }
+
+    fn production(
+        leader_slots: u64,
+        blocks_produced: u64,
+        cluster_skip_rate: f64,
+    ) -> Option<EpochBlockProduction> {
+        EpochBlockProduction::new(
+            &stats(EPOCH, leader_slots, blocks_produced),
+            cluster_skip_rate,
+        )
     }
 
     fn detail(
         leader_slots: u64,
         blocks_produced: u64,
         cluster_skip_rate: f64,
-    ) -> Option<BlockProductionDetail> {
-        BlockProductionDetail::for_epoch(
-            &stats(100, leader_slots, blocks_produced),
-            cluster_skip_rate,
-        )
+    ) -> Option<dto::BlockProductionDetail> {
+        production(leader_slots, blocks_produced, cluster_skip_rate)
+            .map(|production| production.detail(&Default::default()))
     }
 
     /// The numbers, but only where they broke the rule: what the incidents themselves are built on.
@@ -126,7 +326,7 @@ mod tests {
         leader_slots: u64,
         blocks_produced: u64,
         cluster_skip_rate: f64,
-    ) -> Option<BlockProductionDetail> {
+    ) -> Option<dto::BlockProductionDetail> {
         detail(leader_slots, blocks_produced, cluster_skip_rate)
             .filter(|detail| detail.counts_as_incident)
     }
@@ -138,36 +338,52 @@ mod tests {
 
     #[test]
     fn an_epoch_under_the_leader_slot_gate_still_reports_its_numbers() {
-        // The numbers ride along on a downtime incident; only the verdict needs the gate.
+        // A downtime record still reports the numbers; only the verdict needs the gate.
         let detail = detail(8, 5, 0.0).unwrap();
 
         assert_eq!(detail.missed_slots, 3);
         assert!(!detail.counts_as_incident);
     }
 
+    fn floors(min_missed_slots: Option<u64>, min_leader_slots: Option<u64>) -> IncidentFilters {
+        IncidentFilters {
+            min_missed_slots,
+            min_leader_slots,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn a_caller_missed_slot_floor_tightens_the_rule_but_cannot_loosen_it() {
-        let detail = detail(64, 60, 0.0).unwrap();
+        let production = production(64, 60, 0.0).unwrap();
 
-        assert!(detail.counts_as_incident);
-        assert!(!detail.counts_as_incident(Some(5), None));
+        assert!(production.counts_as_incident(&Default::default()));
+        assert!(!production.counts_as_incident(&floors(Some(5), None)));
         // 4 missed is the rule's own floor, and no caller gets under it.
-        assert!(detail.counts_as_incident(Some(0), None));
+        assert!(production.counts_as_incident(&floors(Some(0), None)));
     }
 
     #[test]
     fn a_caller_leader_slot_floor_tightens_the_rule_but_cannot_loosen_it() {
-        let detail = detail(64, 60, 0.0).unwrap();
+        let production = production(64, 60, 0.0).unwrap();
 
-        assert!(detail.counts_as_incident);
-        assert!(!detail.counts_as_incident(None, Some(65)));
+        assert!(production.counts_as_incident(&Default::default()));
+        assert!(!production.counts_as_incident(&floors(None, Some(65))));
         // 64 slots is the rule's own floor, and no caller gets under it.
-        assert!(detail.counts_as_incident(None, Some(8)));
+        assert!(production.counts_as_incident(&floors(None, Some(8))));
     }
 
     #[test]
     fn an_epoch_with_no_leader_slots_has_no_block_production() {
         assert!(detail(0, 0, 0.0).is_none());
+    }
+
+    #[test]
+    fn the_epoch_in_flight_has_no_block_production() {
+        let mut running = stats(EPOCH, 1000, 940);
+        running.epoch_end_at = None;
+
+        assert!(EpochBlockProduction::new(&running, 0.0).is_none());
     }
 
     #[test]
@@ -221,5 +437,236 @@ mod tests {
             validator(vec![stats(100, 32, 0)]),
         ];
         assert_eq!(cluster_skip_rates(&validators).get(&100), Some(&0.01));
+    }
+
+    fn downtime(epoch: u64, downtime_seconds: u64) -> DowntimeInterval {
+        let start_at: DateTime<Utc> = "2026-01-01T12:00:00Z".parse().unwrap();
+        DowntimeInterval {
+            epoch,
+            start_at: start_at + chrono::Duration::seconds(downtime_seconds as i64),
+            end_at: start_at + chrono::Duration::seconds(2 * downtime_seconds as i64),
+            downtime_seconds,
+        }
+    }
+
+    /// An epoch that missed 60 of its 1000 leader slots: 6%, over any bar the rule can set.
+    fn breached(epoch: u64) -> EpochBlockProduction {
+        EpochBlockProduction::new(&stats(epoch, 1000, 940), 0.0).unwrap()
+    }
+
+    /// An epoch that produced every slot it was given.
+    fn clean(epoch: u64) -> EpochBlockProduction {
+        EpochBlockProduction::new(&stats(epoch, 1000, 1000), 0.0).unwrap()
+    }
+
+    fn records(
+        downtimes: Vec<DowntimeInterval>,
+        block_production: Vec<EpochBlockProduction>,
+    ) -> ValidatorIncidentRecords {
+        ValidatorIncidentRecords {
+            downtimes,
+            block_production,
+        }
+    }
+
+    fn served_types(incidents: &[dto::IncidentRecord]) -> Vec<&'static str> {
+        incidents
+            .iter()
+            .map(|incident| match incident.detail {
+                dto::IncidentDetail::Downtime { .. } => "Downtime",
+                dto::IncidentDetail::BlockProduction { .. } => "BlockProduction",
+            })
+            .collect()
+    }
+
+    fn carried_numbers(incident: &dto::IncidentRecord) -> Option<&dto::BlockProductionDetail> {
+        match &incident.detail {
+            dto::IncidentDetail::Downtime {
+                block_production, ..
+            } => block_production.as_ref(),
+            dto::IncidentDetail::BlockProduction {
+                block_production, ..
+            } => Some(block_production),
+        }
+    }
+
+    #[test]
+    fn a_restart_under_the_floor_is_no_incident_of_its_own() {
+        let records = records(vec![downtime(EPOCH, 12)], vec![clean(EPOCH)]);
+
+        assert!(records
+            .into_response_incidents(&Default::default())
+            .is_empty());
+    }
+
+    #[test]
+    fn a_restart_under_the_floor_in_a_breached_epoch_serves_the_breach() {
+        let records = records(vec![downtime(EPOCH, 12)], vec![breached(EPOCH)]);
+        let incidents = records.into_response_incidents(&Default::default());
+
+        assert_eq!(served_types(&incidents), vec!["BlockProduction"]);
+        assert_eq!(incidents[0].epoch, EPOCH);
+    }
+
+    #[test]
+    fn three_restarts_under_the_floor_in_a_breached_epoch_serve_one_row() {
+        let records = records(
+            vec![
+                downtime(EPOCH, 12),
+                downtime(EPOCH, 13),
+                downtime(EPOCH, 14),
+            ],
+            vec![breached(EPOCH)],
+        );
+
+        assert_eq!(
+            served_types(&records.into_response_incidents(&Default::default())),
+            vec!["BlockProduction"]
+        );
+    }
+
+    #[test]
+    fn an_outage_in_a_breached_epoch_carries_the_numbers() {
+        let records = records(vec![downtime(EPOCH, 600)], vec![breached(EPOCH)]);
+        let incidents = records.into_response_incidents(&Default::default());
+
+        assert_eq!(served_types(&incidents), vec!["Downtime"]);
+        let numbers = carried_numbers(&incidents[0]).expect("the downtime record has them");
+        assert_eq!(numbers.missed_slots, 60);
+        assert!(numbers.counts_as_incident);
+    }
+
+    #[test]
+    fn every_outage_of_a_breached_epoch_is_its_own_row() {
+        let records = records(
+            vec![
+                downtime(EPOCH, 600),
+                downtime(EPOCH, 700),
+                downtime(EPOCH, 800),
+            ],
+            vec![breached(EPOCH)],
+        );
+        let incidents = records.into_response_incidents(&Default::default());
+
+        assert_eq!(served_types(&incidents), vec!["Downtime"; 3]);
+        assert!(incidents
+            .iter()
+            .all(|incident| carried_numbers(incident).is_some()));
+    }
+
+    #[test]
+    fn an_outage_of_a_passing_epoch_carries_numbers_that_are_no_verdict() {
+        let records = records(vec![downtime(EPOCH, 600)], vec![clean(EPOCH)]);
+        let incidents = records.into_response_incidents(&Default::default());
+
+        let numbers = carried_numbers(&incidents[0]).expect("the downtime record has them");
+        assert_eq!(numbers.missed_slots, 0);
+        assert!(!numbers.counts_as_incident);
+    }
+
+    #[test]
+    fn a_breached_epoch_the_validator_stayed_up_for_opens_its_own_row() {
+        let records = records(vec![], vec![breached(EPOCH)]);
+
+        assert_eq!(
+            served_types(&records.into_response_incidents(&Default::default())),
+            vec!["BlockProduction"]
+        );
+    }
+
+    // The epoch both went down and breached, so each type has something of its own to serve.
+    #[test]
+    fn each_type_serves_the_epoch_under_its_own_name() {
+        let records = records(vec![downtime(EPOCH, 600)], vec![breached(EPOCH)]);
+
+        for (incident_type, served) in [
+            (IncidentType::Downtime, "Downtime"),
+            (IncidentType::BlockProduction, "BlockProduction"),
+        ] {
+            let filters = IncidentFilters {
+                types: Some(vec![incident_type]),
+                ..Default::default()
+            };
+            assert_eq!(
+                served_types(&records.into_response_incidents(&filters)),
+                vec![served],
+                "{incident_type:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn from_epoch_drops_what_sits_before_the_window() {
+        let records = records(
+            vec![downtime(99, 600), downtime(100, 600)],
+            vec![breached(98), breached(99), breached(100)],
+        );
+        let filters = IncidentFilters {
+            from_epoch: 100,
+            ..Default::default()
+        };
+
+        let incidents = records.into_response_incidents(&filters);
+        assert_eq!(
+            incidents
+                .iter()
+                .map(|incident| incident.epoch)
+                .collect::<Vec<_>>(),
+            vec![100]
+        );
+    }
+
+    #[test]
+    fn a_zero_downtime_floor_serves_every_interval() {
+        let records = records(
+            vec![downtime(EPOCH, 12), downtime(EPOCH, 13)],
+            vec![breached(EPOCH)],
+        );
+        let filters = IncidentFilters {
+            min_downtime_seconds: 0,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            served_types(&records.into_response_incidents(&filters)),
+            vec!["Downtime"; 2]
+        );
+    }
+
+    #[test]
+    fn a_caller_floor_over_the_breach_leaves_the_epoch_unserved() {
+        let records = records(vec![downtime(EPOCH, 12)], vec![breached(EPOCH)]);
+        let filters = IncidentFilters {
+            min_missed_slots: Some(61),
+            ..Default::default()
+        };
+
+        assert!(records.into_response_incidents(&filters).is_empty());
+    }
+
+    #[test]
+    fn incidents_come_back_oldest_epoch_first() {
+        let records = records(
+            vec![downtime(101, 600), downtime(99, 600)],
+            vec![breached(100)],
+        );
+
+        let incidents = records.into_response_incidents(&Default::default());
+        assert_eq!(
+            incidents
+                .iter()
+                .map(|incident| incident.epoch)
+                .collect::<Vec<_>>(),
+            vec![99, 100, 101]
+        );
+    }
+
+    #[test]
+    fn a_validator_with_no_material_serves_nothing() {
+        let incidents = ValidatorIncidents::default();
+
+        assert!(incidents
+            .into_response_incidents("voteA", &Default::default())
+            .is_empty());
     }
 }

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod dto;
 pub mod groups;
+pub mod incidents;
 pub mod ip_info;
 pub mod node_observations;
 pub mod operators;

--- a/store/src/main.rs
+++ b/store/src/main.rs
@@ -57,6 +57,7 @@ pub mod close_epoch;
 pub mod cluster_info;
 pub mod commissions;
 pub mod dto;
+pub mod incidents;
 pub mod ip_info;
 pub mod ls_open_epochs;
 pub mod node_observations;

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -314,7 +314,7 @@ pub async fn load_incidents(
             }
 
             // With no downtime record to attach to, check block production rule and classify as incident if breached.
-            if !carried && block_production.breached(None) {
+            if !carried && block_production.breached(None, None) {
                 // Without the `epochs` row there is nothing to anchor the incident to.
                 let Some(epoch_start_at) = stats.epoch_start_at else {
                     continue;

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1,8 +1,8 @@
 use crate::dto::{
     client_label, client_lineage, client_name, client_vendor, effective_client_id,
     BlockProductionStats, ClientDiversityStats, ClientLineageStats, ClusterStats, CommissionRecord,
-    DCConcentrationStats, FeatureSetStats, IncidentRecord, RugInfo, RuggerRecord, ScoringRunRecord,
-    UptimeRecord, ValidatorAggregatedFlat, ValidatorEpochStats, ValidatorRecord,
+    DCConcentrationStats, FeatureSetStats, IncidentDetail, IncidentRecord, RugInfo, RuggerRecord,
+    ScoringRunRecord, UptimeRecord, ValidatorAggregatedFlat, ValidatorEpochStats, ValidatorRecord,
     ValidatorScoreRecord, ValidatorScoreV2Record, ValidatorScoringCsvRow, ValidatorWarning,
     ValidatorsAggregated, VersionRecord,
 };
@@ -228,13 +228,15 @@ async fn get_apy_calculators(
 /// with no distribution account written, short enough that a long-departed validator reads as absent.
 const DEFAULT_JITO_COMMISSION_EPOCHS: u64 = 10;
 
-/// Loads all downtime incidents (each a distinct `DOWN` interval in the `uptimes` table) per
-/// validator, over the closed epoch range `from_epoch..=last_epoch`. Each `DOWN` row is one
-/// incident and includes length of downtime.
+/// Loads every incident per validator over the closed epoch range `from_epoch..=last_epoch`. A
+/// downtime incident is one `DOWN` interval in the `uptimes` table and carries its length; a block
+/// production incident is one epoch of `records`' own stats that breached the block production
+/// rule. An epoch with both is one incident carrying both symptoms.
 pub async fn load_incidents(
     psql_client: &Client,
     from_epoch: u64,
     last_epoch: u64,
+    records: &HashMap<String, ValidatorRecord>,
 ) -> anyhow::Result<HashMap<String, Vec<IncidentRecord>>> {
     let rows = psql_client
         .query(
@@ -254,21 +256,71 @@ pub async fn load_incidents(
         )
         .await?;
 
-    let mut records: HashMap<String, Vec<IncidentRecord>> = Default::default();
+    let mut incidents: HashMap<String, Vec<IncidentRecord>> = Default::default();
     for row in rows {
         let vote_account: String = row.get("vote_account");
-        records
+        incidents
             .entry(vote_account)
             .or_default()
             .push(IncidentRecord {
                 epoch: row.get::<_, Decimal>("epoch").try_into()?,
-                start_at: row.get("start_at"),
-                end_at: row.get("end_at"),
-                downtime_seconds: row.get::<_, i64>("downtime_seconds").try_into()?,
+                detail: IncidentDetail::Downtime {
+                    start_at: row.get("start_at"),
+                    end_at: row.get("end_at"),
+                    downtime_seconds: row.get::<_, i64>("downtime_seconds").try_into()?,
+                    block_production: None,
+                },
             });
     }
 
-    Ok(records)
+    // Read off the same epoch stats the incidents are handed back for, so the cluster figure and
+    // the validator it judges come from one snapshot.
+    let cluster_skip_rates = crate::incidents::cluster_skip_rates(records.values());
+
+    for (vote_account, record) in records {
+        // Same window the query above read.
+        for stats in record
+            .epoch_stats
+            .iter()
+            .filter(|stats| (from_epoch..=last_epoch).contains(&stats.epoch))
+        {
+            let Some(block_production) = crate::incidents::breach(stats, &cluster_skip_rates)
+            else {
+                continue;
+            };
+
+            let incidents = incidents.entry(vote_account.clone()).or_default();
+            // An epoch that also went down is one event with two symptoms, so the numbers ride on
+            // that incident rather than opening a second one.
+            match incidents.iter_mut().find(|incident| {
+                incident.epoch == stats.epoch
+                    && matches!(incident.detail, IncidentDetail::Downtime { .. })
+            }) {
+                Some(IncidentRecord {
+                    detail:
+                        IncidentDetail::Downtime {
+                            block_production: downtime_block_production,
+                            ..
+                        },
+                    ..
+                }) => *downtime_block_production = Some(block_production),
+                _ => incidents.push(IncidentRecord {
+                    epoch: stats.epoch,
+                    detail: IncidentDetail::BlockProduction {
+                        epoch_start_at: stats.epoch_start_at,
+                        epoch_end_at: stats.epoch_end_at,
+                        block_production,
+                    },
+                }),
+            }
+        }
+
+        if let Some(incidents) = incidents.get_mut(vote_account) {
+            incidents.sort_by_key(|incident| (incident.epoch, incident.detail.started_at()));
+        }
+    }
+
+    Ok(incidents)
 }
 
 pub async fn load_uptimes(
@@ -1308,14 +1360,15 @@ pub async fn load_validators(
     log::info!("Updating incidents...");
     // Anchored to the epoch the records report, which is the head the API measures its own window
     // from; `cluster_info` can sit an epoch either side of it.
-    let incidents = load_incidents(
+    let mut incidents = load_incidents(
         psql_client,
         (last_epoch + 1).saturating_sub(DEFAULT_CACHE_EPOCHS),
         last_epoch,
+        &records,
     )
     .await?;
     for (vote_account, record) in records.iter_mut() {
-        record.incidents = incidents.get(vote_account).cloned().unwrap_or_default();
+        record.incidents = incidents.remove(vote_account).unwrap_or_default();
     }
 
     log::info!("Updating operators...");

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -313,8 +313,8 @@ pub async fn load_incidents(
                 }
             }
 
-            // With no downtime record to attach to, check block production rule and classify as incident if breached.
-            if !carried && block_production.breached(None, None) {
+            // With no downtime record to attach to, check block production rule and classify as incident if counts_as_incident.
+            if !carried && block_production.counts_as_incident {
                 // Without the `epochs` row there is nothing to anchor the incident to.
                 let Some(epoch_start_at) = stats.epoch_start_at else {
                     continue;

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1,10 +1,10 @@
 use crate::dto::{
     client_label, client_lineage, client_name, client_vendor, effective_client_id,
-    BlockProductionStats, ClientDiversityStats, ClientLineageStats, ClusterStats, CommissionRecord,
-    DCConcentrationStats, FeatureSetStats, IncidentDetail, IncidentRecord, RugInfo, RuggerRecord,
-    ScoringRunRecord, UptimeRecord, ValidatorAggregatedFlat, ValidatorEpochStats, ValidatorRecord,
-    ValidatorScoreRecord, ValidatorScoreV2Record, ValidatorScoringCsvRow, ValidatorWarning,
-    ValidatorsAggregated, VersionRecord,
+    BlockProductionDetail, BlockProductionStats, ClientDiversityStats, ClientLineageStats,
+    ClusterStats, CommissionRecord, DCConcentrationStats, FeatureSetStats, IncidentDetail,
+    IncidentRecord, RugInfo, RuggerRecord, ScoringRunRecord, UptimeRecord, ValidatorAggregatedFlat,
+    ValidatorEpochStats, ValidatorRecord, ValidatorScoreRecord, ValidatorScoreV2Record,
+    ValidatorScoringCsvRow, ValidatorWarning, ValidatorsAggregated, VersionRecord,
 };
 use crate::validators_jito::get_last_jito_info;
 use chrono::{DateTime, Utc};
@@ -284,7 +284,12 @@ pub async fn load_incidents(
             .iter()
             .filter(|stats| (from_epoch..=last_epoch).contains(&stats.epoch))
         {
-            let Some(block_production) = crate::incidents::breach(stats, &cluster_skip_rates)
+            let Some(block_production) =
+                cluster_skip_rates
+                    .get(&stats.epoch)
+                    .and_then(|cluster_skip_rate| {
+                        BlockProductionDetail::qualifies_as_breach(stats, *cluster_skip_rate)
+                    })
             else {
                 continue;
             };

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -228,9 +228,9 @@ async fn get_apy_calculators(
 /// with no distribution account written, short enough that a long-departed validator reads as absent.
 const DEFAULT_JITO_COMMISSION_EPOCHS: u64 = 10;
 
-/// Loads every incident per validator over the given closed epoch range.
-/// If a given epoch has both downtime and a block production incident, this counts as 1 downtime event
-/// with block producgtion details also attached.
+/// Loads every incident per validator over the given closed epoch range. A validator that both went
+/// down and skipped in one epoch reports one downtime incident carrying the block production numbers,
+/// not two incidents.
 pub async fn load_incidents(
     psql_client: &Client,
     from_epoch: u64,
@@ -283,43 +283,53 @@ pub async fn load_incidents(
             .iter()
             .filter(|stats| (from_epoch..=last_epoch).contains(&stats.epoch))
         {
-            // The running epoch has no `epochs` row yet, so nothing to anchor an incident to.
-            let Some(epoch_start_at) = stats.epoch_start_at else {
-                continue;
-            };
+            // No cluster figure, no bar to measure against, so the epoch stays unjudged.
             let Some(block_production) =
                 cluster_skip_rates
                     .get(&stats.epoch)
                     .and_then(|cluster_skip_rate| {
-                        BlockProductionDetail::qualifies_as_breach(stats, *cluster_skip_rate)
+                        BlockProductionDetail::for_epoch(stats, *cluster_skip_rate)
                     })
             else {
                 continue;
             };
 
-            let incidents = incidents.entry(vote_account.clone()).or_default();
-            // An epoch that also went down is one event with two symptoms, so the numbers ride on
-            // that incident rather than opening a second one.
-            match incidents.iter_mut().find(|incident| {
-                incident.epoch == stats.epoch
-                    && matches!(incident.detail, IncidentDetail::Downtime { .. })
-            }) {
-                Some(IncidentRecord {
-                    detail:
-                        IncidentDetail::Downtime {
-                            block_production: downtime_block_production,
-                            ..
-                        },
+            // A validator that also went down that epoch has one event with 2 symptoms, so the
+            // numbers go onto the downtime records instead of opening another incident.
+            let mut carried = false;
+            for incident in incidents
+                .get_mut(vote_account)
+                .into_iter()
+                .flatten()
+                .filter(|incident| incident.epoch == stats.epoch)
+            {
+                if let IncidentDetail::Downtime {
+                    block_production: downtime_block_production,
                     ..
-                }) => *downtime_block_production = Some(block_production),
-                _ => incidents.push(IncidentRecord {
-                    epoch: stats.epoch,
-                    detail: IncidentDetail::BlockProduction {
-                        epoch_start_at,
-                        epoch_end_at: stats.epoch_end_at,
-                        block_production,
-                    },
-                }),
+                } = &mut incident.detail
+                {
+                    *downtime_block_production = Some(block_production.clone());
+                    carried = true;
+                }
+            }
+
+            // With no downtime record to attach to, check block production rule and classify as incident if breached.
+            if !carried && block_production.breached(None) {
+                // Without the `epochs` row there is nothing to anchor the incident to.
+                let Some(epoch_start_at) = stats.epoch_start_at else {
+                    continue;
+                };
+                incidents
+                    .entry(vote_account.clone())
+                    .or_default()
+                    .push(IncidentRecord {
+                        epoch: stats.epoch,
+                        detail: IncidentDetail::BlockProduction {
+                            epoch_start_at,
+                            epoch_end_at: stats.epoch_end_at,
+                            block_production,
+                        },
+                    });
             }
         }
 

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -228,10 +228,9 @@ async fn get_apy_calculators(
 /// with no distribution account written, short enough that a long-departed validator reads as absent.
 const DEFAULT_JITO_COMMISSION_EPOCHS: u64 = 10;
 
-/// Loads every incident per validator over the closed epoch range `from_epoch..=last_epoch`. A
-/// downtime incident is one `DOWN` interval in the `uptimes` table and carries its length; a block
-/// production incident is one epoch of `records`' own stats that breached the block production
-/// rule. An epoch with both is one incident carrying both symptoms.
+/// Loads every incident per validator over the given closed epoch range.
+/// If a given epoch has both downtime and a block production incident, this counts as 1 downtime event
+/// with block producgtion details also attached.
 pub async fn load_incidents(
     psql_client: &Client,
     from_epoch: u64,

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -283,6 +283,10 @@ pub async fn load_incidents(
             .iter()
             .filter(|stats| (from_epoch..=last_epoch).contains(&stats.epoch))
         {
+            // The running epoch has no `epochs` row yet, so nothing to anchor an incident to.
+            let Some(epoch_start_at) = stats.epoch_start_at else {
+                continue;
+            };
             let Some(block_production) =
                 cluster_skip_rates
                     .get(&stats.epoch)
@@ -311,7 +315,7 @@ pub async fn load_incidents(
                 _ => incidents.push(IncidentRecord {
                     epoch: stats.epoch,
                     detail: IncidentDetail::BlockProduction {
-                        epoch_start_at: stats.epoch_start_at,
+                        epoch_start_at,
                         epoch_end_at: stats.epoch_end_at,
                         block_production,
                     },

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -313,10 +313,12 @@ pub async fn load_incidents(
                 }
             }
 
-            // With no downtime record to attach to, check block production rule and classify as incident if counts_as_incident.
             if !carried && block_production.counts_as_incident {
-                // Without the `epochs` row there is nothing to anchor the incident to.
-                let Some(epoch_start_at) = stats.epoch_start_at else {
+                // No `end_at` means the epoch is still running, and its block production covers
+                // just the leader slots so far: skip to not produce misleading/false incident
+                let (Some(epoch_start_at), Some(epoch_end_at)) =
+                    (stats.epoch_start_at, stats.epoch_end_at)
+                else {
                     continue;
                 };
                 incidents
@@ -326,7 +328,7 @@ pub async fn load_incidents(
                         epoch: stats.epoch,
                         detail: IncidentDetail::BlockProduction {
                             epoch_start_at,
-                            epoch_end_at: stats.epoch_end_at,
+                            epoch_end_at,
                             block_production,
                         },
                     });

--- a/store/src/utils.rs
+++ b/store/src/utils.rs
@@ -1,11 +1,12 @@
 use crate::dto::{
     client_label, client_lineage, client_name, client_vendor, effective_client_id,
-    BlockProductionDetail, BlockProductionStats, ClientDiversityStats, ClientLineageStats,
-    ClusterStats, CommissionRecord, DCConcentrationStats, FeatureSetStats, IncidentDetail,
-    IncidentRecord, RugInfo, RuggerRecord, ScoringRunRecord, UptimeRecord, ValidatorAggregatedFlat,
-    ValidatorEpochStats, ValidatorRecord, ValidatorScoreRecord, ValidatorScoreV2Record,
-    ValidatorScoringCsvRow, ValidatorWarning, ValidatorsAggregated, VersionRecord,
+    BlockProductionStats, ClientDiversityStats, ClientLineageStats, ClusterStats, CommissionRecord,
+    DCConcentrationStats, FeatureSetStats, RugInfo, RuggerRecord, ScoringRunRecord, UptimeRecord,
+    ValidatorAggregatedFlat, ValidatorEpochStats, ValidatorRecord, ValidatorScoreRecord,
+    ValidatorScoreV2Record, ValidatorScoringCsvRow, ValidatorWarning, ValidatorsAggregated,
+    VersionRecord,
 };
+use crate::incidents::{DowntimeInterval, EpochBlockProduction, ValidatorIncidents};
 use crate::validators_jito::get_last_jito_info;
 use chrono::{DateTime, Utc};
 use collect::take_rates::query_validator_rewards;
@@ -228,15 +229,16 @@ async fn get_apy_calculators(
 /// with no distribution account written, short enough that a long-departed validator reads as absent.
 const DEFAULT_JITO_COMMISSION_EPOCHS: u64 = 10;
 
-/// Loads every incident per validator over the given closed epoch range. A validator that both went
-/// down and skipped in one epoch reports one downtime incident carrying the block production numbers,
-/// not two incidents.
-pub async fn load_incidents(
+/// Loads the raw incident material per validator over the given closed epoch range: every `DOWN`
+/// interval as recorded, and the block production of every closed epoch. Neither is judged or
+/// merged here; `ValidatorIncidentRecords::into_response_incidents` does both under a caller's
+/// floors.
+pub async fn load_validator_incidents(
     psql_client: &Client,
     from_epoch: u64,
     last_epoch: u64,
     records: &HashMap<String, ValidatorRecord>,
-) -> anyhow::Result<HashMap<String, Vec<IncidentRecord>>> {
+) -> anyhow::Result<ValidatorIncidents> {
     let rows = psql_client
         .query(
             "
@@ -255,20 +257,17 @@ pub async fn load_incidents(
         )
         .await?;
 
-    let mut incidents: HashMap<String, Vec<IncidentRecord>> = Default::default();
+    let mut incidents = ValidatorIncidents::default();
     for row in rows {
         let vote_account: String = row.get("vote_account");
         incidents
-            .entry(vote_account)
-            .or_default()
-            .push(IncidentRecord {
+            .records(&vote_account)
+            .downtimes
+            .push(DowntimeInterval {
                 epoch: row.get::<_, Decimal>("epoch").try_into()?,
-                detail: IncidentDetail::Downtime {
-                    start_at: row.get("start_at"),
-                    end_at: row.get("end_at"),
-                    downtime_seconds: row.get::<_, i64>("downtime_seconds").try_into()?,
-                    block_production: None,
-                },
+                start_at: row.get("start_at"),
+                end_at: row.get("end_at"),
+                downtime_seconds: row.get::<_, i64>("downtime_seconds").try_into()?,
             });
     }
 
@@ -283,60 +282,17 @@ pub async fn load_incidents(
             .iter()
             .filter(|stats| (from_epoch..=last_epoch).contains(&stats.epoch))
         {
-            // No cluster figure, no bar to measure against, so the epoch stays unjudged.
-            let Some(block_production) =
-                cluster_skip_rates
-                    .get(&stats.epoch)
-                    .and_then(|cluster_skip_rate| {
-                        BlockProductionDetail::for_epoch(stats, *cluster_skip_rate)
-                    })
+            // No cluster figure, no bar to measure against, so the epoch stays unrecorded.
+            let Some(production) = cluster_skip_rates
+                .get(&stats.epoch)
+                .and_then(|cluster_skip_rate| EpochBlockProduction::new(stats, *cluster_skip_rate))
             else {
                 continue;
             };
-
-            // A validator that also went down that epoch has one event with 2 symptoms, so the
-            // numbers go onto the downtime records instead of opening another incident.
-            let mut carried = false;
-            for incident in incidents
-                .get_mut(vote_account)
-                .into_iter()
-                .flatten()
-                .filter(|incident| incident.epoch == stats.epoch)
-            {
-                if let IncidentDetail::Downtime {
-                    block_production: downtime_block_production,
-                    ..
-                } = &mut incident.detail
-                {
-                    *downtime_block_production = Some(block_production.clone());
-                    carried = true;
-                }
-            }
-
-            if !carried && block_production.counts_as_incident {
-                // No `end_at` means the epoch is still running, and its block production covers
-                // just the leader slots so far: skip to not produce misleading/false incident
-                let (Some(epoch_start_at), Some(epoch_end_at)) =
-                    (stats.epoch_start_at, stats.epoch_end_at)
-                else {
-                    continue;
-                };
-                incidents
-                    .entry(vote_account.clone())
-                    .or_default()
-                    .push(IncidentRecord {
-                        epoch: stats.epoch,
-                        detail: IncidentDetail::BlockProduction {
-                            epoch_start_at,
-                            epoch_end_at,
-                            block_production,
-                        },
-                    });
-            }
-        }
-
-        if let Some(incidents) = incidents.get_mut(vote_account) {
-            incidents.sort_by_key(|incident| (incident.epoch, incident.detail.started_at()));
+            incidents
+                .records(vote_account)
+                .block_production
+                .push(production);
         }
     }
 
@@ -1375,20 +1331,6 @@ pub async fn load_validators(
     log::info!("Updating unique delegators...");
     for (vote_account, record) in records.iter_mut() {
         record.unique_delegators = overlays.unique_delegators.get(vote_account).copied();
-    }
-
-    log::info!("Updating incidents...");
-    // Anchored to the epoch the records report, which is the head the API measures its own window
-    // from; `cluster_info` can sit an epoch either side of it.
-    let mut incidents = load_incidents(
-        psql_client,
-        (last_epoch + 1).saturating_sub(DEFAULT_CACHE_EPOCHS),
-        last_epoch,
-        &records,
-    )
-    .await?;
-    for (vote_account, record) in records.iter_mut() {
-        record.incidents = incidents.remove(vote_account).unwrap_or_default();
     }
 
     log::info!("Updating operators...");

--- a/store/tests/incidents_sql.rs
+++ b/store/tests/incidents_sql.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use chrono::{DateTime, Utc};
 use common::{migrated_client, skip_without_database};
 use std::collections::HashMap;
 use store::dto::{IncidentDetail, IncidentRecord, ValidatorEpochStats, ValidatorRecord};
@@ -14,13 +15,32 @@ fn no_records() -> HashMap<String, ValidatorRecord> {
 /// One validator whose epoch produced too few of its leader slots to pass: 8 of 64 missed is 12.5%,
 /// over any bar the rule can set.
 fn skipped_epoch(vote_account: &str, epoch: u64) -> HashMap<String, ValidatorRecord> {
+    epoch_stats(vote_account, epoch, 64, 56)
+}
+
+/// A validator that produced every slot it was given, so nothing about the epoch breaches.
+fn clean_epoch(vote_account: &str, epoch: u64) -> HashMap<String, ValidatorRecord> {
+    epoch_stats(vote_account, epoch, 64, 64)
+}
+
+fn epoch_stats(
+    vote_account: &str,
+    epoch: u64,
+    leader_slots: u64,
+    blocks_produced: u64,
+) -> HashMap<String, ValidatorRecord> {
+    // A standalone block production incident anchors to these, so they have to be set as the
+    // `epochs` join would set them.
+    let epoch_start_at: DateTime<Utc> = "2026-01-01T00:00:00Z".parse().unwrap();
     HashMap::from([(
         vote_account.to_string(),
         ValidatorRecord {
             epoch_stats: vec![ValidatorEpochStats {
                 epoch,
-                leader_slots: 64,
-                blocks_produced: 56,
+                leader_slots,
+                blocks_produced,
+                epoch_start_at: Some(epoch_start_at),
+                epoch_end_at: Some(epoch_start_at + chrono::Duration::days(2)),
                 ..Default::default()
             }],
             ..Default::default()
@@ -235,6 +255,90 @@ async fn an_epoch_that_only_skipped_is_its_own_incident() {
         incidents["voteA"][0].detail,
         IncidentDetail::BlockProduction { .. }
     ));
+}
+
+#[tokio::test]
+async fn an_epoch_that_went_down_carries_its_block_production_even_when_it_passed() {
+    let schema = "ds_test_incidents_informational";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    down(
+        &client,
+        "voteA",
+        100,
+        "2026-01-01T00:00:00Z",
+        "2026-01-01T00:05:00Z",
+    )
+    .await;
+
+    let incidents = load_incidents(&client, 100, 100, &clean_epoch("voteA", 100))
+        .await
+        .unwrap();
+
+    let IncidentDetail::Downtime {
+        block_production, ..
+    } = &incidents["voteA"][0].detail
+    else {
+        panic!("the downtime row is the one served");
+    };
+    let block_production = block_production.as_ref().expect("numbers ride along");
+    assert_eq!(block_production.leader_slots, 64);
+    assert_eq!(block_production.missed_slots, 0);
+    assert!(!block_production.breached(None));
+}
+
+#[tokio::test]
+async fn an_epoch_that_passed_opens_no_incident_of_its_own() {
+    let schema = "ds_test_incidents_informational_only";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    let incidents = load_incidents(&client, 100, 100, &clean_epoch("voteA", 100))
+        .await
+        .unwrap();
+
+    assert!(incidents.is_empty());
+}
+
+// Block production is an epoch-level fact, so intervals of one epoch cannot disagree about it.
+#[tokio::test]
+async fn every_downtime_of_an_epoch_carries_that_epoch_s_block_production() {
+    let schema = "ds_test_incidents_every_interval";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    for (start_at, end_at) in [
+        ("2026-01-01T00:00:00Z", "2026-01-01T00:05:00Z"),
+        ("2026-01-02T00:00:00Z", "2026-01-02T00:05:00Z"),
+        ("2026-01-03T00:00:00Z", "2026-01-03T00:05:00Z"),
+    ] {
+        down(&client, "voteA", 100, start_at, end_at).await;
+    }
+
+    let incidents = load_incidents(&client, 100, 100, &skipped_epoch("voteA", 100))
+        .await
+        .unwrap();
+
+    assert_eq!(incidents["voteA"].len(), 3);
+    for incident in &incidents["voteA"] {
+        let IncidentDetail::Downtime {
+            block_production, ..
+        } = &incident.detail
+        else {
+            panic!("a DOWN row is a downtime incident");
+        };
+        assert_eq!(
+            block_production.as_ref().map(|detail| detail.missed_slots),
+            Some(8)
+        );
+    }
 }
 
 // The window bound is the query's, so a skipped epoch older than it is not served either.

--- a/store/tests/incidents_sql.rs
+++ b/store/tests/incidents_sql.rs
@@ -18,7 +18,7 @@ fn skipped_epoch(vote_account: &str, epoch: u64) -> HashMap<String, ValidatorRec
     epoch_stats(vote_account, epoch, 64, 56)
 }
 
-/// A validator that produced every slot it was given, so nothing about the epoch breaches.
+/// A validator that produced every slot it was given, so nothing about the epoch is an incident.
 fn clean_epoch(vote_account: &str, epoch: u64) -> HashMap<String, ValidatorRecord> {
     epoch_stats(vote_account, epoch, 64, 64)
 }
@@ -287,7 +287,7 @@ async fn an_epoch_that_went_down_carries_its_block_production_even_when_it_passe
     let block_production = block_production.as_ref().expect("numbers ride along");
     assert_eq!(block_production.leader_slots, 64);
     assert_eq!(block_production.missed_slots, 0);
-    assert!(!block_production.breached(None, None));
+    assert!(!block_production.counts_as_incident);
 }
 
 #[tokio::test]

--- a/store/tests/incidents_sql.rs
+++ b/store/tests/incidents_sql.rs
@@ -61,81 +61,30 @@ fn epochs(incidents: &[IncidentRecord]) -> Vec<u64> {
     incidents.iter().map(|incident| incident.epoch).collect()
 }
 
-// The handler measures its own window off the same head this bound is derived from, so an epoch
-// exactly on the bound has to be served or the two disagree by one epoch.
+// `uptimes` is written every minute and `validators` hourly, so epoch 102 is a live case: a DOWN row
+// above the head for the hour the validator write takes to catch up.
 #[tokio::test]
-async fn the_window_starts_on_from_epoch_itself() {
+async fn the_window_is_closed_on_both_ends() {
     let schema = "ds_test_incidents_window";
     if skip_without_database(schema) {
         return;
     }
     let client = migrated_client(schema).await.unwrap();
 
-    down(
-        &client,
-        "voteA",
-        99,
-        "2026-01-01T00:00:00Z",
-        "2026-01-01T00:05:00Z",
-    )
-    .await;
-    down(
-        &client,
-        "voteA",
-        100,
-        "2026-02-01T00:00:00Z",
-        "2026-02-01T00:05:00Z",
-    )
-    .await;
-    down(
-        &client,
-        "voteA",
-        101,
-        "2026-03-01T00:00:00Z",
-        "2026-03-01T00:05:00Z",
-    )
-    .await;
+    for (epoch, start_at, end_at) in [
+        (99, "2026-01-01T00:00:00Z", "2026-01-01T00:05:00Z"),
+        (100, "2026-02-01T00:00:00Z", "2026-02-01T00:05:00Z"),
+        (101, "2026-03-01T00:00:00Z", "2026-03-01T00:05:00Z"),
+        (102, "2026-04-01T00:00:00Z", "2026-04-01T00:05:00Z"),
+    ] {
+        down(&client, "voteA", epoch, start_at, end_at).await;
+    }
 
     let incidents = load_incidents(&client, 100, 101, &no_records())
         .await
         .unwrap();
 
     assert_eq!(epochs(&incidents["voteA"]), vec![100, 101]);
-}
-
-// `uptimes` is written every minute and `validators` hourly, so after an epoch rollover a DOWN row
-// sits above the head the window is anchored to. Serving it would make the window one epoch wider
-// than the caller asked for, but only for the hour it takes the validator write to catch up.
-#[tokio::test]
-async fn the_window_ends_on_last_epoch_itself() {
-    let schema = "ds_test_incidents_head";
-    if skip_without_database(schema) {
-        return;
-    }
-    let client = migrated_client(schema).await.unwrap();
-
-    down(
-        &client,
-        "voteA",
-        100,
-        "2026-01-01T00:00:00Z",
-        "2026-01-01T00:05:00Z",
-    )
-    .await;
-    down(
-        &client,
-        "voteA",
-        101,
-        "2026-02-01T00:00:00Z",
-        "2026-02-01T00:05:00Z",
-    )
-    .await;
-
-    let incidents = load_incidents(&client, 100, 100, &no_records())
-        .await
-        .unwrap();
-
-    assert_eq!(epochs(&incidents["voteA"]), vec![100]);
 }
 
 #[tokio::test]
@@ -231,48 +180,6 @@ async fn each_down_row_is_its_own_incident_oldest_first() {
         .unwrap();
 
     assert_eq!(epochs(&incidents["voteA"]), vec![100, 101, 102]);
-}
-
-#[tokio::test]
-async fn incidents_are_keyed_by_the_validator_that_was_down() {
-    let schema = "ds_test_incidents_grouping";
-    if skip_without_database(schema) {
-        return;
-    }
-    let client = migrated_client(schema).await.unwrap();
-
-    down(
-        &client,
-        "voteA",
-        100,
-        "2026-01-01T00:00:00Z",
-        "2026-01-01T00:05:00Z",
-    )
-    .await;
-    down(
-        &client,
-        "voteB",
-        100,
-        "2026-01-01T00:00:00Z",
-        "2026-01-01T00:05:00Z",
-    )
-    .await;
-    down(
-        &client,
-        "voteA",
-        101,
-        "2026-02-01T00:00:00Z",
-        "2026-02-01T00:05:00Z",
-    )
-    .await;
-
-    let incidents = load_incidents(&client, 100, 101, &no_records())
-        .await
-        .unwrap();
-
-    assert_eq!(incidents.len(), 2);
-    assert_eq!(epochs(&incidents["voteA"]), vec![100, 101]);
-    assert_eq!(epochs(&incidents["voteB"]), vec![100]);
 }
 
 // Both symptoms of one epoch belong to one incident, so the epoch is served once with the block

--- a/store/tests/incidents_sql.rs
+++ b/store/tests/incidents_sql.rs
@@ -1,9 +1,32 @@
 mod common;
 
 use common::{migrated_client, skip_without_database};
-use store::dto::IncidentRecord;
+use std::collections::HashMap;
+use store::dto::{IncidentDetail, IncidentRecord, ValidatorEpochStats, ValidatorRecord};
 use store::utils::load_incidents;
 use tokio_postgres::Client;
+
+/// No records, so no block production incident can be derived and only the query is under test.
+fn no_records() -> HashMap<String, ValidatorRecord> {
+    HashMap::new()
+}
+
+/// One validator whose epoch produced too few of its leader slots to pass: 8 of 64 missed is 12.5%,
+/// over any bar the rule can set.
+fn skipped_epoch(vote_account: &str, epoch: u64) -> HashMap<String, ValidatorRecord> {
+    HashMap::from([(
+        vote_account.to_string(),
+        ValidatorRecord {
+            epoch_stats: vec![ValidatorEpochStats {
+                epoch,
+                leader_slots: 64,
+                blocks_produced: 56,
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+    )])
+}
 
 // `identity` and `vote_account` are the same string here; nothing the query reads distinguishes them.
 async fn interval(
@@ -73,7 +96,9 @@ async fn the_window_starts_on_from_epoch_itself() {
     )
     .await;
 
-    let incidents = load_incidents(&client, 100, 101).await.unwrap();
+    let incidents = load_incidents(&client, 100, 101, &no_records())
+        .await
+        .unwrap();
 
     assert_eq!(epochs(&incidents["voteA"]), vec![100, 101]);
 }
@@ -106,7 +131,9 @@ async fn the_window_ends_on_last_epoch_itself() {
     )
     .await;
 
-    let incidents = load_incidents(&client, 100, 100).await.unwrap();
+    let incidents = load_incidents(&client, 100, 100, &no_records())
+        .await
+        .unwrap();
 
     assert_eq!(epochs(&incidents["voteA"]), vec![100]);
 }
@@ -129,7 +156,10 @@ async fn an_up_interval_is_not_an_incident() {
     )
     .await;
 
-    assert!(load_incidents(&client, 100, 100).await.unwrap().is_empty());
+    assert!(load_incidents(&client, 100, 100, &no_records())
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 // Every filter the API applies afterwards reads `downtime_seconds`, including the restart-noise floor.
@@ -150,9 +180,17 @@ async fn downtime_seconds_is_the_length_of_the_interval() {
     )
     .await;
 
-    let incidents = load_incidents(&client, 100, 100).await.unwrap();
+    let incidents = load_incidents(&client, 100, 100, &no_records())
+        .await
+        .unwrap();
 
-    assert_eq!(incidents["voteA"][0].downtime_seconds, 200);
+    let IncidentDetail::Downtime {
+        downtime_seconds, ..
+    } = incidents["voteA"][0].detail
+    else {
+        panic!("a DOWN row is a downtime incident");
+    };
+    assert_eq!(downtime_seconds, 200);
 }
 
 #[tokio::test]
@@ -188,7 +226,9 @@ async fn each_down_row_is_its_own_incident_oldest_first() {
     )
     .await;
 
-    let incidents = load_incidents(&client, 100, 102).await.unwrap();
+    let incidents = load_incidents(&client, 100, 102, &no_records())
+        .await
+        .unwrap();
 
     assert_eq!(epochs(&incidents["voteA"]), vec![100, 101, 102]);
 }
@@ -226,9 +266,82 @@ async fn incidents_are_keyed_by_the_validator_that_was_down() {
     )
     .await;
 
-    let incidents = load_incidents(&client, 100, 101).await.unwrap();
+    let incidents = load_incidents(&client, 100, 101, &no_records())
+        .await
+        .unwrap();
 
     assert_eq!(incidents.len(), 2);
     assert_eq!(epochs(&incidents["voteA"]), vec![100, 101]);
     assert_eq!(epochs(&incidents["voteB"]), vec![100]);
+}
+
+// Both symptoms of one epoch belong to one incident, so the epoch is served once with the block
+// production numbers on the downtime row.
+#[tokio::test]
+async fn an_epoch_that_went_down_and_skipped_is_one_incident() {
+    let schema = "ds_test_incidents_dedup";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    down(
+        &client,
+        "voteA",
+        100,
+        "2026-01-01T00:00:00Z",
+        "2026-01-01T00:05:00Z",
+    )
+    .await;
+
+    let incidents = load_incidents(&client, 100, 100, &skipped_epoch("voteA", 100))
+        .await
+        .unwrap();
+
+    assert_eq!(epochs(&incidents["voteA"]), vec![100]);
+    let IncidentDetail::Downtime {
+        block_production, ..
+    } = &incidents["voteA"][0].detail
+    else {
+        panic!("the downtime row is the one served");
+    };
+    assert_eq!(
+        block_production.as_ref().map(|detail| detail.missed_slots),
+        Some(8)
+    );
+}
+
+#[tokio::test]
+async fn an_epoch_that_only_skipped_is_its_own_incident() {
+    let schema = "ds_test_incidents_block_production";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    let incidents = load_incidents(&client, 100, 100, &skipped_epoch("voteA", 100))
+        .await
+        .unwrap();
+
+    assert_eq!(epochs(&incidents["voteA"]), vec![100]);
+    assert!(matches!(
+        incidents["voteA"][0].detail,
+        IncidentDetail::BlockProduction { .. }
+    ));
+}
+
+// The window bound is the query's, so a skipped epoch older than it is not served either.
+#[tokio::test]
+async fn a_skipped_epoch_before_from_epoch_is_left_out() {
+    let schema = "ds_test_incidents_block_production_window";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    let incidents = load_incidents(&client, 100, 100, &skipped_epoch("voteA", 99))
+        .await
+        .unwrap();
+
+    assert!(incidents.is_empty());
 }

--- a/store/tests/incidents_sql.rs
+++ b/store/tests/incidents_sql.rs
@@ -287,7 +287,7 @@ async fn an_epoch_that_went_down_carries_its_block_production_even_when_it_passe
     let block_production = block_production.as_ref().expect("numbers ride along");
     assert_eq!(block_production.leader_slots, 64);
     assert_eq!(block_production.missed_slots, 0);
-    assert!(!block_production.breached(None));
+    assert!(!block_production.breached(None, None));
 }
 
 #[tokio::test]

--- a/store/tests/incidents_sql.rs
+++ b/store/tests/incidents_sql.rs
@@ -3,42 +3,28 @@ mod common;
 use chrono::{DateTime, Utc};
 use common::{migrated_client, skip_without_database};
 use std::collections::HashMap;
-use store::dto::{IncidentDetail, IncidentRecord, ValidatorEpochStats, ValidatorRecord};
-use store::utils::load_incidents;
+use store::dto::{ValidatorEpochStats, ValidatorRecord};
+use store::incidents::ValidatorIncidents;
+use store::utils::load_validator_incidents;
 use tokio_postgres::Client;
 
-/// No records, so no block production incident can be derived and only the query is under test.
+/// No records, so no block production can be derived and only the query is under test.
 fn no_records() -> HashMap<String, ValidatorRecord> {
     HashMap::new()
 }
 
-/// One validator whose epoch produced too few of its leader slots to pass: 8 of 64 missed is 12.5%,
-/// over any bar the rule can set.
-fn skipped_epoch(vote_account: &str, epoch: u64) -> HashMap<String, ValidatorRecord> {
-    epoch_stats(vote_account, epoch, 64, 56)
-}
-
-/// A validator that produced every slot it was given, so nothing about the epoch is an incident.
-fn clean_epoch(vote_account: &str, epoch: u64) -> HashMap<String, ValidatorRecord> {
-    epoch_stats(vote_account, epoch, 64, 64)
-}
-
-fn epoch_stats(
-    vote_account: &str,
-    epoch: u64,
-    leader_slots: u64,
-    blocks_produced: u64,
-) -> HashMap<String, ValidatorRecord> {
-    // A standalone block production incident anchors to these, so they have to be set as the
-    // `epochs` join would set them.
+/// One validator that missed 8 of its 64 leader slots in the given epoch.
+fn epoch_stats(vote_account: &str, epoch: u64) -> HashMap<String, ValidatorRecord> {
+    // Block production is only recorded for a closed epoch, so the boundaries have to be set as
+    // the `epochs` join would set them.
     let epoch_start_at: DateTime<Utc> = "2026-01-01T00:00:00Z".parse().unwrap();
     HashMap::from([(
         vote_account.to_string(),
         ValidatorRecord {
             epoch_stats: vec![ValidatorEpochStats {
                 epoch,
-                leader_slots,
-                blocks_produced,
+                leader_slots: 64,
+                blocks_produced: 56,
                 epoch_start_at: Some(epoch_start_at),
                 epoch_end_at: Some(epoch_start_at + chrono::Duration::days(2)),
                 ..Default::default()
@@ -77,8 +63,14 @@ async fn down(client: &Client, vote_account: &str, epoch: u64, start_at: &str, e
     interval(client, vote_account, "DOWN", epoch, start_at, end_at).await
 }
 
-fn epochs(incidents: &[IncidentRecord]) -> Vec<u64> {
-    incidents.iter().map(|incident| incident.epoch).collect()
+fn downtime_epochs(incidents: &ValidatorIncidents, vote_account: &str) -> Vec<u64> {
+    incidents
+        .get(vote_account)
+        .expect("the validator has incident material")
+        .downtimes
+        .iter()
+        .map(|downtime| downtime.epoch)
+        .collect()
 }
 
 // `uptimes` is written every minute and `validators` hourly, so epoch 102 is a live case: a DOWN row
@@ -100,11 +92,11 @@ async fn the_window_is_closed_on_both_ends() {
         down(&client, "voteA", epoch, start_at, end_at).await;
     }
 
-    let incidents = load_incidents(&client, 100, 101, &no_records())
+    let incidents = load_validator_incidents(&client, 100, 101, &no_records())
         .await
         .unwrap();
 
-    assert_eq!(epochs(&incidents["voteA"]), vec![100, 101]);
+    assert_eq!(downtime_epochs(&incidents, "voteA"), vec![100, 101]);
 }
 
 #[tokio::test]
@@ -125,7 +117,7 @@ async fn an_up_interval_is_not_an_incident() {
     )
     .await;
 
-    assert!(load_incidents(&client, 100, 100, &no_records())
+    assert!(load_validator_incidents(&client, 100, 100, &no_records())
         .await
         .unwrap()
         .is_empty());
@@ -149,21 +141,18 @@ async fn downtime_seconds_is_the_length_of_the_interval() {
     )
     .await;
 
-    let incidents = load_incidents(&client, 100, 100, &no_records())
+    let incidents = load_validator_incidents(&client, 100, 100, &no_records())
         .await
         .unwrap();
 
-    let IncidentDetail::Downtime {
-        downtime_seconds, ..
-    } = incidents["voteA"][0].detail
-    else {
-        panic!("a DOWN row is a downtime incident");
-    };
-    assert_eq!(downtime_seconds, 200);
+    assert_eq!(
+        incidents.get("voteA").unwrap().downtimes[0].downtime_seconds,
+        200
+    );
 }
 
 #[tokio::test]
-async fn each_down_row_is_its_own_incident_oldest_first() {
+async fn every_down_row_is_loaded_oldest_first() {
     let schema = "ds_test_incidents_order";
     if skip_without_database(schema) {
         return;
@@ -195,185 +184,64 @@ async fn each_down_row_is_its_own_incident_oldest_first() {
     )
     .await;
 
-    let incidents = load_incidents(&client, 100, 102, &no_records())
+    let incidents = load_validator_incidents(&client, 100, 102, &no_records())
         .await
         .unwrap();
 
-    assert_eq!(epochs(&incidents["voteA"]), vec![100, 101, 102]);
-}
-
-// Both symptoms of one epoch belong to one incident, so the epoch is served once with the block
-// production numbers on the downtime row.
-#[tokio::test]
-async fn an_epoch_that_went_down_and_skipped_is_one_incident() {
-    let schema = "ds_test_incidents_dedup";
-    if skip_without_database(schema) {
-        return;
-    }
-    let client = migrated_client(schema).await.unwrap();
-
-    down(
-        &client,
-        "voteA",
-        100,
-        "2026-01-01T00:00:00Z",
-        "2026-01-01T00:05:00Z",
-    )
-    .await;
-
-    let incidents = load_incidents(&client, 100, 100, &skipped_epoch("voteA", 100))
-        .await
-        .unwrap();
-
-    assert_eq!(epochs(&incidents["voteA"]), vec![100]);
-    let IncidentDetail::Downtime {
-        block_production, ..
-    } = &incidents["voteA"][0].detail
-    else {
-        panic!("the downtime row is the one served");
-    };
-    assert_eq!(
-        block_production.as_ref().map(|detail| detail.missed_slots),
-        Some(8)
-    );
+    assert_eq!(downtime_epochs(&incidents, "voteA"), vec![100, 101, 102]);
 }
 
 #[tokio::test]
-async fn an_epoch_that_only_skipped_is_its_own_incident() {
+async fn a_closed_epoch_reports_its_block_production() {
     let schema = "ds_test_incidents_block_production";
     if skip_without_database(schema) {
         return;
     }
     let client = migrated_client(schema).await.unwrap();
 
-    let incidents = load_incidents(&client, 100, 100, &skipped_epoch("voteA", 100))
+    let incidents = load_validator_incidents(&client, 100, 100, &epoch_stats("voteA", 100))
         .await
         .unwrap();
 
-    assert_eq!(epochs(&incidents["voteA"]), vec![100]);
-    assert!(matches!(
-        incidents["voteA"][0].detail,
-        IncidentDetail::BlockProduction { .. }
-    ));
+    let production = &incidents.get("voteA").unwrap().block_production;
+    assert_eq!(production.len(), 1);
+    assert_eq!(production[0].leader_slots, 64);
+    assert_eq!(production[0].blocks_produced, 56);
 }
 
+// The epoch in flight has no `epochs` row yet, and its counters cover only the slots so far.
 #[tokio::test]
-async fn an_epoch_that_went_down_carries_its_block_production_even_when_it_passed() {
-    let schema = "ds_test_incidents_informational";
-    if skip_without_database(schema) {
-        return;
-    }
-    let client = migrated_client(schema).await.unwrap();
-
-    down(
-        &client,
-        "voteA",
-        100,
-        "2026-01-01T00:00:00Z",
-        "2026-01-01T00:05:00Z",
-    )
-    .await;
-
-    let incidents = load_incidents(&client, 100, 100, &clean_epoch("voteA", 100))
-        .await
-        .unwrap();
-
-    let IncidentDetail::Downtime {
-        block_production, ..
-    } = &incidents["voteA"][0].detail
-    else {
-        panic!("the downtime row is the one served");
-    };
-    let block_production = block_production.as_ref().expect("numbers ride along");
-    assert_eq!(block_production.leader_slots, 64);
-    assert_eq!(block_production.missed_slots, 0);
-    assert!(!block_production.counts_as_incident);
-}
-
-#[tokio::test]
-async fn an_epoch_that_passed_opens_no_incident_of_its_own() {
-    let schema = "ds_test_incidents_informational_only";
-    if skip_without_database(schema) {
-        return;
-    }
-    let client = migrated_client(schema).await.unwrap();
-
-    let incidents = load_incidents(&client, 100, 100, &clean_epoch("voteA", 100))
-        .await
-        .unwrap();
-
-    assert!(incidents.is_empty());
-}
-
-// Block production is an epoch-level fact, so intervals of one epoch cannot disagree about it.
-#[tokio::test]
-async fn every_downtime_of_an_epoch_carries_that_epoch_s_block_production() {
-    let schema = "ds_test_incidents_every_interval";
-    if skip_without_database(schema) {
-        return;
-    }
-    let client = migrated_client(schema).await.unwrap();
-
-    for (start_at, end_at) in [
-        ("2026-01-01T00:00:00Z", "2026-01-01T00:05:00Z"),
-        ("2026-01-02T00:00:00Z", "2026-01-02T00:05:00Z"),
-        ("2026-01-03T00:00:00Z", "2026-01-03T00:05:00Z"),
-    ] {
-        down(&client, "voteA", 100, start_at, end_at).await;
-    }
-
-    let incidents = load_incidents(&client, 100, 100, &skipped_epoch("voteA", 100))
-        .await
-        .unwrap();
-
-    assert_eq!(incidents["voteA"].len(), 3);
-    for incident in &incidents["voteA"] {
-        let IncidentDetail::Downtime {
-            block_production, ..
-        } = &incident.detail
-        else {
-            panic!("a DOWN row is a downtime incident");
-        };
-        assert_eq!(
-            block_production.as_ref().map(|detail| detail.missed_slots),
-            Some(8)
-        );
-    }
-}
-
-// The window bound is the query's, so a skipped epoch older than it is not served either.
-#[tokio::test]
-async fn a_skipped_epoch_before_from_epoch_is_left_out() {
-    let schema = "ds_test_incidents_block_production_window";
-    if skip_without_database(schema) {
-        return;
-    }
-    let client = migrated_client(schema).await.unwrap();
-
-    let incidents = load_incidents(&client, 100, 100, &skipped_epoch("voteA", 99))
-        .await
-        .unwrap();
-
-    assert!(incidents.is_empty());
-}
-
-// The window runs up to MAX(epoch), so the running epoch is in it. Its skip rate is measured over
-// the slots elapsed so far, which is why it is not judged until it closes.
-#[tokio::test]
-async fn the_running_epoch_opens_no_incident_of_its_own() {
+async fn the_running_epoch_reports_no_block_production() {
     let schema = "ds_test_incidents_running_epoch";
     if skip_without_database(schema) {
         return;
     }
     let client = migrated_client(schema).await.unwrap();
 
-    // The same skipped epoch, without the `epochs.end_at` an epoch only gets once it ends.
-    let mut records = skipped_epoch("voteA", 100);
+    let mut records = epoch_stats("voteA", 100);
     for record in records.values_mut() {
         record.epoch_stats[0].epoch_end_at = None;
     }
 
-    let incidents = load_incidents(&client, 100, 100, &records).await.unwrap();
+    let incidents = load_validator_incidents(&client, 100, 100, &records)
+        .await
+        .unwrap();
+
+    assert!(incidents.is_empty());
+}
+
+// The window bound is the query's, so an epoch older than it is not read either.
+#[tokio::test]
+async fn an_epoch_before_from_epoch_is_left_out() {
+    let schema = "ds_test_incidents_block_production_window";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    let incidents = load_validator_incidents(&client, 100, 100, &epoch_stats("voteA", 99))
+        .await
+        .unwrap();
 
     assert!(incidents.is_empty());
 }

--- a/store/tests/incidents_sql.rs
+++ b/store/tests/incidents_sql.rs
@@ -356,3 +356,24 @@ async fn a_skipped_epoch_before_from_epoch_is_left_out() {
 
     assert!(incidents.is_empty());
 }
+
+// The window runs up to MAX(epoch), so the running epoch is in it. Its skip rate is measured over
+// the slots elapsed so far, which is why it is not judged until it closes.
+#[tokio::test]
+async fn the_running_epoch_opens_no_incident_of_its_own() {
+    let schema = "ds_test_incidents_running_epoch";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    // The same skipped epoch, without the `epochs.end_at` an epoch only gets once it ends.
+    let mut records = skipped_epoch("voteA", 100);
+    for record in records.values_mut() {
+        record.epoch_stats[0].epoch_end_at = None;
+    }
+
+    let incidents = load_incidents(&client, 100, 100, &records).await.unwrap();
+
+    assert!(incidents.is_empty());
+}

--- a/store/tests/incidents_sql.rs
+++ b/store/tests/incidents_sql.rs
@@ -3,8 +3,8 @@ mod common;
 use chrono::{DateTime, Utc};
 use common::{migrated_client, skip_without_database};
 use std::collections::HashMap;
-use store::dto::{ValidatorEpochStats, ValidatorRecord};
-use store::incidents::ValidatorIncidents;
+use store::dto::{IncidentDetail, ValidatorEpochStats, ValidatorRecord};
+use store::incidents::{IncidentFilters, ValidatorIncidents};
 use store::utils::load_validator_incidents;
 use tokio_postgres::Client;
 
@@ -15,23 +15,33 @@ fn no_records() -> HashMap<String, ValidatorRecord> {
 
 /// One validator that missed 8 of its 64 leader slots in the given epoch.
 fn epoch_stats(vote_account: &str, epoch: u64) -> HashMap<String, ValidatorRecord> {
+    records(&[vote_account], epoch)
+}
+
+/// 8 of 64 leader slots missed, for each of the given validators.
+fn records(vote_accounts: &[&str], epoch: u64) -> HashMap<String, ValidatorRecord> {
     // Block production is only recorded for a closed epoch, so the boundaries have to be set as
     // the `epochs` join would set them.
     let epoch_start_at: DateTime<Utc> = "2026-01-01T00:00:00Z".parse().unwrap();
-    HashMap::from([(
-        vote_account.to_string(),
-        ValidatorRecord {
-            epoch_stats: vec![ValidatorEpochStats {
-                epoch,
-                leader_slots: 64,
-                blocks_produced: 56,
-                epoch_start_at: Some(epoch_start_at),
-                epoch_end_at: Some(epoch_start_at + chrono::Duration::days(2)),
-                ..Default::default()
-            }],
-            ..Default::default()
-        },
-    )])
+    vote_accounts
+        .iter()
+        .map(|vote_account| {
+            (
+                vote_account.to_string(),
+                ValidatorRecord {
+                    epoch_stats: vec![ValidatorEpochStats {
+                        epoch,
+                        leader_slots: 64,
+                        blocks_produced: 56,
+                        epoch_start_at: Some(epoch_start_at),
+                        epoch_end_at: Some(epoch_start_at + chrono::Duration::days(2)),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+            )
+        })
+        .collect()
 }
 
 // `identity` and `vote_account` are the same string here; nothing the query reads distinguishes them.
@@ -244,4 +254,51 @@ async fn an_epoch_before_from_epoch_is_left_out() {
         .unwrap();
 
     assert!(incidents.is_empty());
+}
+
+// The `DOWN` rows are keyed by the row's vote account and the block production by the records key,
+// so a mix-up between the two would file one validator's epoch under the other.
+#[tokio::test]
+async fn each_validator_is_keyed_by_its_own_vote_account() {
+    let schema = "ds_test_incidents_keying";
+    if skip_without_database(schema) {
+        return;
+    }
+    let client = migrated_client(schema).await.unwrap();
+
+    down(
+        &client,
+        "voteA",
+        100,
+        "2026-01-01T00:00:00Z",
+        "2026-01-01T00:10:00Z",
+    )
+    .await;
+
+    let incidents = load_validator_incidents(&client, 100, 100, &records(&["voteA", "voteB"], 100))
+        .await
+        .unwrap();
+
+    let down_only = incidents.get("voteA").unwrap();
+    assert_eq!(downtime_epochs(&incidents, "voteA"), vec![100]);
+    assert_eq!(down_only.block_production.len(), 1);
+
+    let skipped_only = incidents.get("voteB").unwrap();
+    assert!(skipped_only.downtimes.is_empty());
+    assert_eq!(skipped_only.block_production.len(), 1);
+
+    // Both breached, so the one that also went down reports it on its downtime record and the one
+    // that stayed up reports it on a record of its own.
+    let filters = IncidentFilters::default();
+    assert!(matches!(
+        incidents.into_response_incidents("voteA", &filters)[0].detail,
+        IncidentDetail::Downtime {
+            block_production: Some(_),
+            ..
+        }
+    ));
+    assert!(matches!(
+        incidents.into_response_incidents("voteB", &filters)[0].detail,
+        IncidentDetail::BlockProduction { .. }
+    ));
 }


### PR DESCRIPTION
New incident type `BlockProduction`.

The endpoint `GET /validators` now also returns incidents caused by validator failing to meet following criteria:

```
1.  leader_slots  >= 64
2.  missed_slots  >= 4
3.  skip_rate     >= min( max(1%, 10 * cluster_skip_rate[N]), 5% )
```

The API includes query parameters that allow caller to adjust leader slots and missed slots thresholds (`min_incident_leader_slots` and `min_incident_missed_slots`). 64 and 4 respectively are minimums; events with lower values are not recorded as incidents.

When `BlockProduction` is caused by `Downtime` incident, these are combined into 1 incident record instead of 2.

All `Downtime` incidents now include also block production details if available:

```rs
pub struct BlockProductionDetail {
    pub leader_slots: u64,
    pub blocks_produced: u64,
    pub missed_slots: u64,
    /// `missed_slots / leader_slots`, as a fraction.
    pub skip_rate: f64,
    /// The epoch's cluster-wide skip rate, over the validators that were evaluable that epoch.
    pub cluster_skip_rate: f64,
    /// The bar `skip_rate` had to clear that epoch, as a fraction.
    pub threshold: f64,
    /// Whether these numbers count as an incident.
    /// Affected by query params `min_incident_missed_slots` and `min_incident_leader_slots`.
    pub counts_as_incident: bool,
}
```
This struct is included also in the lone `BlockProduction` incident record. This includes information that allows the client to render more details about why the downtime/block production incident happened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Validator listings now support filtering by incident type, including downtime and block-production incidents.
  - Added configurable missed-slot and leader-slot thresholds for identifying block-production incidents.
  - Incident details now distinguish downtime from block-production events and provide clearer timing and classification information.
  - Added incident detail types to the API documentation schema.

- **Bug Fixes**
  - Prevented incidents from being created from incomplete, still-running epochs.
  - Improved incident filtering, grouping, deduplication, and mixed-condition handling.
  - Corrected incident ordering to use the block-production period start time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->