### PR TITLE
[GEN-9064] count only equivalent to `/validators`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serde_yaml",
  "solana-program",
  "store",

--- a/api.md
+++ b/api.md
@@ -99,6 +99,20 @@ curl -sfLS 'localhost:8000/validators?limit=1&offset=0' | jq
 }
 ```
 
+## Count validators
+Takes the filtering query parameters of `List validators` — everything except `epochs`,
+`query_from_date`, `order_field`, `order_direction`, `offset`, `limit` — and serves the number of
+rows they match, the same number `List validators` serves as `total_count`. Under
+`with_operator_groups=true` the rows are operator blocks.
+```bash
+curl -sfLS 'localhost:8000/validators/count?query_marinade_stake=true' | jq
+```
+```json
+{
+  "count": 123
+}
+```
+
 ## Uptimes
 ```bash
 curl -sfLS localhost:8000/validators/XkCriyrNwS3G4rzAXtG5B1nnvb5Ka1JtCku93VqeKAr/uptimes | jq

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -31,3 +31,7 @@ prometheus = { workspace = true }
 lazy_static = { workspace = true }
 regex = { workspace = true }
 utoipa = { workspace = true }
+
+[dev-dependencies]
+# The two typed views of the /validators query string are asserted against the same decoder warp uses.
+serde_urlencoded = "0.7.1"

--- a/api/src/api_docs.rs
+++ b/api/src/api_docs.rs
@@ -3,7 +3,8 @@ use crate::handlers::{
     glossary, health, jito, jito_mev, list_clients, list_providers, list_validators, readiness,
     reports_commission_changes, reports_scoring, reports_scoring_html, reports_staking, rewards,
     take_rates, unstake_hints, uptimes, validator_score_breakdown, validator_score_breakdowns,
-    validator_scores, validators_block_rewards, validators_flat, versions, workflow_metrics_upload,
+    validator_scores, validators_block_rewards, validators_count, validators_flat, versions,
+    workflow_metrics_upload,
 };
 use utoipa::OpenApi;
 
@@ -82,6 +83,7 @@ use utoipa::OpenApi;
         schemas(jito_mev::ResponseJitoMev),
         schemas(jito::ResponseJito),
         schemas(validators_block_rewards::ResponseValidatorsBlockRewards),
