### PR TITLE
fix(api): add the missing leading slash to two documented report paths

### DIFF
--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -115,3 +115,28 @@ use utoipa::OpenApi;
     )
 )]
 pub struct ApiDoc;
+
+#[cfg(test)]
+mod tests {
+    use super::ApiDoc;
+    use utoipa::OpenApi;
+
+    /// A `utoipa::path` without a leading slash still routes correctly but
+    /// produces a spec that strict OpenAPI validators reject, which breaks
+    /// client generators consuming /docs.json.
+    #[test]
+    fn every_documented_path_starts_with_a_slash() {
+        let unslashed: Vec<_> = ApiDoc::openapi()
+            .paths
+            .paths
+            .keys()
+            .filter(|path| !path.starts_with('/'))
+            .cloned()
+            .collect();
+
+        assert!(
+            unslashed.is_empty(),
+            "paths missing leading slash: {unslashed:?}"
+        );
+    }
+}

--- a/api/src/handlers/reports_commission_changes.rs
+++ b/api/src/handlers/reports_commission_changes.rs
@@ -23,7 +23,7 @@ pub struct CommissionChange {
     get,
     tag = "Validators",
     operation_id = "List commission changes",
-    path = "reports/commission-changes",
+    path = "/reports/commission-changes",
     responses(
         (status = 200, body = ResponseCommissionChanges)
     )

--- a/api/src/handlers/reports_scoring.rs
+++ b/api/src/handlers/reports_scoring.rs
@@ -146,7 +146,7 @@ fn scoring_run_to_report(scoring_run: ScoringRunRecord) -> Report {
     get,
     tag = "Scoring",
     operation_id = "List scoring reports",
-    path = "reports/scoring",
+    path = "/reports/scoring",
     responses(
         (status = 200, body = ResponseReportScoring)
     )


### PR DESCRIPTION
## Summary

`reports/scoring` and `reports/commission-changes` are annotated in `utoipa::path` without a leading slash, so they land in `/docs.json` as `"reports/scoring"` instead of `"/reports/scoring"`. Strict OpenAPI validators reject that (`#/paths must NOT have unevaluated properties`), which breaks client generators reading the spec — orval 8 now fails hard on it, where orval 7 only warned and dropped the two operations.

Routing is unaffected: `main.rs` registers both under `warp::path!("reports" / ...)`, and both endpoints already return 200 in production. Only the published spec changes. The sibling handler `reports_staking.rs` was already correct; these were the only two occurrences in the repo.

Added a test over `ApiDoc::openapi()` asserting every documented path starts with a slash — it fails on master with `paths missing leading slash: ["reports/commission-changes", "reports/scoring"]` and passes with the fix.

## Follow-ups

- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the commission-changes reporting endpoint path to `/reports/commission-changes`.
  - Corrected the scoring reports endpoint path to `/reports/scoring`.
  - These corrections ensure reporting API requests use consistent, valid paths.

- **Tests**
  - Added validation to confirm that all generated API documentation paths begin with `/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->