### PR TITLE
fix(api): document query parameters as query, not path

### DIFF
--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -121,6 +121,7 @@ pub struct ApiDoc;
 #[cfg(test)]
 mod tests {
     use super::ApiDoc;
+    use utoipa::openapi::path::ParameterIn;
     use utoipa::OpenApi;
 
     /// A `utoipa::path` without a leading slash still routes correctly but
@@ -139,6 +140,51 @@ mod tests {
         assert!(
             unslashed.is_empty(),
             "paths missing leading slash: {unslashed:?}"
+        );
+    }
+
+    /// A `parameter_in` left at its `Path` default documents a query parameter
+    /// as a path segment, which strict OpenAPI validators reject and which
+    /// tells consumers to build the wrong URL.
+    #[test]
+    fn every_path_parameter_has_a_matching_path_segment() {
+        let openapi = ApiDoc::openapi();
+
+        let mut orphans = Vec::new();
+
+        for (path, item) in &openapi.paths.paths {
+            let segments: Vec<&str> = path
+                .split('/')
+                .filter_map(|segment| segment.strip_prefix('{').and_then(|s| s.strip_suffix('}')))
+                .collect();
+
+            let operations = [
+                &item.get,
+                &item.put,
+                &item.post,
+                &item.delete,
+                &item.options,
+                &item.head,
+                &item.patch,
+                &item.trace,
+            ];
+
+            for parameter in operations
+                .into_iter()
+                .flatten()
+                .flat_map(|operation| operation.parameters.iter().flatten())
+            {
+                if parameter.parameter_in == ParameterIn::Path
+                    && !segments.contains(&parameter.name.as_str())
+                {
+                    orphans.push(format!("{path}:{}", parameter.name));
+                }
+            }
+        }
+
+        assert!(
+            orphans.is_empty(),
+            "path parameters without a matching path segment: {orphans:?}"
         );
     }
 }

--- a/api/src/handlers/admin_score_upload.rs
+++ b/api/src/handlers/admin_score_upload.rs
@@ -15,6 +15,7 @@ pub struct ResponseAdminScoreUpload {
 }
 
 #[derive(Deserialize, Serialize, Debug, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct QueryParams {
     epoch: i32,
     components: String,

--- a/api/src/handlers/global_unstake_hints.rs
+++ b/api/src/handlers/global_unstake_hints.rs
@@ -10,6 +10,7 @@ pub struct ResponseGlobalUnstakeHints {
 }
 
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct QueryParams {
     epoch: u64,
 }

--- a/api/src/handlers/unstake_hints.rs
+++ b/api/src/handlers/unstake_hints.rs
@@ -10,6 +10,7 @@ pub struct ResponseUnstakeHints {
 }
 
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct QueryParams {
     epoch: u64,
 }

--- a/api/src/handlers/validator_score_breakdown.rs
+++ b/api/src/handlers/validator_score_breakdown.rs
@@ -14,6 +14,7 @@ pub struct ResponseScoreBreakdown {
 }
 
 #[derive(Deserialize, Serialize, Debug, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct QueryParams {
     query_vote_account: String,
 }

--- a/api/src/handlers/validator_score_breakdowns.rs
+++ b/api/src/handlers/validator_score_breakdowns.rs
@@ -20,6 +20,7 @@ pub struct ResponseScoreBreakdowns {
 }
 
 #[derive(Deserialize, Serialize, Debug, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct QueryParams {
     query_from_date: Option<DateTime<Utc>>,
     query_vote_account: Option<String>,

--- a/api/src/handlers/validators_flat.rs
+++ b/api/src/handlers/validators_flat.rs
@@ -8,6 +8,7 @@ use warp::Reply;
 const DEFAULT_EPOCHS: u64 = 10;
 
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct QueryParams {
     epochs: Option<u64>,
     last_epoch: u64,

--- a/api/src/handlers/workflow_metrics_upload.rs
+++ b/api/src/handlers/workflow_metrics_upload.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use warp::{http::StatusCode, reply::json, Reply};
 
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct QueryParams {
     job_scheduled: Option<bool>,
     job_success: Option<bool>,


### PR DESCRIPTION
## Summary

Seven `QueryParams` structs derive `utoipa::IntoParams` without `#[into_params(parameter_in = Query)]`. utoipa's default is `Path`, so `/docs.json` declares 16 query parameters as path segments — e.g. `/validators/flat` documents `epochs` and `last_epoch` as path parameters that the path has no `{}` slot for. Nine other handlers already set the attribute; these seven were missed.

Routing is unaffected — every one of them is wired through `warp::query::<QueryParams>()` in `main.rs`, so the endpoints behave exactly as before. Only the published spec changes.

Strict OpenAPI validators reject this, which breaks client generators reading the spec. Verified end to end: dumping `ApiDoc::openapi()` before the change and running orval 8 over it fails with those 16 errors; after the change it generates a client cleanly.

Affected: `validators_flat`, `validator_score_breakdown`, `validator_score_breakdowns`, `global_unstake_hints`, `unstake_hints`, `admin_score_upload`, `workflow_metrics_upload`.

Added a test asserting every documented path parameter has a matching `{segment}` — it fails on master listing all 16 and passes with the fix. It sits next to the leading-slash test from #271, so both spec defects are now covered.

## Follow-ups

- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved generated API documentation by correctly identifying query-string parameters across several endpoints.
  - Enhanced endpoint documentation accuracy for path parameters and documented path formatting.

- **Tests**
  - Added validation to ensure documented path parameters match their corresponding URL segments.
  - Continued coverage for paths requiring a leading slash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->