+        schemas(validators_count::ResponseValidatorsCount),
     ),
     paths(
         admin_score_upload::handler,
@@ -95,6 +97,7 @@ use utoipa::OpenApi;
         glossary::handler,
         health::handler,
         list_validators::handler,
+        validators_count::handler,
         readiness::handler,
         reports_commission_changes::handler,
         reports_scoring_html::handler,

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -88,15 +88,13 @@ pub struct FilterParams {
     /// When true, `query` also matches datacenter location fields (country, city) in addition to
     /// validator name, vote account and identity.
     search_properties: Option<bool>,
-    /// `true` groups the validators into operator blocks, returns the `operators` aggregates beside them, and pages over those top-level rows rather than validators. `/validators/count` then counts those top-level rows.
+    /// `true` groups the validators into operator blocks, returns the `operators` aggregates beside them, and pages over those top-level rows rather than validators.
     with_operator_groups: Option<bool>,
 }
 
-/// The query options that shape the page rather than the match: ordering, `offset`/`limit`, and
-/// the epoch window `epoch_stats` reaches back over. `/validators/count` takes none of them.
 #[derive(Deserialize, Serialize, Debug, Default, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
-pub struct PageParams {
+pub struct ValidatorPageParams {
     epochs: Option<usize>,
     query_from_date: Option<DateTime<Utc>>,
     order_field: Option<OrderField>,
@@ -149,7 +147,7 @@ impl GetValidatorsConfig {
     /// The defaults and the 400s `/validators` and `/validators/count` share.
     pub fn from_params(
         filters: FilterParams,
-        page: PageParams,
+        page: ValidatorPageParams,
     ) -> Result<Self, (StatusCode, String)> {
         if let Some(window) = filters.incident_window_epochs {
             if window == 0 || window > DEFAULT_CACHE_EPOCHS {
@@ -658,14 +656,14 @@ pub fn filter_validators(
     tag = "Validators",
     operation_id = "List validators",
     path = "/validators",
-    params(FilterParams, PageParams),
+    params(FilterParams, ValidatorPageParams),
     responses(
         (status = 200, body = ResponseValidators)
     )
 )]
 pub async fn handler(
     filters: FilterParams,
-    page: PageParams,
+    page: ValidatorPageParams,
     context: WrappedContext,
 ) -> Result<impl Reply, warp::Rejection> {
     metrics::REQUEST_COUNT_VALIDATORS.inc();
@@ -1487,7 +1485,7 @@ mod tests {
         assert_eq!(filters.query.as_deref(), Some("abc"));
         assert_eq!(filters.with_operator_groups, Some(true));
 
-        let page: PageParams = serde_urlencoded::from_str(query).unwrap();
+        let page: ValidatorPageParams = serde_urlencoded::from_str(query).unwrap();
         assert_eq!(page.limit, Some(7));
         assert_eq!(page.order_field, Some(OrderField::Credits));
     }

--- a/api/src/handlers/list_validators.rs
+++ b/api/src/handlers/list_validators.rs
@@ -55,18 +55,16 @@ pub struct ResponseValidators {
     net_apy_updated_at: Option<DateTime<Utc>>,
 }
 
+/// The query options that decide which rows a request matches.
+/// Used by `/validators` and `/validators/count`.
 #[derive(Deserialize, Serialize, Debug, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
-pub struct QueryParams {
-    epochs: Option<usize>,
+pub struct FilterParams {
     /// Text search over validator name, vote account and identity. To also search other
     /// properties (datacenter location), set `search_properties=true`.
     query: Option<String>,
-    query_from_date: Option<DateTime<Utc>>,
     query_vote_accounts: Option<String>,
     query_identities: Option<String>,
-    order_field: Option<OrderField>,
-    order_direction: Option<OrderDirection>,
     query_superminority: Option<bool>,
     query_score: Option<bool>,
     query_marinade_stake: Option<bool>,
@@ -90,8 +88,19 @@ pub struct QueryParams {
     /// When true, `query` also matches datacenter location fields (country, city) in addition to
     /// validator name, vote account and identity.
     search_properties: Option<bool>,
-    /// `true` groups the validators into operator blocks, returns the `operators` aggregates beside them, and pages over those top-level rows rather than validators.
+    /// `true` groups the validators into operator blocks, returns the `operators` aggregates beside them, and pages over those top-level rows rather than validators. `/validators/count` then counts those top-level rows.
     with_operator_groups: Option<bool>,
+}
+
+/// The query options that shape the page rather than the match: ordering, `offset`/`limit`, and
+/// the epoch window `epoch_stats` reaches back over. `/validators/count` takes none of them.
+#[derive(Deserialize, Serialize, Debug, Default, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct PageParams {
+    epochs: Option<usize>,
+    query_from_date: Option<DateTime<Utc>>,
+    order_field: Option<OrderField>,
+    order_direction: Option<OrderDirection>,
     offset: Option<usize>,
     limit: Option<usize>,
 }
@@ -134,6 +143,87 @@ pub struct ValidatorsPage {
     pub total_count: usize,
     pub bond_flags_updated_at: Option<DateTime<Utc>>,
     pub net_apy_updated_at: Option<DateTime<Utc>>,
+}
+
+impl GetValidatorsConfig {
+    /// The defaults and the 400s `/validators` and `/validators/count` share.
+    pub fn from_params(
+        filters: FilterParams,
+        page: PageParams,
+    ) -> Result<Self, (StatusCode, String)> {
+        if let Some(window) = filters.incident_window_epochs {
+            if window == 0 || window > DEFAULT_CACHE_EPOCHS {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("incident_window_epochs must be between 1 and {DEFAULT_CACHE_EPOCHS}"),
+                ));
+            }
+        }
+        if let Some(missed_slots) = filters.min_incident_missed_slots {
+            if missed_slots < MIN_MISSED_SLOTS {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("min_incident_missed_slots must be at least {MIN_MISSED_SLOTS}"),
+                ));
+            }
+        }
+        if let Some(leader_slots) = filters.min_incident_leader_slots {
+            if leader_slots < MIN_LEADER_SLOTS {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("min_incident_leader_slots must be at least {MIN_LEADER_SLOTS}"),
+                ));
+            }
+        }
+        let query_incident_types = match filters.query_incident_types.as_deref() {
+            Some(types) => match IncidentType::parse_list(types) {
+                Ok(types) => Some(types),
+                Err(unknown) => {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        format!(
+                            "query_incident_types does not know {unknown:?}, expected Downtime or BlockProduction"
+                        ),
+                    ))
+                }
+            },
+            None => Some(DEFAULT_INCIDENT_TYPES.to_vec()),
+        };
+
+        Ok(Self {
+            order_direction: page.order_direction.unwrap_or(DEFAULT_ORDER_DIRECTION),
+            order_field: page.order_field.unwrap_or(DEFAULT_ORDER_FIELD),
+            offset: page.offset.unwrap_or(0),
+            limit: page.limit.unwrap_or(DEFAULT_LIMIT),
+            query: filters.query,
+            query_vote_accounts: filters.query_vote_accounts.map(|i| {
+                i.split(",")
+                    .map(|vote_account| vote_account.to_string())
+                    .collect()
+            }),
+            query_identities: filters
+                .query_identities
+                .map(|i| i.split(",").map(|identity| identity.to_string()).collect()),
+            query_superminority: filters.query_superminority,
+            query_score: filters.query_score,
+            query_marinade_stake: filters.query_marinade_stake,
+            query_with_names: filters.query_with_names,
+            query_sfdp: filters.query_sfdp,
+            query_incident_free: filters.query_incident_free,
+            query_incident_types,
+            min_incident_downtime_seconds: filters.min_incident_downtime_seconds,
+            min_incident_missed_slots: filters.min_incident_missed_slots,
+            min_incident_leader_slots: filters.min_incident_leader_slots,
+            incident_window_epochs: filters.incident_window_epochs,
+            query_verified: filters.query_verified,
+            query_protected: filters.query_protected,
+            query_flagged: filters.query_flagged,
+            search_properties: filters.search_properties,
+            query_from_date: page.query_from_date,
+            epochs: page.epochs.unwrap_or(DEFAULT_EPOCHS),
+            with_operator_groups: filters.with_operator_groups == Some(true),
+        })
+    }
 }
 
 pub async fn get_validators(
@@ -203,6 +293,33 @@ pub async fn get_validators(
         bond_flags_updated_at,
         net_apy_updated_at,
     })
+}
+
+/// The number `/validators` serves as `total_count`, without paging or ordering the match.
+pub async fn count_validators(context: WrappedContext, config: GetValidatorsConfig) -> usize {
+    let (validators, incidents) = {
+        let cache = &context.read().await.cache;
+        (cache.get_validators(), cache.get_validator_incidents())
+    };
+
+    count_rows(
+        &filter_validators(validators, &incidents, &config),
+        config.with_operator_groups,
+    )
+}
+
+/// Rows the match occupies, in the units it is paged in: validators, or top-level rows under
+/// `with_operator_groups`.
+fn count_rows(validators: &[ValidatorRecord], with_operator_groups: bool) -> usize {
+    if with_operator_groups {
+        validators
+            .iter()
+            .map(top_level_row)
+            .collect::<HashSet<TopLevelRow>>()
+            .len()
+    } else {
+        validators.len()
+    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Debug)]
@@ -541,88 +658,20 @@ pub fn filter_validators(
     tag = "Validators",
     operation_id = "List validators",
     path = "/validators",
-    params(QueryParams),
+    params(FilterParams, PageParams),
     responses(
         (status = 200, body = ResponseValidators)
     )
 )]
 pub async fn handler(
-    query_params: QueryParams,
+    filters: FilterParams,
+    page: PageParams,
     context: WrappedContext,
 ) -> Result<impl Reply, warp::Rejection> {
     metrics::REQUEST_COUNT_VALIDATORS.inc();
-    if let Some(window) = query_params.incident_window_epochs {
-        if window == 0 || window > DEFAULT_CACHE_EPOCHS {
-            return Ok(response_error(
-                StatusCode::BAD_REQUEST,
-                format!("incident_window_epochs must be between 1 and {DEFAULT_CACHE_EPOCHS}"),
-            ));
-        }
-    }
-    if let Some(missed_slots) = query_params.min_incident_missed_slots {
-        if missed_slots < MIN_MISSED_SLOTS {
-            return Ok(response_error(
-                StatusCode::BAD_REQUEST,
-                format!("min_incident_missed_slots must be at least {MIN_MISSED_SLOTS}"),
-            ));
-        }
-    }
-    if let Some(leader_slots) = query_params.min_incident_leader_slots {
-        if leader_slots < MIN_LEADER_SLOTS {
-            return Ok(response_error(
-                StatusCode::BAD_REQUEST,
-                format!("min_incident_leader_slots must be at least {MIN_LEADER_SLOTS}"),
-            ));
-        }
-    }
-    let query_incident_types = match query_params.query_incident_types.as_deref() {
-        Some(types) => match IncidentType::parse_list(types) {
-            Ok(types) => Some(types),
-            Err(unknown) => {
-                return Ok(response_error(
-                    StatusCode::BAD_REQUEST,
-                    format!(
-                        "query_incident_types does not know {unknown:?}, expected Downtime or BlockProduction"
-                    ),
-                ))
-            }
-        },
-        None => Some(DEFAULT_INCIDENT_TYPES.to_vec()),
-    };
-    let config = GetValidatorsConfig {
-        order_direction: query_params
-            .order_direction
-            .unwrap_or(DEFAULT_ORDER_DIRECTION),
-        order_field: query_params.order_field.unwrap_or(DEFAULT_ORDER_FIELD),
-        offset: query_params.offset.unwrap_or(0),
-        limit: query_params.limit.unwrap_or(DEFAULT_LIMIT),
-        query: query_params.query,
-        query_vote_accounts: query_params.query_vote_accounts.map(|i| {
-            i.split(",")
-                .map(|vote_account| vote_account.to_string())
-                .collect()
-        }),
-        query_identities: query_params
-            .query_identities
-            .map(|i| i.split(",").map(|identity| identity.to_string()).collect()),
-        query_superminority: query_params.query_superminority,
-        query_score: query_params.query_score,
-        query_marinade_stake: query_params.query_marinade_stake,
-        query_with_names: query_params.query_with_names,
-        query_sfdp: query_params.query_sfdp,
-        query_incident_free: query_params.query_incident_free,
-        query_incident_types,
-        min_incident_downtime_seconds: query_params.min_incident_downtime_seconds,
-        min_incident_missed_slots: query_params.min_incident_missed_slots,
-        min_incident_leader_slots: query_params.min_incident_leader_slots,
-        incident_window_epochs: query_params.incident_window_epochs,
-        query_verified: query_params.query_verified,
-        query_protected: query_params.query_protected,
-        query_flagged: query_params.query_flagged,
-        search_properties: query_params.search_properties,
-        query_from_date: query_params.query_from_date,
-        epochs: query_params.epochs.unwrap_or(DEFAULT_EPOCHS),
-        with_operator_groups: query_params.with_operator_groups == Some(true),
+    let config = match GetValidatorsConfig::from_params(filters, page) {
+        Ok(config) => config,
+        Err((status, message)) => return Ok(response_error(status, message)),
     };
 
     log::info!("Query validators {config:?}");
@@ -1426,6 +1475,35 @@ mod tests {
             ],
             vec![operator("X", 600), operator("Y", 300)],
         )
+    }
+
+    /// `/validators` reads both structs off one query string and `/validators/count` reads only
+    /// the filters, so neither may reject the other's params.
+    #[test]
+    fn the_two_views_ignore_each_others_params() {
+        let query = "query=abc&with_operator_groups=true&limit=7&order_field=Credits";
+
+        let filters: FilterParams = serde_urlencoded::from_str(query).unwrap();
+        assert_eq!(filters.query.as_deref(), Some("abc"));
+        assert_eq!(filters.with_operator_groups, Some(true));
+
+        let page: PageParams = serde_urlencoded::from_str(query).unwrap();
+        assert_eq!(page.limit, Some(7));
+        assert_eq!(page.order_field, Some(OrderField::Credits));
+    }
+
+    #[test]
+    fn the_count_matches_the_total_count_beside_a_page() {
+        let (validators, operators) = two_operators();
+        let (_, total_count) = paged(validators.clone(), Some(operators), 0, 1);
+        assert_eq!(
+            count_rows(&validators, true),
+            total_count,
+            "operator blocks"
+        );
+
+        let (_, total_count) = paged(validators.clone(), None, 0, 1);
+        assert_eq!(count_rows(&validators, false), total_count, "validators");
     }
 
     #[test]

--- a/api/src/handlers/mod.rs
+++ b/api/src/handlers/mod.rs
@@ -25,6 +25,7 @@ pub mod validator_score_breakdown;
 pub mod validator_score_breakdowns;
 pub mod validator_scores;
 pub mod validators_block_rewards;
+pub mod validators_count;
 pub mod validators_flat;
 pub mod versions;
 pub mod workflow_metrics_upload;

--- a/api/src/handlers/validators_count.rs
+++ b/api/src/handlers/validators_count.rs
@@ -1,6 +1,6 @@
 use crate::context::WrappedContext;
 use crate::handlers::list_validators::{
-    count_validators, FilterParams, GetValidatorsConfig, PageParams,
+    count_validators, FilterParams, GetValidatorsConfig, ValidatorPageParams,
 };
 use crate::metrics;
 use crate::utils::response::response_error;
@@ -30,7 +30,7 @@ pub async fn handler(
     context: WrappedContext,
 ) -> Result<impl Reply, warp::Rejection> {
     metrics::REQUEST_COUNT_VALIDATORS_COUNT.inc();
-    let config = match GetValidatorsConfig::from_params(filters, PageParams::default()) {
+    let config = match GetValidatorsConfig::from_params(filters, ValidatorPageParams::default()) {
         Ok(config) => config,
         Err((status, message)) => return Ok(response_error(status, message)),
     };

--- a/api/src/handlers/validators_count.rs
+++ b/api/src/handlers/validators_count.rs
@@ -1,0 +1,46 @@
+use crate::context::WrappedContext;
+use crate::handlers::list_validators::{
+    count_validators, FilterParams, GetValidatorsConfig, PageParams,
+};
+use crate::metrics;
+use crate::utils::response::response_error;
+use serde::Serialize;
+use warp::{http::StatusCode, reply::json, Reply};
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct ResponseValidatorsCount {
+    /// Rows matching the query and filters: validators, or operator blocks under
+    /// `with_operator_groups`. The same number `/validators` serves as `total_count`.
+    count: usize,
+}
+
+#[utoipa::path(
+    get,
+    tag = "Validators",
+    operation_id = "Count validators",
+    path = "/validators/count",
+    params(FilterParams),
+    responses(
+        (status = 200, body = ResponseValidatorsCount),
+        (status = 400, description = "Invalid incident query params")
+    )
+)]
+pub async fn handler(
+    filters: FilterParams,
+    context: WrappedContext,
+) -> Result<impl Reply, warp::Rejection> {
+    metrics::REQUEST_COUNT_VALIDATORS_COUNT.inc();
+    let config = match GetValidatorsConfig::from_params(filters, PageParams::default()) {
+        Ok(config) => config,
+        Err((status, message)) => return Ok(response_error(status, message)),
+    };
+
+    log::info!("Count validators {config:?}");
+
+    let count = count_validators(context, config).await;
+
+    Ok(warp::reply::with_status(
+        json(&ResponseValidatorsCount { count }),
+        StatusCode::OK,
+    ))
+}

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -135,7 +135,7 @@ async fn main() -> anyhow::Result<()> {
         .and(warp::path::end())
         .and(warp::get())
         .and(warp::query::<list_validators::FilterParams>())
-        .and(warp::query::<list_validators::PageParams>())
+        .and(warp::query::<list_validators::ValidatorPageParams>())
         .and(with_context(context.clone()))
         .and_then(list_validators::handler);
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -7,7 +7,8 @@ use crate::handlers::{
     glossary, health, jito, jito_mev, list_clients, list_providers, list_validators, readiness,
     reports_commission_changes, reports_scoring, reports_scoring_html, reports_staking, rewards,
     take_rates, unstake_hints, uptimes, validator_score_breakdown, validator_score_breakdowns,
-    validator_scores, validators_block_rewards, validators_flat, versions, workflow_metrics_upload,
+    validator_scores, validators_block_rewards, validators_count, validators_flat, versions,
+    workflow_metrics_upload,
 };
 use clap::Parser;
 use env_logger::Env;
@@ -129,12 +130,21 @@ async fn main() -> anyhow::Result<()> {
         .and(with_ready(ready))
         .and_then(readiness::handler);
 
+    // Two typed views over the same query string: the count route takes the filters alone.
     let route_validators = warp::path!("validators")
         .and(warp::path::end())
         .and(warp::get())
-        .and(warp::query::<list_validators::QueryParams>())
+        .and(warp::query::<list_validators::FilterParams>())
+        .and(warp::query::<list_validators::PageParams>())
         .and(with_context(context.clone()))
         .and_then(list_validators::handler);
+
+    let route_validators_count = warp::path!("validators" / "count")
+        .and(warp::path::end())
+        .and(warp::get())
+        .and(warp::query::<list_validators::FilterParams>())
+        .and(with_context(context.clone()))
+        .and_then(validators_count::handler);
 
     let route_clients = warp::path!("clients")
         .and(warp::path::end())
@@ -320,6 +330,7 @@ async fn main() -> anyhow::Result<()> {
         .or(route_readiness)
         .or(route_cluster_stats)
         .or(route_validators)
+        .or(route_validators_count)
         .or(route_clients)
         .or(route_providers)
         .or(route_validator_score_breakdown)

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -21,6 +21,11 @@ lazy_static! {
         "How many times /validators endpoint was requested"
     )
     .unwrap();
+    pub static ref REQUEST_COUNT_VALIDATORS_COUNT: IntCounter = register_int_counter!(
+        "ds_request_count_validators_count",
+        "How many times /validators/count endpoint was requested"
+    )
+    .unwrap();
     pub static ref REQUEST_COUNT_CLIENTS: IntCounter = register_int_counter!(
         "ds_request_count_clients",
         "How many times /clients endpoint was requested"


### PR DESCRIPTION
Added endpoint `/validators/count`that accepts all same filters as `/validators` and returns only total count:

```json
{ "count": <number> }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `GET /validators/count` endpoint that returns the number of validators matching supplied filters.
  * Supports validator filtering, including operator-group behavior, without pagination or ordering.
  * Invalid or unsupported query parameters return an error response.

* **Documentation**
  * Documented supported filters, operator-group behavior, example requests, and the `{ "count": 123 }` response format.

* **Monitoring**
  * Added request metrics for the validators count endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->